### PR TITLE
feat(rooms): presence preference + /rooms/live-users

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -172,7 +172,7 @@
     },
     "packages/live": {
       "name": "@syra.fm/live",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/react": "~19.2.14",
         "nativewind": "5.0.0-preview.3",

--- a/packages/backend/src/models/RoomUserPreference.ts
+++ b/packages/backend/src/models/RoomUserPreference.ts
@@ -1,0 +1,49 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * How a user's "live" presence badge should surface across apps.
+ *
+ *  - `active`   — show me live whenever I host a live room (default).
+ *  - `speaking` — show me live only while I'm actually an active speaker /
+ *                 broadcasting, not merely hosting a live room in silence.
+ */
+export type LiveVisibility = 'active' | 'speaking';
+
+export const LIVE_VISIBILITY_VALUES: readonly LiveVisibility[] = ['active', 'speaking'];
+
+/** Applied when a user has never set a preference. */
+export const DEFAULT_LIVE_VISIBILITY: LiveVisibility = 'active';
+
+/** Runtime guard for untrusted (request-body) input. */
+export function isLiveVisibility(value: unknown): value is LiveVisibility {
+  return value === 'active' || value === 'speaking';
+}
+
+export interface IRoomUserPreference extends Document {
+  /** Oxy user id — the owner of this preference row. One row per user. */
+  userId: string;
+  liveVisibility: LiveVisibility;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const RoomUserPreferenceSchema = new Schema<IRoomUserPreference>({
+  userId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+  liveVisibility: {
+    type: String,
+    enum: LIVE_VISIBILITY_VALUES,
+    default: DEFAULT_LIVE_VISIBILITY,
+  },
+}, { timestamps: true, versionKey: false });
+
+export const RoomUserPreference = mongoose.model<IRoomUserPreference>(
+  'RoomUserPreference',
+  RoomUserPreferenceSchema,
+);
+
+export default RoomUserPreference;

--- a/packages/backend/src/routes/rooms.presence.test.ts
+++ b/packages/backend/src/routes/rooms.presence.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { connect, clear, disconnect } from '../test/mongo';
+import RoomUserPreference, { LiveVisibility, DEFAULT_LIVE_VISIBILITY } from '../models/RoomUserPreference';
+import { selectLiveUsers } from './rooms.routes';
+
+beforeAll(connect);
+afterEach(clear);
+afterAll(disconnect);
+
+// ── selectLiveUsers — pure filtering ──────────────────────────────────────────
+
+describe('selectLiveUsers', () => {
+  it('includes host + speakers for the default (active) preference and never listeners', () => {
+    const rooms = [
+      { _id: 'r1', host: 'host1', speakers: ['host1', 'speaker1'] },
+    ];
+
+    const result = selectLiveUsers(rooms, new Map());
+
+    expect(result).toEqual([
+      { userId: 'host1', roomId: 'r1' },
+      { userId: 'speaker1', roomId: 'r1' },
+    ]);
+  });
+
+  it("with 'speaking' includes only active speakers (members of the speakers list)", () => {
+    // host2 is NOT in its room's speakers list — an inactive broadcaster.
+    const rooms = [
+      { _id: 'r2', host: 'host2', speakers: ['speakerX'] },
+    ];
+    const prefs = new Map<string, LiveVisibility>([
+      ['host2', 'speaking'],
+      ['speakerX', 'speaking'],
+    ]);
+
+    const result = selectLiveUsers(rooms, prefs);
+
+    // host2 (speaking, not an active speaker) is dropped; speakerX is kept.
+    expect(result).toEqual([{ userId: 'speakerX', roomId: 'r2' }]);
+  });
+
+  it("keeps a 'speaking' host when the host is a speaker (the common case)", () => {
+    const rooms = [
+      { _id: 'r3', host: 'host3', speakers: ['host3'] },
+    ];
+    const prefs = new Map<string, LiveVisibility>([['host3', 'speaking']]);
+
+    expect(selectLiveUsers(rooms, prefs)).toEqual([{ userId: 'host3', roomId: 'r3' }]);
+  });
+
+  it('yields one entry per (userId, roomId) across multiple live rooms', () => {
+    const rooms = [
+      { _id: 'r1', host: 'dj', speakers: ['dj'] },
+      { _id: 'r2', host: 'dj', speakers: ['dj'] },
+    ];
+
+    expect(selectLiveUsers(rooms, new Map())).toEqual([
+      { userId: 'dj', roomId: 'r1' },
+      { userId: 'dj', roomId: 'r2' },
+    ]);
+  });
+});
+
+// ── RoomUserPreference — upsert ────────────────────────────────────────────────
+
+describe('RoomUserPreference upsert', () => {
+  it("defaults liveVisibility to 'active' when unset", async () => {
+    const created = await RoomUserPreference.create({ userId: 'user-default' });
+    expect(created.liveVisibility).toBe(DEFAULT_LIVE_VISIBILITY);
+    expect(DEFAULT_LIVE_VISIBILITY).toBe('active');
+  });
+
+  it('upserts a single row keyed by userId (insert then update in place)', async () => {
+    const inserted = await RoomUserPreference.findOneAndUpdate(
+      { userId: 'user-1' },
+      { $set: { liveVisibility: 'speaking' } },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    ).lean();
+    expect(inserted?.liveVisibility).toBe('speaking');
+
+    const updated = await RoomUserPreference.findOneAndUpdate(
+      { userId: 'user-1' },
+      { $set: { liveVisibility: 'active' } },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    ).lean();
+    expect(updated?.liveVisibility).toBe('active');
+
+    // Still exactly one row for this user — the upsert updated in place.
+    expect(await RoomUserPreference.countDocuments({ userId: 'user-1' })).toBe(1);
+  });
+});

--- a/packages/backend/src/routes/rooms.routes.ts
+++ b/packages/backend/src/routes/rooms.routes.ts
@@ -1,8 +1,9 @@
 import { Router, Response } from 'express';
 import multer from 'multer';
 import Room, { IRoom, MediaQueueItem, RoomStatus, RoomType, OwnerType, BroadcastKind, SpeakerPermission } from '../models/Room';
+import RoomUserPreference, { LiveVisibility, DEFAULT_LIVE_VISIBILITY, isLiveVisibility } from '../models/RoomUserPreference';
 import House, { HouseMemberRole } from '../models/House';
-import type { OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
+import { requireOxyAuth, getRequiredOxyUserId, type OxyAuthRequest as AuthRequest } from '@oxyhq/core/server';
 import { isAdmin } from '../middleware/admin';
 import { logger } from '../utils/logger';
 import {
@@ -1062,6 +1063,158 @@ router.get('/top-hosts', async (req: AuthRequest, res: Response) => {
     logger.error('Error fetching top hosts:', { userId: req.user?.id, error });
     res.status(500).json({
       message: 'Error fetching top hosts',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Live presence
+// ---------------------------------------------------------------------------
+
+/** One live-badge entry: this user is broadcasting in this live room. */
+export type LiveUserEntry = { userId: string; roomId: string };
+
+/** The minimal live-room shape {@link selectLiveUsers} needs. */
+type LiveRoomBroadcasters = { _id: unknown; host: string; speakers?: readonly string[] };
+
+/**
+ * Pure core of `GET /rooms/live-users`: from the set of currently-live rooms and
+ * each candidate's visibility preference, produce the `(userId, roomId)`
+ * live-badge entries.
+ *
+ * The "broadcasting" users of a room are its `host` ∪ `speakers` — plain
+ * listeners (who live only in `participants`) are NEVER surfaced. Each broadcaster
+ * is then filtered by their preference:
+ *  - `active`   — surfaced whenever they broadcast in a live room (host or speaker).
+ *  - `speaking` — surfaced only while an active speaker. The cheap signal is
+ *    membership in the room's persisted `speakers` list; we intentionally do NOT
+ *    fan out a per-room Redis `HGETALL` of live/unmuted state across every live
+ *    room. The host is a speaker by construction, so a host who chose `speaking`
+ *    still surfaces while their room is live.
+ *
+ * Yields at most one entry per (userId, roomId); a user broadcasting in multiple
+ * live rooms yields one entry per room.
+ */
+export function selectLiveUsers(
+  rooms: ReadonlyArray<LiveRoomBroadcasters>,
+  visibilityByUserId: ReadonlyMap<string, LiveVisibility>,
+): LiveUserEntry[] {
+  const entries: LiveUserEntry[] = [];
+
+  for (const room of rooms) {
+    const roomId = String(room._id);
+    const speakers = Array.isArray(room.speakers) ? room.speakers : [];
+    const speakerSet = new Set<string>(speakers);
+    // host ∪ speakers, deduped — the room's broadcasters.
+    const broadcasters = new Set<string>([room.host, ...speakers]);
+
+    for (const userId of broadcasters) {
+      if (!userId) continue;
+      const visibility = visibilityByUserId.get(userId) ?? DEFAULT_LIVE_VISIBILITY;
+      if (visibility === 'speaking' && !speakerSet.has(userId)) {
+        continue;
+      }
+      entries.push({ userId, roomId });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * List the users currently broadcasting in a live room, so apps can render a
+ * "live" badge on their avatar. Public (optional auth); the result is not
+ * viewer-specific.
+ * GET /api/rooms/live-users
+ * → { liveUsers: { userId: string; roomId: string }[] }
+ */
+router.get('/live-users', async (_req: AuthRequest, res: Response) => {
+  try {
+    const rooms = await Room.find({ status: RoomStatus.LIVE })
+      .select('_id host speakers')
+      .lean();
+
+    // Collect every broadcaster (host + speakers) across all live rooms, then
+    // resolve their preferences in a SINGLE batched query (default → active).
+    const candidateIds = new Set<string>();
+    for (const room of rooms) {
+      if (room.host) candidateIds.add(room.host);
+      for (const speaker of room.speakers ?? []) {
+        if (speaker) candidateIds.add(speaker);
+      }
+    }
+
+    const preferences = candidateIds.size > 0
+      ? await RoomUserPreference.find({ userId: { $in: Array.from(candidateIds) } })
+          .select('userId liveVisibility')
+          .lean()
+      : [];
+
+    const visibilityByUserId = new Map<string, LiveVisibility>(
+      preferences.map((pref) => [pref.userId, pref.liveVisibility]),
+    );
+
+    res.json({ liveUsers: selectLiveUsers(rooms, visibilityByUserId) });
+  } catch (error) {
+    logger.error('Error fetching live users:', { error });
+    res.status(500).json({
+      message: 'Error fetching live users',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Get the current user's live-presence preference.
+ * GET /api/rooms/me/presence-preference
+ * → { liveVisibility: 'active' | 'speaking' } (default 'active' if never set)
+ */
+router.get('/me/presence-preference', requireOxyAuth, async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = getRequiredOxyUserId(req);
+    const preference = await RoomUserPreference.findOne({ userId })
+      .select('liveVisibility')
+      .lean();
+
+    res.json({ liveVisibility: preference?.liveVisibility ?? DEFAULT_LIVE_VISIBILITY });
+  } catch (error) {
+    logger.error('Error fetching presence preference:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error fetching presence preference',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Set the current user's live-presence preference (upsert).
+ * PUT /api/rooms/me/presence-preference
+ * Body: { liveVisibility: 'active' | 'speaking' }
+ * → { liveVisibility: 'active' | 'speaking' }
+ */
+router.put('/me/presence-preference', requireOxyAuth, async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = getRequiredOxyUserId(req);
+    const { liveVisibility } = (req.body ?? {}) as { liveVisibility?: unknown };
+
+    if (!isLiveVisibility(liveVisibility)) {
+      return res.status(400).json({ message: "liveVisibility must be 'active' or 'speaking'" });
+    }
+
+    const preference = await RoomUserPreference.findOneAndUpdate(
+      { userId },
+      { $set: { liveVisibility } },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    )
+      .select('liveVisibility')
+      .lean();
+
+    res.json({ liveVisibility: preference?.liveVisibility ?? liveVisibility });
+  } catch (error) {
+    logger.error('Error updating presence preference:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error updating presence preference',
       error: error instanceof Error ? error.message : 'Unknown error',
     });
   }


### PR DESCRIPTION
Backend for the live-avatar badge: per-user RoomUserPreference (active|speaking) + GET/PUT /rooms/me/presence-preference + public GET /rooms/live-users. Build exit 0, 461 tests. 🤖 Generated with Claude Code