### PR TITLE
chore(deps): refresh deps natively via bun + scope Dependabot to github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration for Syra.
+#
+# This repo uses bun (bun.lock) and does NOT track any package-lock.json.
+# Dependabot's npm/npm_and_yarn updater only understands package-lock.json /
+# yarn.lock, so enabling it produces invalid PRs that add stray, unused,
+# out-of-sync npm lockfiles. It is intentionally NOT enabled here.
+# JavaScript dependency updates are applied natively via `bun update`.
+#
+# Only the github-actions ecosystem is managed by Dependabot.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
         "jsonwebtoken": "^9.0.2",
         "jwt-decode": "^4.0.0",
         "mongoose": "^8.17.0",
-        "multer": "^2.0.2",
+        "multer": "^2.1.1",
         "node-telegram-bot-api": "^0.66.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -52,7 +52,7 @@
         "sharp": "^0.34.5",
         "socket.io": "^4.8.1",
         "url-metadata": "^5.2.3",
-        "validator": "^13.11.0",
+        "validator": "^13.15.22",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -249,7 +249,7 @@
     },
     "packages/sdk": {
       "name": "@syra.fm/sdk",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "zod": "^3.25.76",
       },
@@ -2422,7 +2422,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "multer": ["multer@2.1.1", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.6.0", "concat-stream": "^2.0.0", "type-is": "^1.6.18" } }, "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A=="],
+    "multer": ["multer@2.2.0", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.6.0", "concat-stream": "^2.0.0", "type-is": "^1.6.18" } }, "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ=="],
 
     "multitars": ["multitars@1.0.0", "", {}, "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,7 @@
     "jsonwebtoken": "^9.0.2",
     "jwt-decode": "^4.0.0",
     "mongoose": "^8.17.0",
-    "multer": "^2.0.2",
+    "multer": "^2.1.1",
     "node-telegram-bot-api": "^0.66.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
@@ -49,7 +49,7 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.1",
     "url-metadata": "^5.2.3",
-    "validator": "^13.11.0",
+    "validator": "^13.15.22",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Replaces the 10 invalid npm-ecosystem Dependabot PRs (#17 #15 #14 #12 #9 #5 #4 #3 #2 #1).

Syra uses **bun.lock** and tracks **no package-lock.json** anywhere, so Dependabot's npm updater only ever edits stray `package-lock.json` files that don't exist in the tree. Those PRs are invalid (merging would add unused, out-of-sync npm lockfiles). The equivalent updates are applied here natively with bun.

## Changes
- `multer` `^2.0.2` -> `^2.1.1` (resolves to **2.2.0**) in `packages/backend` — covers #17
- `validator` `^13.11.0` -> `^13.15.22` (resolves to **13.15.35**) in `packages/backend` — covers #1
- Transitive security advisories from #15/#14/#9/#4/#3/#2 are **already satisfied** by the current lockfile resolution: `bn.js@4.12.3`, `undici@7.27.2`, `node-forge@1.4.0`, `minimatch@10.2.5`, `js-yaml@4.2.0`. (`tar` from #12/#9 is not in the tree.)
- Add `.github/dependabot.yml` scoped to **github-actions only** — the npm ecosystem is intentionally disabled because Dependabot cannot read `bun.lock`.

## Verification
- `bun install --frozen-lockfile` — clean
- Backend build (`tsc`) — pass
- Backend tests — **445 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)