### PR TITLE
refactor(live): rename Agora identifiers → live-rooms (@syra.fm/live 0.2.0)

### DIFF
--- a/packages/frontend/app/index.tsx
+++ b/packages/frontend/app/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { Image } from 'expo-image';
-import { RoomCard, useLiveRoom, createAgoraService, type Room } from '@syra.fm/live';
+import { RoomCard, useLiveRoom, createRoomsService, type Room } from '@syra.fm/live';
 import SEO from '@/components/SEO';
 import { MediaCard } from '@/components/MediaCard';
 import { ResponsiveGrid } from '@/components/ResponsiveGrid';
@@ -87,10 +87,10 @@ const HomeScreen: React.FC = () => {
   // Live rooms — the same fetch the Live surface uses (public, error-swallowing:
   // `getRooms` returns `[]` on failure/no-auth). Keyed off the shared
   // `liveRoomsQueryKey` so it shares one cache authority with `app/live.tsx`.
-  const agoraService = useMemo(() => createAgoraService(authenticatedClient), []);
+  const roomsService = useMemo(() => createRoomsService(authenticatedClient), []);
   const liveRoomsQuery = useQuery({
     queryKey: liveRoomsQueryKey,
-    queryFn: () => agoraService.getRooms('live'),
+    queryFn: () => roomsService.getRooms('live'),
     staleTime: 30_000,
   });
 

--- a/packages/frontend/app/live.tsx
+++ b/packages/frontend/app/live.tsx
@@ -9,7 +9,7 @@ import {
   RoomCard,
   CreateRoomSheet,
   useLiveRoom,
-  createAgoraService,
+  createRoomsService,
   type Room,
   type CreateRoomSheetRef,
   type CreateRoomFormState,
@@ -30,7 +30,7 @@ export default function LiveScreen() {
   const insets = useSafeAreaInsets();
   const { joinLiveRoom } = useLiveRoom();
 
-  const agoraService = useMemo(() => createAgoraService(authenticatedClient), []);
+  const roomsService = useMemo(() => createRoomsService(authenticatedClient), []);
   const {
     data: liveRooms = [],
     isRefetching,
@@ -38,7 +38,7 @@ export default function LiveScreen() {
     refetch,
   } = useQuery({
     queryKey: liveRoomsQueryKey,
-    queryFn: () => agoraService.getRooms('live'),
+    queryFn: () => roomsService.getRooms('live'),
     staleTime: 30_000,
   });
 

--- a/packages/frontend/components/providers/AppProviders.tsx
+++ b/packages/frontend/components/providers/AppProviders.tsx
@@ -24,7 +24,7 @@ import { StatusBar } from 'expo-status-bar';
 import { OxyProvider, useOxy } from '@oxyhq/services';
 import { OxyServices } from '@oxyhq/core';
 import { ImageResolverProvider, type ImageResolver } from '@oxyhq/bloom/image-resolver';
-import { AgoraProvider, LiveRoomProvider } from '@syra.fm/live';
+import { LiveConfigProvider, LiveRoomProvider } from '@syra.fm/live';
 
 import { OXY_CLIENT_ID } from '@/config';
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -50,9 +50,9 @@ function LiveRoomsProvider({ children }: { children: React.ReactNode }) {
   }, [queryClient]);
   const config = useMemo(() => ({ ...liveConfig, onRoomChanged }), [onRoomChanged]);
   return (
-    <AgoraProvider config={config}>
+    <LiveConfigProvider config={config}>
       <LiveRoomProvider>{children}</LiveRoomProvider>
-    </AgoraProvider>
+    </LiveConfigProvider>
   );
 }
 

--- a/packages/frontend/lib/liveConfig.ts
+++ b/packages/frontend/lib/liveConfig.ts
@@ -1,7 +1,7 @@
 import { useOxy } from '@oxyhq/services';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useQuery } from '@tanstack/react-query';
-import type { AgoraConfig, AgoraTheme, UserEntity } from '@syra.fm/live';
+import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
 import { authenticatedClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
@@ -23,12 +23,12 @@ const liveUserQueryKey = (id: string) => ['live', 'user', id] as const;
 const LIVE_USER_STALE_TIME = 5 * 60 * 1000;
 
 /**
- * Bloom's `useTheme` returns a superset of the engine's `AgoraTheme`. Spreading
+ * Bloom's `useTheme` returns a superset of the engine's `LiveTheme`. Spreading
  * `colors` into a fresh object literal both forwards every Bloom color key the
  * live-room UI reads AND gives the object the string index signature
- * `AgoraTheme.colors` requires (a named interface has none).
+ * `LiveTheme.colors` requires (a named interface has none).
  */
-function useLiveTheme(): AgoraTheme {
+function useLiveTheme(): LiveTheme {
   const theme = useTheme();
   return { isDark: theme.isDark, colors: { ...theme.colors } };
 }
@@ -75,7 +75,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * sonner toasts. `onRoomChanged` is injected in `AppProviders` where a
  * `QueryClient` is in scope.
  */
-export const liveConfig: AgoraConfig = {
+export const liveConfig: LiveConfig = {
   httpClient: authenticatedClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
@@ -84,7 +84,7 @@ export const liveConfig: AgoraConfig = {
   ensureUserById: ensureLiveUserById,
   getCachedFileDownloadUrl: async (_oxy, fileId, variant) => oxyServices.getFileDownloadUrl(fileId, variant),
   getCachedFileDownloadUrlSync: (_oxy, fileId, variant) => oxyServices.getFileDownloadUrl(fileId, variant),
-  AvatarComponent: Avatar as AgoraConfig['AvatarComponent'],
+  AvatarComponent: Avatar as LiveConfig['AvatarComponent'],
   toast: liveToast,
   introSound: require('@syra.fm/live/src/assets/sounds/intro.mp3'),
 };

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syra.fm/live",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Syra live rooms engine (DI-based; audio rooms over LiveKit)",
   "source": "src/index.ts",
   "main": "lib/commonjs/index.js",

--- a/packages/live/src/assets/icons/spaces-icon.tsx
+++ b/packages/live/src/assets/icons/spaces-icon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import Svg, { Path } from 'react-native-svg';
 import { ViewStyle, type ColorValue } from 'react-native';
 
-export const Agora = ({ color = 'currentColor', size = 26, style }: { color?: ColorValue; size?: number; style?: ViewStyle }) => (
+export const LiveRoomsIcon = ({ color = 'currentColor', size = 26, style }: { color?: ColorValue; size?: number; style?: ViewStyle }) => (
   <Svg viewBox="0 0 24 24" width={size} height={size} style={style}>
     <Path d="M12 22.25c-4.99 0-9.18-3.393-10.39-7.994l1.93-.512c.99 3.746 4.4 6.506 8.46 6.506s7.47-2.76 8.46-6.506l1.93.512c-1.21 4.601-5.4 7.994-10.39 7.994zM5 11.5c0 3.866 3.13 7 7 7s7-3.134 7-7V8.75c0-3.866-3.13-7-7-7s-7 3.134-7 7v2.75zm12-2.75v2.75c0 2.761-2.24 5-5 5s-5-2.239-5-5V8.75c0-2.761 2.24-5 5-5s5 2.239 5 5zM11.25 8v4.25c0 .414.34.75.75.75s.75-.336.75-.75V8c0-.414-.34-.75-.75-.75s-.75.336-.75.75zm-3 1v2.25c0 .414.34.75.75.75s.75-.336.75-.75V9c0-.414-.34-.75-.75-.75s-.75.336-.75.75zm7.5 0c0-.414-.34-.75-.75-.75s-.75.336-.75.75v2.25c0 .414.34.75.75.75s.75-.336.75-.75V9z" fill={color} />
   </Svg>
 );
 
-export const AgoraActive = ({ color = 'currentColor', size = 26, style }: { color?: ColorValue; size?: number; style?: ViewStyle }) => (
+export const LiveRoomsIconActive = ({ color = 'currentColor', size = 26, style }: { color?: ColorValue; size?: number; style?: ViewStyle }) => (
   <Svg viewBox="0 0 24 24" width={size} height={size} style={style}>
     <Path d="M12 22.25c-4.99 0-9.18-3.393-10.39-7.994l1.93-.512c.99 3.746 4.4 6.506 8.46 6.506s7.47-2.76 8.46-6.506l1.93.512c-1.21 4.601-5.4 7.994-10.39 7.994zm0-20.5c-3.87 0-7 3.134-7 7v2.75c0 3.866 3.13 7 7 7s7-3.134 7-7V8.75c0-3.866-3.13-7-7-7zm-2.25 9.5c0 .414-.34.75-.75.75s-.75-.336-.75-.75V9c0-.414.34-.75.75-.75s.75.336.75.75v2.25zm3 1c0 .414-.34.75-.75.75s-.75-.336-.75-.75V8c0-.414.34-.75.75-.75s.75.336.75.75v4.25zm3-1c0 .414-.34.75-.75.75s-.75-.336-.75-.75V9c0-.414.34-.75.75-.75s.75.336.75.75v2.25z" fill={color} />
   </Svg>

--- a/packages/live/src/components/CreateRoomSheet.tsx
+++ b/packages/live/src/components/CreateRoomSheet.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import { useLiveRoom } from '../context/LiveRoomContext';
 import type { Room, House } from '../types';
 
@@ -70,7 +70,7 @@ export const CreateRoomSheet = forwardRef<CreateRoomSheetRef, CreateRoomSheetPro
   houses,
 }, ref) => {
   const Scroll = ScrollViewComponent || ScrollView;
-  const { useTheme, agoraService, toast } = useAgoraConfig();
+  const { useTheme, roomsService, toast } = useLiveConfig();
   const theme = useTheme();
   const { joinLiveRoom } = useLiveRoom();
   const [title, setTitle] = useState('');
@@ -106,10 +106,10 @@ export const CreateRoomSheet = forwardRef<CreateRoomSheetRef, CreateRoomSheetPro
 
     setLoading(true);
     try {
-      const room = await agoraService.createRoom(buildCreatePayload());
+      const room = await roomsService.createRoom(buildCreatePayload());
 
       if (room) {
-        const started = await agoraService.startRoom(room._id);
+        const started = await roomsService.startRoom(room._id);
         onClose();
         if (started) {
           joinLiveRoom(room._id);
@@ -138,7 +138,7 @@ export const CreateRoomSheet = forwardRef<CreateRoomSheetRef, CreateRoomSheetPro
 
     setLoading(true);
     try {
-      const room = await agoraService.createRoom({
+      const room = await roomsService.createRoom({
         ...buildCreatePayload(),
         scheduledStart: scheduledStart.trim(),
       });
@@ -162,7 +162,7 @@ export const CreateRoomSheet = forwardRef<CreateRoomSheetRef, CreateRoomSheetPro
 
     setLoading(true);
     try {
-      const room = await agoraService.createRoom(buildCreatePayload());
+      const room = await roomsService.createRoom(buildCreatePayload());
 
       if (room) {
         onClose();

--- a/packages/live/src/components/InsightsPanel.tsx
+++ b/packages/live/src/components/InsightsPanel.tsx
@@ -3,12 +3,12 @@ import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
 import { PanelHeader } from './PanelHeader';
-import type { Room, RoomParticipant, AgoraTheme } from '../types';
+import type { Room, RoomParticipant, LiveTheme } from '../types';
 
 interface InsightsPanelProps {
   room: Room | null;
   participants: RoomParticipant[];
-  theme: AgoraTheme;
+  theme: LiveTheme;
   onClose: () => void;
 }
 

--- a/packages/live/src/components/LiveRoomSheet.tsx
+++ b/packages/live/src/components/LiveRoomSheet.tsx
@@ -11,7 +11,7 @@ import {
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useAuth } from '@oxyhq/services';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import { MiniRoomBar } from './MiniRoomBar';
 import { StreamConfigPanel } from './StreamConfigPanel';
 import { InsightsPanel } from './InsightsPanel';
@@ -22,7 +22,7 @@ import { useRoomConnection } from '../hooks/useRoomConnection';
 import { useRoomAudio } from '../hooks/useRoomAudio';
 import { useActiveSpeakers } from '../hooks/useActiveSpeakers';
 import { useRoomUsers, getDisplayName, getAvatarUrl } from '../hooks/useRoomUsers';
-import type { RoomParticipant, Room, StreamInfo, UserEntity, AgoraTheme } from '../types';
+import type { RoomParticipant, Room, StreamInfo, UserEntity, LiveTheme } from '../types';
 
 type ActivePanel = null | 'stream' | 'insights' | 'settings';
 
@@ -51,7 +51,7 @@ function formatClock(totalSeconds: number, withHours: boolean): string {
 type AvatarComponentType = React.ComponentType<{ size: number; source?: string; shape?: string; style?: ViewStyle }>;
 type CachedFileDownloadUrlSyncFn = (oxyServices: unknown, fileId: string, variant?: string) => string;
 
-const RoleBadge = ({ role, theme }: { role: string; theme: AgoraTheme }) => {
+const RoleBadge = ({ role, theme }: { role: string; theme: LiveTheme }) => {
   if (role === 'host') {
     return (
       <View style={[styles.roleBadge, { backgroundColor: theme.colors.primary }]}>
@@ -82,7 +82,7 @@ const SpeakerTile = ({
   participant: RoomParticipant;
   isCurrentUser: boolean;
   isSpeaking: boolean;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   userProfile: UserEntity | undefined;
   oxyServices: unknown;
   AvatarComponent: AvatarComponentType;
@@ -134,7 +134,7 @@ const ListenerAvatar = ({
 };
 
 const ConnectedSpeakerTile = ({ participant, isCurrentUser, isSpeaking, theme, oxyServices, AvatarComponent, getCachedFileDownloadUrlSync, useUserById }: {
-  participant: RoomParticipant; isCurrentUser: boolean; isSpeaking: boolean; theme: AgoraTheme; oxyServices: unknown;
+  participant: RoomParticipant; isCurrentUser: boolean; isSpeaking: boolean; theme: LiveTheme; oxyServices: unknown;
   AvatarComponent: AvatarComponentType; getCachedFileDownloadUrlSync: CachedFileDownloadUrlSyncFn; useUserById: (id: string | undefined) => UserEntity | undefined;
 }) => {
   const userProfile = useUserById(participant.userId);
@@ -150,7 +150,7 @@ const ConnectedListenerAvatar = ({ participant, oxyServices, AvatarComponent, ge
 };
 
 const ConnectedRequestRow = ({ request, theme, oxyServices, onApprove, onDeny, AvatarComponent, getCachedFileDownloadUrlSync, useUserById }: {
-  request: { userId: string; requestedAt: string }; theme: AgoraTheme; oxyServices: unknown;
+  request: { userId: string; requestedAt: string }; theme: LiveTheme; oxyServices: unknown;
   onApprove: (userId: string) => void; onDeny: (userId: string) => void;
   AvatarComponent: AvatarComponentType; getCachedFileDownloadUrlSync: CachedFileDownloadUrlSyncFn; useUserById: (id: string | undefined) => UserEntity | undefined;
 }) => {
@@ -183,7 +183,7 @@ interface LiveRoomSheetProps {
 }
 
 export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeave }: LiveRoomSheetProps) {
-  const { useTheme, useUserById, AvatarComponent, agoraService, toast, getCachedFileDownloadUrl, getCachedFileDownloadUrlSync, onRoomChanged, t } = useAgoraConfig();
+  const { useTheme, useUserById, AvatarComponent, roomsService, toast, getCachedFileDownloadUrl, getCachedFileDownloadUrlSync, onRoomChanged, t } = useLiveConfig();
   const theme = useTheme();
   const { user, oxyServices } = useAuth();
   const [room, setRoom] = useState<Room | null>(null);
@@ -195,7 +195,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
 
   useEffect(() => {
     if (roomId) {
-      agoraService.getRoom(roomId).then(setRoom);
+      roomsService.getRoom(roomId).then(setRoom);
     }
   }, [roomId]);
 
@@ -247,7 +247,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
 
   const handleStopRoom = async () => {
     if (!roomId) return;
-    const success = await agoraService.stopRoom(roomId);
+    const success = await roomsService.stopRoom(roomId);
     if (success) {
       onRoomChanged?.(roomId);
       leave();
@@ -259,7 +259,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
 
   const handleDeleteRoom = async () => {
     if (!roomId) return;
-    const success = await agoraService.deleteRoom(roomId);
+    const success = await roomsService.deleteRoom(roomId);
     if (success) {
       onRoomChanged?.(roomId);
       leave();
@@ -275,9 +275,9 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
     if (!roomId || startingRoom) return;
     setStartingRoom(true);
     try {
-      const success = await agoraService.startRoom(roomId);
+      const success = await roomsService.startRoom(roomId);
       if (success) {
-        const updated = await agoraService.getRoom(roomId);
+        const updated = await roomsService.getRoom(roomId);
         if (updated) setRoom(updated);
         onRoomChanged?.(roomId);
         toast.success('Room is now live!');
@@ -293,7 +293,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
 
   const handleStartRecording = async () => {
     if (!roomId) return;
-    const success = await agoraService.startRecording(roomId);
+    const success = await roomsService.startRecording(roomId);
     if (success) {
       toast.success('Recording started');
     } else {
@@ -303,7 +303,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
 
   const handleStopRecording = async () => {
     if (!roomId) return;
-    const success = await agoraService.stopRecording(roomId);
+    const success = await roomsService.stopRecording(roomId);
     if (success) {
       toast.success('Recording saved');
     } else {
@@ -365,7 +365,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
     if (!roomId || streamLoading) return;
     setStreamLoading(true);
     try {
-      const success = await agoraService.stopStream(roomId);
+      const success = await roomsService.stopStream(roomId);
       if (success) {
         toast.success('Stream stopped');
       } else {
@@ -383,12 +383,12 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
     if (!roomId || skipLoading) return;
     setSkipLoading(true);
     try {
-      const result = await agoraService.skipPodcastNext(roomId);
+      const result = await roomsService.skipPodcastNext(roomId);
       if (!result) {
         toast.error(tr('agora.podcastStream.skipFailed'));
       } else {
         toast.success(tr(result.ended ? 'agora.podcastStream.queueEnded' : 'agora.podcastStream.skipped'));
-        const updated = await agoraService.getRoom(roomId);
+        const updated = await roomsService.getRoom(roomId);
         if (updated) setRoom(updated);
       }
     } catch {
@@ -435,7 +435,7 @@ export function LiveRoomSheet({ roomId, isExpanded, onCollapse, onExpand, onLeav
         initialStreamKey={room?.rtmpStreamKey ?? undefined}
         onClose={() => setActivePanel(null)}
         onStreamStarted={() => {
-          agoraService.getRoom(roomId).then(setRoom);
+          roomsService.getRoom(roomId).then(setRoom);
           onRoomChanged?.(roomId);
           setActivePanel(null);
         }}

--- a/packages/live/src/components/MiniRoomBar.tsx
+++ b/packages/live/src/components/MiniRoomBar.tsx
@@ -11,7 +11,7 @@ import Animated, {
   cancelAnimation,
 } from 'react-native-reanimated';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 
 interface MiniRoomBarProps {
   title: string;
@@ -36,7 +36,7 @@ export function MiniRoomBar({
   onToggleMute,
   onLeave,
 }: MiniRoomBarProps) {
-  const { useTheme } = useAgoraConfig();
+  const { useTheme } = useLiveConfig();
   const theme = useTheme();
 
   const pulseScale = useSharedValue(1);

--- a/packages/live/src/components/PanelHeader.tsx
+++ b/packages/live/src/components/PanelHeader.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
-import type { AgoraTheme } from '../types';
+import type { LiveTheme } from '../types';
 
 interface PanelHeaderProps {
   title: string;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   onBack: () => void;
 }
 

--- a/packages/live/src/components/PodcastStreamPicker.tsx
+++ b/packages/live/src/components/PodcastStreamPicker.tsx
@@ -12,8 +12,8 @@ import {
 import type { ViewStyle } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
-import { useAgoraConfig, type PinnedPodcast } from '../context/AgoraConfigContext';
-import type { AgoraTheme } from '../types';
+import { useLiveConfig, type PinnedPodcast } from '../context/LiveConfigContext';
+import type { LiveTheme } from '../types';
 import type { PodcastResult, EpisodeListItem, MusicTrackResult } from '../services/spacesService';
 
 const SEARCH_DEBOUNCE_MS = 350;
@@ -23,8 +23,8 @@ const SYRA_WEB_BASE_URL = 'https://syra.fm';
 
 /**
  * English source copy for every user-facing string in the picker. Hosts with an
- * i18n layer (the Mention frontend) inject `t` via `useAgoraConfig()` and these
- * are never read; hosts without one (the standalone Agora app) fall back to
+ * i18n layer (the Mention frontend) inject `t` via `useLiveConfig()` and these
+ * are never read; hosts without one (the standalone live-rooms app) fall back to
  * these. Keys mirror the `agora.podcastStream.*` entries in the app locale files.
  */
 const DEFAULT_STRINGS: Record<string, string> = {
@@ -112,7 +112,7 @@ const ShowRow = memo(function ShowRow({
   onSelect,
 }: {
   show: PodcastResult;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   AvatarComponent: AvatarComponentType;
   onSelect: (show: PodcastResult) => void;
 }) {
@@ -145,7 +145,7 @@ const EpisodeRow = memo(function EpisodeRow({
   queueActionLabel,
 }: {
   episode: EpisodeListItem;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   AvatarComponent: AvatarComponentType;
   onSelect: (episode: EpisodeListItem) => void;
   queueEnabled: boolean;
@@ -200,7 +200,7 @@ const ErrorState = memo(function ErrorState({
   retryLabel,
   onRetry,
 }: {
-  theme: AgoraTheme;
+  theme: LiveTheme;
   message: string;
   retryLabel: string;
   onRetry: () => void;
@@ -225,8 +225,8 @@ const ErrorState = memo(function ErrorState({
  * Self-contained two-level podcast picker for the live-room stream setup. Level 1
  * is a debounced Syra show search; tapping a show drills into Level 2, its episode
  * list. Tapping an episode reports `(syraPodcastId, episodeId)` to the parent — the
- * picker owns NO room/stream logic. Ships inside agora-shared, so it depends only
- * on `useAgoraConfig()` injection and never imports from a host app (`@/`).
+ * picker owns NO room/stream logic. Ships inside @syra.fm/live, so it depends only
+ * on `useLiveConfig()` injection and never imports from a host app (`@/`).
  *
  * UX affordances (all backend-field-free): a host copyright disclaimer, an honest
  * error+Retry state distinct from empty results, a one-tap "stream my pinned
@@ -234,7 +234,7 @@ const ErrorState = memo(function ErrorState({
  * "Open in Syra" deep link on the episode-list header.
  */
 export function PodcastStreamPicker({ onSelectEpisode, onStartQueue }: PodcastStreamPickerProps) {
-  const { useTheme, agoraService, AvatarComponent, toast, t, getPinnedPodcast } = useAgoraConfig();
+  const { useTheme, roomsService, AvatarComponent, toast, t, getPinnedPodcast } = useLiveConfig();
   const theme = useTheme();
 
   const tr = useCallback<TranslateFn>(
@@ -292,7 +292,7 @@ export function PodcastStreamPicker({ onSelectEpisode, onStartQueue }: PodcastSt
         setShowsLoadingMore(true);
       }
 
-      const result = await agoraService.searchPodcasts(trimmed, offset);
+      const result = await roomsService.searchPodcasts(trimmed, offset);
       if (seq !== showsSeqRef.current) return; // superseded by a newer query
 
       if (!result.ok) {
@@ -314,7 +314,7 @@ export function PodcastStreamPicker({ onSelectEpisode, onStartQueue }: PodcastSt
       setShowsLoading(false);
       setShowsLoadingMore(false);
     },
-    [agoraService],
+    [roomsService],
   );
 
   const handleQueryChange = useCallback(
@@ -355,7 +355,7 @@ export function PodcastStreamPicker({ onSelectEpisode, onStartQueue }: PodcastSt
         setEpisodesLoadingMore(true);
       }
 
-      const result = await agoraService.getPodcastEpisodes(syraPodcastId, offset);
+      const result = await roomsService.getPodcastEpisodes(syraPodcastId, offset);
       if (seq !== episodesSeqRef.current) return; // superseded by a newer show
 
       if (!result.ok) {
@@ -375,7 +375,7 @@ export function PodcastStreamPicker({ onSelectEpisode, onStartQueue }: PodcastSt
       setEpisodesLoading(false);
       setEpisodesLoadingMore(false);
     },
-    [agoraService],
+    [roomsService],
   );
 
   const handleSelectShow = useCallback(
@@ -712,7 +712,7 @@ const MusicTrackRow = memo(function MusicTrackRow({
   queueActionLabel,
 }: {
   track: MusicTrackResult;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   AvatarComponent: AvatarComponentType;
   onSelect: (track: MusicTrackResult) => void;
   isQueued: boolean;
@@ -771,7 +771,7 @@ interface MusicPickerProps {
  * A debounced Syra catalog search; tapping a track reports its `trackId` to the
  * parent (the picker owns NO room/stream logic and never sees an audio URL — the
  * backend resolves the playable source server-side). Ships inside the shared
- * package, so it depends only on `useAgoraConfig()` injection and never imports
+ * package, so it depends only on `useLiveConfig()` injection and never imports
  * from a host app (`@/`).
  *
  * Mirrors {@link PodcastStreamPicker}: a host copyright/broadcast disclaimer, an
@@ -779,7 +779,7 @@ interface MusicPickerProps {
  * queue (per-row "+" plus a floating "Play (N)" footer).
  */
 export function MusicPicker({ onSelectTrack, onStartQueue }: MusicPickerProps) {
-  const { useTheme, agoraService, AvatarComponent, t } = useAgoraConfig();
+  const { useTheme, roomsService, AvatarComponent, t } = useLiveConfig();
   const theme = useTheme();
 
   const tr = useCallback<TranslateFn>((key) => (t ? t(key) : DEFAULT_STRINGS[key] ?? key), [t]);
@@ -819,7 +819,7 @@ export function MusicPicker({ onSelectTrack, onStartQueue }: MusicPickerProps) {
         setLoadingMore(true);
       }
 
-      const result = await agoraService.searchMusic(trimmed, offset);
+      const result = await roomsService.searchMusic(trimmed, offset);
       if (seq !== seqRef.current) return; // superseded by a newer query
 
       if (!result.ok) {
@@ -839,7 +839,7 @@ export function MusicPicker({ onSelectTrack, onStartQueue }: MusicPickerProps) {
       setLoading(false);
       setLoadingMore(false);
     },
-    [agoraService],
+    [roomsService],
   );
 
   const handleQueryChange = useCallback(

--- a/packages/live/src/components/RecordingCard.tsx
+++ b/packages/live/src/components/RecordingCard.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, StyleProp, ViewStyle } from '
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useAuth } from '@oxyhq/services';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import { getAvatarUrl, getDisplayName } from '../hooks/useRoomUsers';
 import type { Recording } from '../validation';
 
@@ -35,7 +35,7 @@ interface RecordingCardProps {
 // --- Component ---
 
 export const RecordingCard: React.FC<RecordingCardProps> = ({ recording, onPress, style }) => {
-  const { useTheme, useUserById, AvatarComponent, getCachedFileDownloadUrlSync } = useAgoraConfig();
+  const { useTheme, useUserById, AvatarComponent, getCachedFileDownloadUrlSync } = useLiveConfig();
   const theme = useTheme();
   const { oxyServices } = useAuth();
   const hostProfile = useUserById(recording.host);

--- a/packages/live/src/components/RecordingsPanel.tsx
+++ b/packages/live/src/components/RecordingsPanel.tsx
@@ -3,13 +3,13 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 
 import { PanelHeader } from './PanelHeader';
-import { useAgoraConfig } from '../context/AgoraConfigContext';
-import type { Recording, AgoraTheme } from '../types';
+import { useLiveConfig } from '../context/LiveConfigContext';
+import type { Recording, LiveTheme } from '../types';
 
 interface RecordingsPanelProps {
   roomId: string;
   isHost: boolean;
-  theme: AgoraTheme;
+  theme: LiveTheme;
   onClose: () => void;
   onPlay?: (playbackUrl: string, recording: Recording) => void;
 }
@@ -31,7 +31,7 @@ function formatDate(dateStr: string): string {
 }
 
 export function RecordingsPanel({ roomId, isHost, theme, onClose, onPlay }: RecordingsPanelProps) {
-  const { agoraService, toast } = useAgoraConfig();
+  const { roomsService, toast } = useLiveConfig();
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [loading, setLoading] = useState(true);
   const [playingId, setPlayingId] = useState<string | null>(null);
@@ -42,7 +42,7 @@ export function RecordingsPanel({ roomId, isHost, theme, onClose, onPlay }: Reco
 
   const loadRecordings = async () => {
     setLoading(true);
-    const data = await agoraService.getRoomRecordings(roomId);
+    const data = await roomsService.getRoomRecordings(roomId);
     setRecordings(data);
     setLoading(false);
   };
@@ -50,7 +50,7 @@ export function RecordingsPanel({ roomId, isHost, theme, onClose, onPlay }: Reco
   const handlePlay = async (recording: Recording) => {
     setPlayingId(recording._id);
     try {
-      const result = await agoraService.getRecording(recording._id);
+      const result = await roomsService.getRecording(recording._id);
       if (result?.playbackUrl) {
         onPlay?.(result.playbackUrl, recording);
       } else {
@@ -65,7 +65,7 @@ export function RecordingsPanel({ roomId, isHost, theme, onClose, onPlay }: Reco
 
   const handleToggleAccess = async (recording: Recording) => {
     const newAccess = recording.access === 'public' ? 'participants' as const : 'public' as const;
-    const success = await agoraService.updateRecordingAccess(recording._id, newAccess);
+    const success = await roomsService.updateRecordingAccess(recording._id, newAccess);
     if (success) {
       setRecordings((prev) =>
         prev.map((r) => r._id === recording._id ? { ...r, access: newAccess } : r)
@@ -77,7 +77,7 @@ export function RecordingsPanel({ roomId, isHost, theme, onClose, onPlay }: Reco
   };
 
   const handleDelete = async (recording: Recording) => {
-    const success = await agoraService.deleteRecording(recording._id);
+    const success = await roomsService.deleteRecording(recording._id);
     if (success) {
       setRecordings((prev) => prev.filter((r) => r._id !== recording._id));
       toast.success('Recording deleted');

--- a/packages/live/src/components/RoomCard.tsx
+++ b/packages/live/src/components/RoomCard.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, StyleProp, ViewStyle } from '
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useAuth } from '@oxyhq/services';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import { AnimatedPulse } from './AnimatedPulse';
 import { useRoomUsers, getAvatarUrl } from '../hooks/useRoomUsers';
 
@@ -101,7 +101,7 @@ export const RoomCard: React.FC<RoomCardProps> = ({
   isSaved,
   style,
 }) => {
-  const { useTheme, useUserById, AvatarComponent, getCachedFileDownloadUrlSync } = useAgoraConfig();
+  const { useTheme, useUserById, AvatarComponent, getCachedFileDownloadUrlSync } = useLiveConfig();
   const theme = useTheme();
   const { oxyServices } = useAuth();
   const hostProfile = useUserById(room.host);
@@ -292,7 +292,7 @@ function SpeakerRow({
 }: {
   speakerIds: string[];
   listenerCount: number;
-  theme: ReturnType<ReturnType<typeof useAgoraConfig>['useTheme']>;
+  theme: ReturnType<ReturnType<typeof useLiveConfig>['useTheme']>;
 }) {
   return (
     <View style={styles.avatarRow}>
@@ -311,7 +311,7 @@ function SpeakerRow({
 }
 
 function SpeakerAvatar({ userId }: { userId: string }) {
-  const { useUserById, AvatarComponent, getCachedFileDownloadUrlSync, useTheme } = useAgoraConfig();
+  const { useUserById, AvatarComponent, getCachedFileDownloadUrlSync, useTheme } = useLiveConfig();
   const theme = useTheme();
   const { oxyServices } = useAuth();
   const profile = useUserById(userId);

--- a/packages/live/src/components/StreamConfigModal.tsx
+++ b/packages/live/src/components/StreamConfigModal.tsx
@@ -16,7 +16,7 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useAuth } from '@oxyhq/services';
 import * as ImagePicker from 'expo-image-picker';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 
 interface StreamConfigModalProps {
   visible: boolean;
@@ -29,7 +29,7 @@ interface StreamConfigModalProps {
 type StreamMode = 'url' | 'rtmp';
 
 export function StreamConfigModal({ visible, onClose, roomId, initialStreamUrl, onStreamStarted }: StreamConfigModalProps) {
-  const { useTheme, agoraService, toast } = useAgoraConfig();
+  const { useTheme, roomsService, toast } = useLiveConfig();
   const theme = useTheme();
   const { oxyServices } = useAuth();
 
@@ -126,7 +126,7 @@ export function StreamConfigModal({ visible, onClose, roomId, initialStreamUrl, 
     if (!streamUrl.trim() || loading) return;
     setLoading(true);
     try {
-      const result = await agoraService.startStream(roomId, {
+      const result = await roomsService.startStream(roomId, {
         url: streamUrl.trim(),
         title: title.trim() || undefined,
         image: imageFileId || undefined,
@@ -151,7 +151,7 @@ export function StreamConfigModal({ visible, onClose, roomId, initialStreamUrl, 
     if (generatingKey) return;
     setGeneratingKey(true);
     try {
-      const result = await agoraService.generateStreamKey(roomId, {
+      const result = await roomsService.generateStreamKey(roomId, {
         title: title.trim() || undefined,
         image: imageFileId || undefined,
         description: description.trim() || undefined,
@@ -183,7 +183,7 @@ export function StreamConfigModal({ visible, onClose, roomId, initialStreamUrl, 
     }
     setLoading(true);
     try {
-      const success = await agoraService.updateStreamMetadata(roomId, {
+      const success = await roomsService.updateStreamMetadata(roomId, {
         ...(mode === 'url' ? { url: trimmedUrl } : {}),
         title: title.trim() || undefined,
         image: imageFileId || undefined,

--- a/packages/live/src/components/StreamConfigPanel.tsx
+++ b/packages/live/src/components/StreamConfigPanel.tsx
@@ -13,7 +13,7 @@ import {
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import * as ImagePicker from 'expo-image-picker';
 
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import { PanelHeader } from './PanelHeader';
 import { PodcastStreamPicker, MusicPicker } from './PodcastStreamPicker';
 
@@ -45,7 +45,7 @@ function appendNativeFile(formData: FormData, file: NativeFormDataFile): void {
 }
 
 export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initialRtmpUrl, initialStreamKey, onClose, onStreamStarted }: StreamConfigPanelProps) {
-  const { useTheme, agoraService, toast, onRoomChanged } = useAgoraConfig();
+  const { useTheme, roomsService, toast, onRoomChanged } = useLiveConfig();
   const theme = useTheme();
 
   const initialUrl = initialStreamUrl?.trim() ?? '';
@@ -107,7 +107,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
           appendNativeFile(formData, nativeFile);
         }
 
-        const cdnUrl = await agoraService.uploadRoomImage(roomId, formData);
+        const cdnUrl = await roomsService.uploadRoomImage(roomId, formData);
         if (cdnUrl) {
           setImageCdnUrl(cdnUrl);
         } else {
@@ -130,7 +130,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
   const ensureRoomLive = async (): Promise<boolean> => {
     if (roomStatus === 'live') return true;
     if (roomStatus === 'scheduled') {
-      const started = await agoraService.startRoom(roomId);
+      const started = await roomsService.startRoom(roomId);
       if (!started) {
         toast.error('Failed to start room');
         return false;
@@ -147,7 +147,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setLoading(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.startStream(roomId, {
+      const result = await roomsService.startStream(roomId, {
         url: streamUrl.trim(),
         title: title.trim() || undefined,
         image: imageCdnUrl || undefined,
@@ -173,7 +173,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setLoading(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.startPodcastStream(roomId, { syraPodcastId, episodeId });
+      const result = await roomsService.startPodcastStream(roomId, { syraPodcastId, episodeId });
       if (result) {
         toast.success('Stream started');
         resetState();
@@ -197,7 +197,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setLoading(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.startPodcastStream(roomId, {
+      const result = await roomsService.startPodcastStream(roomId, {
         syraPodcastId: first.syraPodcastId,
         episodeId: first.episodeId,
         queue: rest,
@@ -223,7 +223,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setLoading(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.startTrackStream(roomId, { trackId });
+      const result = await roomsService.startTrackStream(roomId, { trackId });
       if (result) {
         toast.success('Stream started');
         resetState();
@@ -247,7 +247,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setLoading(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.startTrackStream(roomId, {
+      const result = await roomsService.startTrackStream(roomId, {
         trackId: first,
         queue: rest.map((trackId) => ({ trackId })),
       });
@@ -274,7 +274,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     setGeneratingKey(true);
     try {
       if (!(await ensureRoomLive())) return;
-      const result = await agoraService.generateStreamKey(roomId, {
+      const result = await roomsService.generateStreamKey(roomId, {
         title: title.trim() || undefined,
         image: imageCdnUrl || undefined,
         description: description.trim() || undefined,
@@ -313,7 +313,7 @@ export function StreamConfigPanel({ roomId, roomStatus, initialStreamUrl, initia
     }
     setLoading(true);
     try {
-      const success = await agoraService.updateStreamMetadata(roomId, {
+      const success = await roomsService.updateStreamMetadata(roomId, {
         ...(mode === 'url' ? { url: trimmedUrl } : {}),
         title: title.trim() || undefined,
         image: imageCdnUrl || undefined,

--- a/packages/live/src/context/LiveConfigContext.tsx
+++ b/packages/live/src/context/LiveConfigContext.tsx
@@ -1,13 +1,13 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import type { ViewStyle } from 'react-native';
-import type { AgoraTheme, UserEntity, HttpClient } from '../types';
-import { createAgoraService, type AgoraServiceInstance } from '../services/spacesService';
+import type { LiveTheme, UserEntity, HttpClient } from '../types';
+import { createRoomsService, type RoomsServiceInstance } from '../services/spacesService';
 import { RoomSocketService } from '../services/spaceSocketService';
 import { createGetRoomToken, type GetRoomTokenFn } from '../services/livekitService';
 
 /**
  * The viewer's pinned Syra podcast (resolved from their profile media), surfaced
- * by {@link AgoraConfig.getPinnedPodcast}. `title`/`artworkUrl` are optional —
+ * by {@link LiveConfig.getPinnedPodcast}. `title`/`artworkUrl` are optional —
  * the id is all the picker needs to drill into the episode list.
  */
 export interface PinnedPodcast {
@@ -16,14 +16,14 @@ export interface PinnedPodcast {
   artworkUrl?: string;
 }
 
-export interface AgoraConfig {
+export interface LiveConfig {
   httpClient: HttpClient;
   socketUrl: string;
-  useTheme: () => AgoraTheme;
+  useTheme: () => LiveTheme;
   /**
    * Translate a UI string key to the active locale. Optional: hosts WITH an i18n
    * layer (the Mention frontend) inject their real translator so the shared
-   * live-room UI localizes; hosts WITHOUT one (the standalone Agora app) omit it
+   * live-room UI localizes; hosts WITHOUT one (the standalone live-rooms app) omit it
    * and the shared components fall back to their bundled English source copy.
    * Keys are looked up flat (e.g. `agora.podcastStream.disclaimer`).
    */
@@ -66,31 +66,31 @@ export interface AgoraConfig {
   dockClassName?: string;
 }
 
-export interface AgoraConfigInternal extends AgoraConfig {
-  agoraService: AgoraServiceInstance;
+export interface LiveConfigInternal extends LiveConfig {
+  roomsService: RoomsServiceInstance;
   roomSocketService: RoomSocketService;
   getRoomToken: GetRoomTokenFn;
 }
 
-const AgoraConfigContext = createContext<AgoraConfigInternal | null>(null);
+const LiveConfigContext = createContext<LiveConfigInternal | null>(null);
 
-export function useAgoraConfig(): AgoraConfigInternal {
-  const config = useContext(AgoraConfigContext);
-  if (!config) throw new Error('useAgoraConfig must be used within an AgoraProvider');
+export function useLiveConfig(): LiveConfigInternal {
+  const config = useContext(LiveConfigContext);
+  if (!config) throw new Error('useLiveConfig must be used within a LiveConfigProvider');
   return config;
 }
 
-export function AgoraProvider({ config, children }: { config: AgoraConfig; children: React.ReactNode }) {
-  const fullConfig = useMemo<AgoraConfigInternal>(() => {
-    const agoraService = createAgoraService(config.httpClient);
+export function LiveConfigProvider({ config, children }: { config: LiveConfig; children: React.ReactNode }) {
+  const fullConfig = useMemo<LiveConfigInternal>(() => {
+    const roomsService = createRoomsService(config.httpClient);
     const roomSocketService = new RoomSocketService(config.socketUrl);
     const getRoomToken = createGetRoomToken(config.httpClient);
-    return { ...config, agoraService, roomSocketService, getRoomToken };
+    return { ...config, roomsService, roomSocketService, getRoomToken };
   }, [config]);
 
   return (
-    <AgoraConfigContext.Provider value={fullConfig}>
+    <LiveConfigContext.Provider value={fullConfig}>
       {children}
-    </AgoraConfigContext.Provider>
+    </LiveConfigContext.Provider>
   );
 }

--- a/packages/live/src/context/LiveRoomContext.tsx
+++ b/packages/live/src/context/LiveRoomContext.tsx
@@ -12,7 +12,7 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
 
-import { useAgoraConfig } from './AgoraConfigContext';
+import { useLiveConfig } from './LiveConfigContext';
 import { LiveRoomSheet } from '../components/LiveRoomSheet';
 import { MINI_BAR_HEIGHT } from '../components/MiniRoomBar';
 
@@ -38,7 +38,7 @@ const BOTTOM_BAR_OFFSET = 76;
 const defaultUseIsDesktop = () => false;
 
 export function LiveRoomProvider({ children }: { children: React.ReactNode }) {
-  const config = useAgoraConfig();
+  const config = useLiveConfig();
   const theme = config.useTheme();
   // NativeWind class the host supplies to pin the dock to the viewport on web
   // (e.g. `"web:fixed"` for the document-scroll shell). Undefined on hosts with
@@ -52,7 +52,7 @@ export function LiveRoomProvider({ children }: { children: React.ReactNode }) {
   //     OMIT the inline position so the supplied `web:fixed` class owns it
   //     (NativeWind lets an inline `position` win over a className, which would
   //     re-sink the dock to the document bottom).
-  //   - WEB + no host className (e.g. the Agora app, fixed-viewport model with
+  //   - WEB + no host className (e.g. the live-rooms app, fixed-viewport model with
   //     no NativeWind): `absolute` — pins to the viewport there, preserving the
   //     prior behavior.
   const dockPosition = useMemo<ViewStyle>(

--- a/packages/live/src/hooks/useRoomAudio.ts
+++ b/packages/live/src/hooks/useRoomAudio.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Platform } from 'react-native';
 import { Room, RoomEvent, Track, ConnectionState } from 'livekit-client';
 import { setAudioModeAsync } from 'expo-audio';
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 
 let AudioSession: { startAudioSession: () => void; stopAudioSession: () => void } | null = null;
 if (Platform.OS !== 'web') {
@@ -24,7 +24,7 @@ interface UseRoomAudioReturn {
 }
 
 export function useRoomAudio({ roomId, isSpeaker, isMuted, isConnected }: UseRoomAudioOptions): UseRoomAudioReturn {
-  const { getRoomToken } = useAgoraConfig();
+  const { getRoomToken } = useLiveConfig();
   const [isLiveKitConnected, setIsLiveKitConnected] = useState(false);
   const [localAudioEnabled, setLocalAudioEnabled] = useState(false);
   const [micPermissionDenied, setMicPermissionDenied] = useState(false);

--- a/packages/live/src/hooks/useRoomConnection.ts
+++ b/packages/live/src/hooks/useRoomConnection.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@oxyhq/services';
 import { createAudioPlayer } from 'expo-audio';
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import type { RoomParticipant, StreamInfo } from '../types';
 
 interface UseRoomConnectionOptions {
@@ -33,7 +33,7 @@ export function useRoomConnection({
   enabled = true,
 }: UseRoomConnectionOptions): UseRoomConnectionReturn {
   const { user, isAuthenticated, isReady, oxyServices } = useAuth();
-  const { roomSocketService, introSound } = useAgoraConfig();
+  const { roomSocketService, introSound } = useLiveConfig();
   const userId = user?.id;
 
   const [isConnected, setIsConnected] = useState(false);

--- a/packages/live/src/hooks/useRoomUsers.ts
+++ b/packages/live/src/hooks/useRoomUsers.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@oxyhq/services';
-import { useAgoraConfig } from '../context/AgoraConfigContext';
+import { useLiveConfig } from '../context/LiveConfigContext';
 import type { UserEntity } from '../types';
 
 export function useRoomUsers(userIds: string[]) {
   const { oxyServices } = useAuth();
-  const { ensureUserById } = useAgoraConfig();
+  const { ensureUserById } = useLiveConfig();
   const resolvedRef = useRef<Set<string>>(new Set());
 
   const loader = useCallback(

--- a/packages/live/src/index.ts
+++ b/packages/live/src/index.ts
@@ -17,7 +17,7 @@ export type {
   RecordingStateData,
   StreamInfo,
   UserEntity,
-  AgoraTheme,
+  LiveTheme,
   HttpResponse,
   HttpRequestConfig,
   HttpClient,
@@ -49,17 +49,17 @@ export {
 
 // Context
 export {
-  AgoraProvider,
-  useAgoraConfig,
-  type AgoraConfig,
-  type AgoraConfigInternal,
-} from './context/AgoraConfigContext';
+  LiveConfigProvider,
+  useLiveConfig,
+  type LiveConfig,
+  type LiveConfigInternal,
+} from './context/LiveConfigContext';
 export { LiveRoomProvider, useLiveRoom } from './context/LiveRoomContext';
 
 // Services
 export {
-  createAgoraService,
-  type AgoraServiceInstance,
+  createRoomsService,
+  type RoomsServiceInstance,
   type CreateRoomData,
   type PodcastResult,
   type EpisodeListItem,
@@ -89,4 +89,4 @@ export { RecordingsPanel } from './components/RecordingsPanel';
 export { RecordingCard } from './components/RecordingCard';
 
 // Assets
-export { Agora, AgoraActive } from './assets/icons/spaces-icon';
+export { LiveRoomsIcon, LiveRoomsIconActive } from './assets/icons/spaces-icon';

--- a/packages/live/src/services/spacesService.ts
+++ b/packages/live/src/services/spacesService.ts
@@ -179,7 +179,7 @@ function parseRecordingResponse(value: unknown): RecordingResponse | null {
   };
 }
 
-export function createAgoraService(httpClient: HttpClient) {
+export function createRoomsService(httpClient: HttpClient) {
   return {
     async getRooms(status?: string, type?: string): Promise<Room[]> {
       try {
@@ -279,7 +279,7 @@ export function createAgoraService(httpClient: HttpClient) {
         const res = await httpClient.post(`/rooms/${id}/stream`, data);
         const parsed = ZStartStreamResponse.safeParse(res.data);
         if (!parsed.success) {
-          console.warn('[agora] Invalid startStream response:', parsed.error.issues[0]);
+          console.warn('[live] Invalid startStream response:', parsed.error.issues[0]);
           return null;
         }
         return parsed.data;
@@ -295,7 +295,7 @@ export function createAgoraService(httpClient: HttpClient) {
         const res = await httpClient.post(`/rooms/${id}/stream/rtmp`, data || {});
         const parsed = ZGenerateStreamKeyResponse.safeParse(res.data);
         if (!parsed.success) {
-          console.warn('[agora] Invalid generateStreamKey response:', parsed.error.issues[0]);
+          console.warn('[live] Invalid generateStreamKey response:', parsed.error.issues[0]);
           return null;
         }
         return parsed.data;
@@ -364,7 +364,7 @@ export function createAgoraService(httpClient: HttpClient) {
         const res = await httpClient.post(`/rooms/${roomId}/stream/podcast`, body);
         const parsed = ZStartStreamResponse.safeParse(res.data);
         if (!parsed.success) {
-          console.warn('[agora] Invalid startPodcastStream response:', parsed.error.issues[0]);
+          console.warn('[live] Invalid startPodcastStream response:', parsed.error.issues[0]);
           return null;
         }
         return parsed.data;
@@ -387,7 +387,7 @@ export function createAgoraService(httpClient: HttpClient) {
         if (res.data.ended === true) return { ended: true };
         const parsed = ZStartStreamResponse.safeParse(res.data);
         if (parsed.success) return { ended: false };
-        console.warn('[agora] Invalid skipPodcastNext response:', parsed.error.issues[0]);
+        console.warn('[live] Invalid skipPodcastNext response:', parsed.error.issues[0]);
         return null;
       } catch (error) {
         console.warn("Failed to skip to next podcast episode", error);
@@ -430,7 +430,7 @@ export function createAgoraService(httpClient: HttpClient) {
         const res = await httpClient.post(`/rooms/${roomId}/stream/track`, body);
         const parsed = ZStartStreamResponse.safeParse(res.data);
         if (!parsed.success) {
-          console.warn('[agora] Invalid startTrackStream response:', parsed.error.issues[0]);
+          console.warn('[live] Invalid startTrackStream response:', parsed.error.issues[0]);
           return null;
         }
         return parsed.data;
@@ -689,4 +689,4 @@ export function createAgoraService(httpClient: HttpClient) {
   };
 }
 
-export type AgoraServiceInstance = ReturnType<typeof createAgoraService>;
+export type RoomsServiceInstance = ReturnType<typeof createRoomsService>;

--- a/packages/live/src/types.ts
+++ b/packages/live/src/types.ts
@@ -81,7 +81,7 @@ export interface UserEntity {
   [key: string]: unknown;
 }
 
-export interface AgoraTheme {
+export interface LiveTheme {
   isDark?: boolean;
   colors: {
     text: string;

--- a/packages/live/src/validation.ts
+++ b/packages/live/src/validation.ts
@@ -228,7 +228,7 @@ export type RoomAttachment = z.infer<typeof ZRoomAttachment>;
 export function validateRoom(data: unknown): Room | null {
   const result = ZRoom.safeParse(data);
   if (result.success) return result.data;
-  console.warn('[agora-shared] Invalid Room:', result.error.issues[0]);
+  console.warn('[live] Invalid Room:', result.error.issues[0]);
   return null;
 }
 
@@ -240,7 +240,7 @@ export function validateRooms(items: unknown[]): Room[] {
     if (parsed.success) {
       valid.push(parsed.data);
     } else {
-      console.warn('[agora-shared] Dropping invalid room:', parsed.error.issues[0]);
+      console.warn('[live] Dropping invalid room:', parsed.error.issues[0]);
     }
   }
   return valid;
@@ -249,14 +249,14 @@ export function validateRooms(items: unknown[]): Room[] {
 export function validateHouse(data: unknown): House | null {
   const result = ZHouse.safeParse(data);
   if (result.success) return result.data;
-  console.warn('[agora-shared] Invalid House:', result.error.issues[0]);
+  console.warn('[live] Invalid House:', result.error.issues[0]);
   return null;
 }
 
 export function validateRecording(data: unknown): Recording | null {
   const result = ZRecording.safeParse(data);
   if (result.success) return result.data;
-  console.warn('[agora-shared] Invalid Recording:', result.error.issues[0]);
+  console.warn('[live] Invalid Recording:', result.error.issues[0]);
   return null;
 }
 
@@ -273,7 +273,7 @@ export function validateRecordings(items: unknown[]): Recording[] {
 export function validateSeries(data: unknown): Series | null {
   const result = ZSeries.safeParse(data);
   if (result.success) return result.data;
-  console.warn('[agora-shared] Invalid Series:', result.error.issues[0]);
+  console.warn('[live] Invalid Series:', result.error.issues[0]);
   return null;
 }
 

--- a/packages/studio/app/live.tsx
+++ b/packages/studio/app/live.tsx
@@ -9,7 +9,7 @@ import {
   RoomCard,
   CreateRoomSheet,
   useLiveRoom,
-  createAgoraService,
+  createRoomsService,
   type Room,
   type CreateRoomSheetRef,
   type CreateRoomFormState,
@@ -31,10 +31,10 @@ function GoLive() {
   const theme = useTheme();
   const { joinLiveRoom } = useLiveRoom();
 
-  const agoraService = useMemo(() => createAgoraService(authenticatedClient), []);
+  const roomsService = useMemo(() => createRoomsService(authenticatedClient), []);
   const { data: liveRooms = [], isLoading, refetch } = useQuery({
     queryKey: liveRoomsQueryKey,
-    queryFn: () => agoraService.getRooms('live'),
+    queryFn: () => roomsService.getRooms('live'),
     staleTime: 30_000,
   });
 

--- a/packages/studio/components/providers/AppProviders.tsx
+++ b/packages/studio/components/providers/AppProviders.tsx
@@ -17,7 +17,7 @@ import { StatusBar } from 'expo-status-bar';
 import { OxyProvider } from '@oxyhq/services';
 import type { OxyServices } from '@oxyhq/core';
 import { ImageResolverProvider, type ImageResolver } from '@oxyhq/bloom/image-resolver';
-import { AgoraProvider, LiveRoomProvider } from '@syra.fm/live';
+import { LiveConfigProvider, LiveRoomProvider } from '@syra.fm/live';
 
 import { OXY_CLIENT_ID } from '@/config';
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -42,9 +42,9 @@ function LiveRoomsProvider({ children }: { children: ReactNode }) {
   }, [queryClient]);
   const config = useMemo(() => ({ ...liveConfig, onRoomChanged }), [onRoomChanged]);
   return (
-    <AgoraProvider config={config}>
+    <LiveConfigProvider config={config}>
       <LiveRoomProvider>{children}</LiveRoomProvider>
-    </AgoraProvider>
+    </LiveConfigProvider>
   );
 }
 

--- a/packages/studio/lib/liveConfig.ts
+++ b/packages/studio/lib/liveConfig.ts
@@ -2,7 +2,7 @@ import { useOxy } from '@oxyhq/services';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { useQuery } from '@tanstack/react-query';
-import type { AgoraConfig, AgoraTheme, UserEntity } from '@syra.fm/live';
+import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
 import { authenticatedClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
@@ -22,12 +22,12 @@ const liveUserQueryKey = (id: string) => ['live', 'user', id] as const;
 const LIVE_USER_STALE_TIME = 5 * 60 * 1000;
 
 /**
- * Bloom's `useTheme` returns a superset of the engine's `AgoraTheme`. Spreading
+ * Bloom's `useTheme` returns a superset of the engine's `LiveTheme`. Spreading
  * `colors` into a fresh object literal forwards every Bloom color key the
- * live-room UI reads and supplies the string index signature `AgoraTheme.colors`
+ * live-room UI reads and supplies the string index signature `LiveTheme.colors`
  * requires.
  */
-function useLiveTheme(): AgoraTheme {
+function useLiveTheme(): LiveTheme {
   const theme = useTheme();
   return { isDark: theme.isDark, colors: { ...theme.colors } };
 }
@@ -78,7 +78,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * React Query-backed user resolution, the canonical Oxy file-download resolver,
  * and sonner toasts. `onRoomChanged` is injected in `AppProviders`.
  */
-export const liveConfig: AgoraConfig = {
+export const liveConfig: LiveConfig = {
   httpClient: authenticatedClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
@@ -87,7 +87,7 @@ export const liveConfig: AgoraConfig = {
   ensureUserById: ensureLiveUserById,
   getCachedFileDownloadUrl: async (_oxy, fileId, variant) => oxyServices.getFileDownloadUrl(fileId, variant),
   getCachedFileDownloadUrlSync: (_oxy, fileId, variant) => oxyServices.getFileDownloadUrl(fileId, variant),
-  AvatarComponent: Avatar as AgoraConfig['AvatarComponent'],
+  AvatarComponent: Avatar as LiveConfig['AvatarComponent'],
   toast: liveToast,
   introSound: require('@syra.fm/live/src/assets/sounds/intro.mp3'),
 };


### PR DESCRIPTION
Pure identifier rename of the engine's public API (AgoraProvider→LiveConfigProvider, useAgoraConfig→useLiveConfig, createAgoraService→createRoomsService, Agora icons→LiveRoomsIcon, etc.) + Syra consumers. Bump 0.2.0. Engine builds, frontend+studio typecheck clean. 🤖 Generated with Claude Code