### PR TITLE
fix(live): SSRF guard on stream URLs + socket ack early-returns

### DIFF
--- a/packages/backend/src/routes/rooms.routes.ts
+++ b/packages/backend/src/routes/rooms.routes.ts
@@ -294,8 +294,12 @@ async function applyUrlIngressToRoom(
 
 /**
  * HTTP wrapper over {@link applyUrlIngressToRoom} for the host-supplied-URL
- * route: starts the ingress and writes the standard `{ message, ingressId, url }`
- * response, or maps a LiveKit failure via {@link sendLiveKitIngressError}.
+ * route: runs the shared SSRF-guarded {@link validatePlayableAudioUrl} probe on
+ * the caller-supplied URL FIRST, then starts the ingress and writes the standard
+ * `{ message, ingressId, url }` response, or maps a validation / LiveKit failure
+ * via {@link sendLiveKitIngressError}. This is the single validation gate for the
+ * manual-URL path, mirroring the probe {@link startResolvedMediaStream} runs for
+ * the resolved podcast/track paths — so no path reaches the ingress unvalidated.
  */
 async function startUrlIngressForRoom(
   room: IRoom,
@@ -304,6 +308,12 @@ async function startUrlIngressForRoom(
   res: Response,
   userId: string,
 ): Promise<void> {
+  const validation = await validatePlayableAudioUrl(meta.url);
+  if (!validation.ok) {
+    res.status(validation.status).json({ message: validation.message });
+    return;
+  }
+
   const outcome = await applyUrlIngressToRoom(room, id, meta);
   if (!outcome.ok) {
     sendLiveKitIngressError(res, outcome.error, 'create-url-ingress', { roomId: id, userId });
@@ -2088,6 +2098,13 @@ router.patch('/:id/stream', async (req: AuthRequest, res: Response) => {
     if (nextStreamUrl !== undefined && nextStreamUrl !== (room.activeStreamUrl ?? undefined)) {
       if (room.status !== RoomStatus.LIVE) {
         return res.status(400).json({ message: 'Room must be live to update stream URL' });
+      }
+
+      // SSRF-guarded probe of the new URL before replacing the ingress -- the same
+      // gate the stream-start paths run, so a URL swap can never bypass validation.
+      const validation = await validatePlayableAudioUrl(nextStreamUrl);
+      if (!validation.ok) {
+        return res.status(validation.status).json({ message: validation.message });
       }
 
       let ingressResult: IngressReplacementResult;

--- a/packages/backend/src/sockets/roomSocket.ts
+++ b/packages/backend/src/sockets/roomSocket.ts
@@ -379,11 +379,17 @@ export function initializeRoomSocket(io: Server): Namespace {
     socket.on('speaker:request', async (data: { roomId: string }, callback?: RoomAck) => {
       try {
         const { roomId } = data || {};
-        if (!roomId) return;
+        if (!roomId) {
+          callback?.({ success: false, error: 'roomId is required' });
+          return;
+        }
 
         // Look up room type to enforce broadcast restriction
         const room = await Room.findById(roomId).lean();
-        if (!room) return;
+        if (!room) {
+          callback?.({ success: false, error: 'Room not found' });
+          return;
+        }
 
         if (room.type === RoomType.BROADCAST) {
           callback?.({ success: false, error: 'Speaker requests are not allowed in broadcast rooms' });
@@ -391,7 +397,10 @@ export function initializeRoomSocket(io: Server): Namespace {
         }
 
         const participant = await redisGetParticipant(roomId, userId);
-        if (!participant || participant.role !== 'listener') return;
+        if (!participant || participant.role !== 'listener') {
+          callback?.({ success: false, error: 'Only a listener can request to speak' });
+          return;
+        }
 
         // For TALK rooms: if speakerPermission is 'everyone', auto-promote
         if (room.type === RoomType.TALK && room.speakerPermission === SpeakerPermission.EVERYONE) {
@@ -437,7 +446,10 @@ export function initializeRoomSocket(io: Server): Namespace {
     socket.on('speaker:approve', async (data: { roomId: string; targetUserId: string }, callback?: RoomAck) => {
       try {
         const { roomId, targetUserId } = data || {};
-        if (!roomId || !targetUserId) return;
+        if (!roomId || !targetUserId) {
+          callback?.({ success: false, error: 'roomId and targetUserId are required' });
+          return;
+        }
 
         // Enforce broadcast restriction
         const room = await Room.findById(roomId).lean();
@@ -447,10 +459,16 @@ export function initializeRoomSocket(io: Server): Namespace {
         }
 
         const redisRoom = await redisGetRoom(roomId);
-        if (!redisRoom || redisRoom.hostId !== userId) return;
+        if (!redisRoom || redisRoom.hostId !== userId) {
+          callback?.({ success: false, error: 'Only the host can approve speakers' });
+          return;
+        }
 
         const target = await redisGetParticipant(roomId, targetUserId);
-        if (!target) return;
+        if (!target) {
+          callback?.({ success: false, error: 'Target user is not in the room' });
+          return;
+        }
 
         // Promote to speaker
         await redisUpdateParticipant(roomId, targetUserId, { role: 'speaker' });
@@ -510,7 +528,10 @@ export function initializeRoomSocket(io: Server): Namespace {
     socket.on('speaker:remove', async (data: { roomId: string; targetUserId: string }, callback?: RoomAck) => {
       try {
         const { roomId, targetUserId } = data || {};
-        if (!roomId || !targetUserId) return;
+        if (!roomId || !targetUserId) {
+          callback?.({ success: false, error: 'roomId and targetUserId are required' });
+          return;
+        }
 
         // Enforce broadcast restriction
         const room = await Room.findById(roomId).lean();
@@ -520,10 +541,20 @@ export function initializeRoomSocket(io: Server): Namespace {
         }
 
         const redisRoom = await redisGetRoom(roomId);
-        if (!redisRoom || redisRoom.hostId !== userId) return;
+        if (!redisRoom || redisRoom.hostId !== userId) {
+          callback?.({ success: false, error: 'Only the host can remove speakers' });
+          return;
+        }
 
         const target = await redisGetParticipant(roomId, targetUserId);
-        if (!target || target.role === 'host') return;
+        if (!target) {
+          callback?.({ success: false, error: 'Target user is not in the room' });
+          return;
+        }
+        if (target.role === 'host') {
+          callback?.({ success: false, error: 'Cannot remove the host' });
+          return;
+        }
 
         await redisUpdateParticipant(roomId, targetUserId, { role: 'listener', isMuted: true });
 


### PR DESCRIPTION
Addresses the Gemini Code Assist review on #32: 2× SSRF-high (manual `POST /stream` + `PATCH /stream` now run `validatePlayableAudioUrl`) and 3× socket ack early-returns (speaker:request/approve/remove). Verified: backend build exit 0, room tests pass, single-validation-per-ingress grep-confirmed. 🤖 Generated with Claude Code