### PR TITLE
fix(live): adapt linked client to the engine's { data } HttpClient (rooms + podcast search empty in Syra apps)

### DIFF
--- a/packages/frontend/lib/liveConfig.ts
+++ b/packages/frontend/lib/liveConfig.ts
@@ -3,7 +3,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useQuery } from '@tanstack/react-query';
 import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
-import { authenticatedClient } from '@/utils/api';
+import { liveHttpClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
 import { useIsDesktop } from '@/hooks/useOptimizedMediaQuery';
 import { oxyServices } from '@/lib/oxyServices';
@@ -76,7 +76,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * `QueryClient` is in scope.
  */
 export const liveConfig: LiveConfig = {
-  httpClient: authenticatedClient,
+  httpClient: liveHttpClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
   useIsDesktop,

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import axios from 'axios';
 import type { OxyServices } from '@oxyhq/core';
+import type { HttpClient } from '@syra.fm/live';
 import { API_URL } from '@/config';
 import { oxyServices } from '@/lib/oxyServices';
 
@@ -11,6 +12,28 @@ const API_CONFIG = {
 
 const syraApiClient = oxyServices.createLinkedClient({ baseURL: API_CONFIG.baseURL });
 const authenticatedClient: ReturnType<OxyServices['getClient']> = syraApiClient.client;
+
+// The @syra.fm/live engine's HttpClient contract resolves each request to a
+// `{ data }` envelope (its services read `res.data`) with request config passed
+// as the second arg (`{ params }`). The OxyServices linked client resolves the
+// parsed body directly, so adapt it once here and pass THIS as `httpClient` in
+// both frontend and studio liveConfig — passing the raw `authenticatedClient`
+// makes the engine read `res.data` off the body and silently get nothing
+// (empty rooms / "no podcasts found").
+export const liveHttpClient: HttpClient = {
+  async get<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.get>[1]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.get<T>(endpoint, config) };
+  },
+  async post<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.post>[2]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.post<T>(endpoint, body, config) };
+  },
+  async delete<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.delete>[1]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.delete<T>(endpoint, config) };
+  },
+  async patch<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.patch>[2]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.patch<T>(endpoint, body, config) };
+  },
+};
 
 export interface ApiRequestOptions {
   cache?: boolean;

--- a/packages/studio/lib/liveConfig.ts
+++ b/packages/studio/lib/liveConfig.ts
@@ -4,7 +4,7 @@ import { Avatar } from '@oxyhq/bloom/avatar';
 import { useQuery } from '@tanstack/react-query';
 import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
-import { authenticatedClient } from '@/utils/api';
+import { liveHttpClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
 import { useResponsive } from '@/hooks/useResponsive';
 import { oxyServices } from '@/lib/oxyServices';
@@ -79,7 +79,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * and sonner toasts. `onRoomChanged` is injected in `AppProviders`.
  */
 export const liveConfig: LiveConfig = {
-  httpClient: authenticatedClient,
+  httpClient: liveHttpClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
   useIsDesktop,

--- a/packages/studio/utils/api.ts
+++ b/packages/studio/utils/api.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import axios from 'axios';
 import type { OxyServices } from '@oxyhq/core';
+import type { HttpClient } from '@syra.fm/live';
 import { API_URL } from '@/config';
 import { oxyServices } from '@/lib/oxyServices';
 
@@ -14,6 +15,27 @@ const API_CONFIG = {
 // studio never hand-rolls Authorization headers, refresh, or CSRF plumbing.
 const syraApiClient = oxyServices.createLinkedClient({ baseURL: API_CONFIG.baseURL });
 const authenticatedClient: ReturnType<OxyServices['getClient']> = syraApiClient.client;
+
+// The @syra.fm/live engine's HttpClient contract resolves each request to a
+// `{ data }` envelope (its services read `res.data`), config passed as the
+// second arg. The linked client resolves the parsed body directly, so adapt it
+// once here and pass THIS as `httpClient` in liveConfig — passing the raw
+// `authenticatedClient` makes the engine read `res.data` off the body and get
+// nothing (empty rooms / "no podcasts found").
+export const liveHttpClient: HttpClient = {
+  async get<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.get>[1]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.get<T>(endpoint, config) };
+  },
+  async post<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.post>[2]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.post<T>(endpoint, body, config) };
+  },
+  async delete<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.delete>[1]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.delete<T>(endpoint, config) };
+  },
+  async patch<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.patch>[2]): Promise<{ data: T }> {
+    return { data: await authenticatedClient.patch<T>(endpoint, body, config) };
+  },
+};
 
 export interface ApiRequestOptions {
   cache?: boolean;


### PR DESCRIPTION
Syra frontend/studio passed the raw linked client as the engine httpClient; the engine expects a { data } envelope. getRooms + podcast search silently returned empty. Added liveHttpClient adapter, used in both liveConfigs. Typecheck clean. 🤖 Generated with Claude Code