### PR TITLE
chore(deps): bump GitHub Actions versions (consolidates #20-#24)

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add to Oxy Platform board
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/OxyHQ/projects/14
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -43,7 +43,7 @@ jobs:
     needs: test
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure AWS credentials (OIDC, no stored keys)
         uses: aws-actions/configure-aws-credentials@v4
@@ -75,7 +75,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push (linux/arm64)
         run: |

--- a/.github/workflows/deploy-creators.yml
+++ b/.github/workflows/deploy-creators.yml
@@ -15,8 +15,8 @@ jobs:
   deploy-creators:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - uses: oven-sh/setup-bun@v2
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -15,8 +15,8 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - uses: oven-sh/setup-bun@v2
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Applies all 5 dependabot github-actions bumps in a single commit to avoid a same-file conflict cascade (multiple PRs edit the same workflow files).

## Bumps
| Action | Old | New | Files |
|--------|-----|-----|-------|
| cloudflare/wrangler-action | 3 | 4 | deploy-creators.yml, deploy-frontends.yml |
| actions/setup-node | 4 | 6 | deploy-creators.yml, deploy-frontends.yml |
| docker/setup-buildx-action | 3 | 4 | deploy-aws.yml |
| actions/add-to-project | 1.0.2 | 2.0.0 | auto-project.yml |
| actions/checkout | 4 | 7 | deploy-aws.yml, deploy-creators.yml, deploy-frontends.yml |

## Compatibility
- **wrangler-action@v4**: `apiToken`/`accountId`/`command`/`wranglerVersion` inputs unchanged and supported in v4 (v4 only bumped the default bundled wrangler and dropped Node 18). The explicit `wranglerVersion: '3.114.0'` pin is preserved.
- setup-buildx/checkout/setup-node/add-to-project: routine major bumps, no required-input changes.

All 4 workflows validated as parseable YAML.

Closes #20, closes #21, closes #22, closes #23, closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/syra/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->