### PR TITLE
refactor(live): engine uses the Oxy linked client directly (drop per-app HttpClient adapters)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -172,7 +172,7 @@
     },
     "packages/live": {
       "name": "@syra.fm/live",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@types/react": "~19.2.14",
         "nativewind": "5.0.0-preview.3",

--- a/packages/frontend/lib/liveConfig.ts
+++ b/packages/frontend/lib/liveConfig.ts
@@ -3,7 +3,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import { useQuery } from '@tanstack/react-query';
 import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
-import { liveHttpClient } from '@/utils/api';
+import { authenticatedClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
 import { useIsDesktop } from '@/hooks/useOptimizedMediaQuery';
 import { oxyServices } from '@/lib/oxyServices';
@@ -76,7 +76,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * `QueryClient` is in scope.
  */
 export const liveConfig: LiveConfig = {
-  httpClient: liveHttpClient,
+  httpClient: authenticatedClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
   useIsDesktop,

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -1,7 +1,6 @@
 import { Platform } from 'react-native';
 import axios from 'axios';
 import type { OxyServices } from '@oxyhq/core';
-import type { HttpClient } from '@syra.fm/live';
 import { API_URL } from '@/config';
 import { oxyServices } from '@/lib/oxyServices';
 
@@ -13,27 +12,6 @@ const API_CONFIG = {
 const syraApiClient = oxyServices.createLinkedClient({ baseURL: API_CONFIG.baseURL });
 const authenticatedClient: ReturnType<OxyServices['getClient']> = syraApiClient.client;
 
-// The @syra.fm/live engine's HttpClient contract resolves each request to a
-// `{ data }` envelope (its services read `res.data`) with request config passed
-// as the second arg (`{ params }`). The OxyServices linked client resolves the
-// parsed body directly, so adapt it once here and pass THIS as `httpClient` in
-// both frontend and studio liveConfig — passing the raw `authenticatedClient`
-// makes the engine read `res.data` off the body and silently get nothing
-// (empty rooms / "no podcasts found").
-export const liveHttpClient: HttpClient = {
-  async get<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.get>[1]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.get<T>(endpoint, config) };
-  },
-  async post<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.post>[2]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.post<T>(endpoint, body, config) };
-  },
-  async delete<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.delete>[1]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.delete<T>(endpoint, config) };
-  },
-  async patch<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.patch>[2]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.patch<T>(endpoint, body, config) };
-  },
-};
 
 export interface ApiRequestOptions {
   cache?: boolean;

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syra.fm/live",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Syra live rooms engine (DI-based; audio rooms over LiveKit)",
   "source": "src/index.ts",
   "main": "lib/commonjs/index.js",

--- a/packages/live/src/index.ts
+++ b/packages/live/src/index.ts
@@ -18,7 +18,6 @@ export type {
   StreamInfo,
   UserEntity,
   LiveTheme,
-  HttpResponse,
   HttpRequestConfig,
   HttpClient,
   FileDownloadService,

--- a/packages/live/src/services/livekitService.ts
+++ b/packages/live/src/services/livekitService.ts
@@ -5,7 +5,7 @@ export type GetRoomTokenFn = (roomId: string) => Promise<{ token: string; url: s
 export function createGetRoomToken(httpClient: Pick<HttpClient, 'post'>): GetRoomTokenFn {
   return async function getRoomToken(roomId: string): Promise<{ token: string; url: string }> {
     const res = await httpClient.post(`/rooms/${roomId}/token`);
-    const { token, url } = res.data;
+    const { token, url } = res;
     return { token: String(token), url: String(url) };
   };
 }

--- a/packages/live/src/services/spacesService.ts
+++ b/packages/live/src/services/spacesService.ts
@@ -187,7 +187,7 @@ export function createRoomsService(httpClient: HttpClient) {
         if (status) params.status = status;
         if (type) params.type = type;
         const res = await httpClient.get("/rooms", { params });
-        const raw = res.data.rooms || res.data.data || res.data || [];
+        const raw = res.rooms || res.data || res || [];
         return validateRooms(Array.isArray(raw) ? raw : []);
       } catch (error) {
         console.warn("Failed to fetch rooms", error);
@@ -199,7 +199,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!id) return null;
       try {
         const res = await httpClient.get(`/rooms/${id}`);
-        const raw = res.data.room || res.data.data || res.data || null;
+        const raw = res.room || res.data || res || null;
         return raw ? validateRoom(raw) : null;
       } catch (error) {
         console.warn("Failed to fetch room", error);
@@ -210,7 +210,7 @@ export function createRoomsService(httpClient: HttpClient) {
     async createRoom(data: CreateRoomData): Promise<Room | null> {
       try {
         const res = await httpClient.post("/rooms", data);
-        const raw = res.data.room || res.data.data || res.data || null;
+        const raw = res.room || res.data || res || null;
         return raw ? validateRoom(raw) : null;
       } catch (error) {
         console.warn("Failed to create room", error);
@@ -277,7 +277,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!id) return null;
       try {
         const res = await httpClient.post(`/rooms/${id}/stream`, data);
-        const parsed = ZStartStreamResponse.safeParse(res.data);
+        const parsed = ZStartStreamResponse.safeParse(res);
         if (!parsed.success) {
           console.warn('[live] Invalid startStream response:', parsed.error.issues[0]);
           return null;
@@ -293,7 +293,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!id) return null;
       try {
         const res = await httpClient.post(`/rooms/${id}/stream/rtmp`, data || {});
-        const parsed = ZGenerateStreamKeyResponse.safeParse(res.data);
+        const parsed = ZGenerateStreamKeyResponse.safeParse(res);
         if (!parsed.success) {
           console.warn('[live] Invalid generateStreamKey response:', parsed.error.issues[0]);
           return null;
@@ -334,7 +334,7 @@ export function createRoomsService(httpClient: HttpClient) {
         const res = await httpClient.get('/podcasts/search', {
           params: { q: query, offset: String(offset), limit: String(PODCAST_PAGE_SIZE) },
         });
-        return { ok: true, ...parsePodcastSearchResponse(res.data, offset) };
+        return { ok: true, ...parsePodcastSearchResponse(res, offset) };
       } catch (error) {
         console.warn("Failed to search podcasts", error);
         return { ok: false };
@@ -348,7 +348,7 @@ export function createRoomsService(httpClient: HttpClient) {
         const res = await httpClient.get(`/podcasts/${syraPodcastId}/episodes`, {
           params: { page: String(Math.floor(offset / PODCAST_PAGE_SIZE) + 1), limit: String(PODCAST_PAGE_SIZE) },
         });
-        return { ok: true, ...parseEpisodeListResponse(res.data, offset) };
+        return { ok: true, ...parseEpisodeListResponse(res, offset) };
       } catch (error) {
         console.warn("Failed to fetch podcast episodes", error);
         return { ok: false };
@@ -362,7 +362,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!roomId) return null;
       try {
         const res = await httpClient.post(`/rooms/${roomId}/stream/podcast`, body);
-        const parsed = ZStartStreamResponse.safeParse(res.data);
+        const parsed = ZStartStreamResponse.safeParse(res);
         if (!parsed.success) {
           console.warn('[live] Invalid startPodcastStream response:', parsed.error.issues[0]);
           return null;
@@ -384,8 +384,8 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!roomId) return null;
       try {
         const res = await httpClient.post(`/rooms/${roomId}/stream/podcast/next`);
-        if (res.data.ended === true) return { ended: true };
-        const parsed = ZStartStreamResponse.safeParse(res.data);
+        if (res.ended === true) return { ended: true };
+        const parsed = ZStartStreamResponse.safeParse(res);
         if (parsed.success) return { ended: false };
         console.warn('[live] Invalid skipPodcastNext response:', parsed.error.issues[0]);
         return null;
@@ -408,7 +408,7 @@ export function createRoomsService(httpClient: HttpClient) {
         const res = await httpClient.get('/tracks/search', {
           params: { q: query, offset: String(offset) },
         });
-        return { ok: true, ...parseMusicSearchResponse(res.data, offset) };
+        return { ok: true, ...parseMusicSearchResponse(res, offset) };
       } catch (error) {
         console.warn("Failed to search music", error);
         return { ok: false };
@@ -428,7 +428,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!roomId) return null;
       try {
         const res = await httpClient.post(`/rooms/${roomId}/stream/track`, body);
-        const parsed = ZStartStreamResponse.safeParse(res.data);
+        const parsed = ZStartStreamResponse.safeParse(res);
         if (!parsed.success) {
           console.warn('[live] Invalid startTrackStream response:', parsed.error.issues[0]);
           return null;
@@ -456,8 +456,8 @@ export function createRoomsService(httpClient: HttpClient) {
       try {
         const res = await httpClient.patch(`/rooms/${id}/archive`);
         return {
-          success: res.data.success !== undefined ? Boolean(res.data.success) : true,
-          archived: res.data.archived !== undefined ? Boolean(res.data.archived) : true,
+          success: res.success !== undefined ? Boolean(res.success) : true,
+          archived: res.archived !== undefined ? Boolean(res.archived) : true,
         };
       } catch (error) {
         console.warn("Failed to archive room", error);
@@ -470,7 +470,7 @@ export function createRoomsService(httpClient: HttpClient) {
         const params: Record<string, string> = {};
         if (search) params.search = search;
         const res = await httpClient.get("/houses", { params });
-        const raw = res.data.houses || res.data.data || res.data || [];
+        const raw = res.houses || res.data || res || [];
         const items = Array.isArray(raw) ? raw : [];
         return items
           .map((h: unknown) => validateHouse(h))
@@ -485,7 +485,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!id) return null;
       try {
         const res = await httpClient.get(`/houses/${id}`);
-        const raw = res.data.house || res.data.data || res.data || null;
+        const raw = res.house || res.data || res || null;
         return raw ? validateHouse(raw) : null;
       } catch (error) {
         console.warn("Failed to fetch house", error);
@@ -526,7 +526,7 @@ export function createRoomsService(httpClient: HttpClient) {
         const params: Record<string, string> = {};
         if (status) params.status = status;
         const res = await httpClient.get(`/houses/${houseId}/rooms`, { params });
-        const raw = res.data.rooms || res.data.data || res.data || [];
+        const raw = res.rooms || res.data || res || [];
         return validateRooms(Array.isArray(raw) ? raw : []);
       } catch (error) {
         console.warn("Failed to fetch house rooms", error);
@@ -562,7 +562,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!roomId) return [];
       try {
         const res = await httpClient.get(`/rooms/${roomId}/recordings`);
-        const raw = res.data.recordings || [];
+        const raw = res.recordings || [];
         return validateRecordings(Array.isArray(raw) ? raw : []);
       } catch (error) {
         console.warn("Failed to fetch recordings", error);
@@ -574,7 +574,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!recordingId) return null;
       try {
         const res = await httpClient.get(`/recordings/${recordingId}`);
-        return parseRecordingResponse(res.data);
+        return parseRecordingResponse(res);
       } catch (error) {
         console.warn("Failed to fetch recording", error);
         return null;
@@ -609,7 +609,7 @@ export function createRoomsService(httpClient: HttpClient) {
         if (sortBy) params.sortBy = sortBy;
         if (limit) params.limit = String(limit);
         const res = await httpClient.get("/recordings", { params });
-        const raw = res.data.recordings || res.data.data || res.data || [];
+        const raw = res.recordings || res.data || res || [];
         return validateRecordings(Array.isArray(raw) ? raw : []);
       } catch (error) {
         console.warn("Failed to fetch recordings", error);
@@ -620,7 +620,7 @@ export function createRoomsService(httpClient: HttpClient) {
     async getTopHosts(): Promise<{ userId: string; roomCount: number; totalListeners: number }[]> {
       try {
         const res = await httpClient.get("/rooms/top-hosts");
-        const raw = res.data.hosts || res.data.data || res.data || [];
+        const raw = res.hosts || res.data || res || [];
         return Array.isArray(raw) ? raw : [];
       } catch (error) {
         console.warn("Failed to fetch top hosts", error);
@@ -633,7 +633,7 @@ export function createRoomsService(httpClient: HttpClient) {
     async createHouse(data: { name: string; description?: string; tags?: string[]; isPublic?: boolean }): Promise<House | null> {
       try {
         const res = await httpClient.post("/houses", data);
-        const raw = res.data.house || res.data.data || res.data || null;
+        const raw = res.house || res.data || res || null;
         return raw ? validateHouse(raw) : null;
       } catch (error) {
         console.warn("Failed to create house", error);
@@ -647,7 +647,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!houseId) return null;
       try {
         const res = await httpClient.post(`/houses/${houseId}/avatar`, formData);
-        return (res.data.avatar as string) || null;
+        return (res.avatar as string) || null;
       } catch (error) {
         console.warn("Failed to upload house avatar", error);
         return null;
@@ -658,7 +658,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!houseId) return null;
       try {
         const res = await httpClient.post(`/houses/${houseId}/cover`, formData);
-        return (res.data.coverImage as string) || null;
+        return (res.coverImage as string) || null;
       } catch (error) {
         console.warn("Failed to upload house cover", error);
         return null;
@@ -669,7 +669,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!roomId) return null;
       try {
         const res = await httpClient.post(`/rooms/${roomId}/image`, formData);
-        return (res.data.streamImage as string) || null;
+        return (res.streamImage as string) || null;
       } catch (error) {
         console.warn("Failed to upload room image", error);
         return null;
@@ -680,7 +680,7 @@ export function createRoomsService(httpClient: HttpClient) {
       if (!seriesId) return null;
       try {
         const res = await httpClient.post(`/series/${seriesId}/cover`, formData);
-        return (res.data.coverImage as string) || null;
+        return (res.coverImage as string) || null;
       } catch (error) {
         console.warn("Failed to upload series cover", error);
         return null;

--- a/packages/live/src/types.ts
+++ b/packages/live/src/types.ts
@@ -95,20 +95,22 @@ export interface LiveTheme {
   };
 }
 
-export interface HttpResponse {
-  data: Record<string, unknown>;
-}
-
 export interface HttpRequestConfig {
   params?: Record<string, string | number | boolean | undefined>;
   [key: string]: unknown;
 }
 
+/**
+ * The HTTP client the engine consumes. Deliberately shaped to match an Oxy
+ * `oxyServices.createLinkedClient(...).client` as-is: every method resolves to
+ * the PARSED RESPONSE BODY directly (not a `{ data }` envelope). Consumers pass
+ * that Oxy client straight through — no per-app adapter.
+ */
 export interface HttpClient {
-  get: (url: string, config?: HttpRequestConfig) => Promise<HttpResponse>;
-  post: (url: string, data?: Record<string, unknown> | FormData, config?: HttpRequestConfig) => Promise<HttpResponse>;
-  patch: (url: string, data?: Record<string, unknown>, config?: HttpRequestConfig) => Promise<HttpResponse>;
-  delete: (url: string, config?: HttpRequestConfig) => Promise<HttpResponse>;
+  get: (url: string, config?: HttpRequestConfig) => Promise<Record<string, unknown>>;
+  post: (url: string, data?: Record<string, unknown> | FormData, config?: HttpRequestConfig) => Promise<Record<string, unknown>>;
+  patch: (url: string, data?: Record<string, unknown>, config?: HttpRequestConfig) => Promise<Record<string, unknown>>;
+  delete: (url: string, config?: HttpRequestConfig) => Promise<Record<string, unknown>>;
 }
 
 export interface FileDownloadService {

--- a/packages/studio/lib/liveConfig.ts
+++ b/packages/studio/lib/liveConfig.ts
@@ -4,7 +4,7 @@ import { Avatar } from '@oxyhq/bloom/avatar';
 import { useQuery } from '@tanstack/react-query';
 import type { LiveConfig, LiveTheme, UserEntity } from '@syra.fm/live';
 
-import { liveHttpClient } from '@/utils/api';
+import { authenticatedClient } from '@/utils/api';
 import { API_URL_SOCKET } from '@/config';
 import { useResponsive } from '@/hooks/useResponsive';
 import { oxyServices } from '@/lib/oxyServices';
@@ -79,7 +79,7 @@ const liveToast = Object.assign((message: string) => { toast(message); }, {
  * and sonner toasts. `onRoomChanged` is injected in `AppProviders`.
  */
 export const liveConfig: LiveConfig = {
-  httpClient: liveHttpClient,
+  httpClient: authenticatedClient,
   socketUrl: API_URL_SOCKET,
   useTheme: useLiveTheme,
   useIsDesktop,

--- a/packages/studio/utils/api.ts
+++ b/packages/studio/utils/api.ts
@@ -1,7 +1,6 @@
 import { Platform } from 'react-native';
 import axios from 'axios';
 import type { OxyServices } from '@oxyhq/core';
-import type { HttpClient } from '@syra.fm/live';
 import { API_URL } from '@/config';
 import { oxyServices } from '@/lib/oxyServices';
 
@@ -16,26 +15,6 @@ const API_CONFIG = {
 const syraApiClient = oxyServices.createLinkedClient({ baseURL: API_CONFIG.baseURL });
 const authenticatedClient: ReturnType<OxyServices['getClient']> = syraApiClient.client;
 
-// The @syra.fm/live engine's HttpClient contract resolves each request to a
-// `{ data }` envelope (its services read `res.data`), config passed as the
-// second arg. The linked client resolves the parsed body directly, so adapt it
-// once here and pass THIS as `httpClient` in liveConfig — passing the raw
-// `authenticatedClient` makes the engine read `res.data` off the body and get
-// nothing (empty rooms / "no podcasts found").
-export const liveHttpClient: HttpClient = {
-  async get<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.get>[1]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.get<T>(endpoint, config) };
-  },
-  async post<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.post>[2]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.post<T>(endpoint, body, config) };
-  },
-  async delete<T = unknown>(endpoint: string, config?: Parameters<typeof authenticatedClient.delete>[1]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.delete<T>(endpoint, config) };
-  },
-  async patch<T = unknown>(endpoint: string, body?: unknown, config?: Parameters<typeof authenticatedClient.patch>[2]): Promise<{ data: T }> {
-    return { data: await authenticatedClient.patch<T>(endpoint, body, config) };
-  },
-};
 
 export interface ApiRequestOptions {
   cache?: boolean;


### PR DESCRIPTION
The @syra.fm/live HttpClient now returns the parsed body (not a {data} envelope), matching oxyServices.createLinkedClient().client. Apps pass the raw client with no adapter — removes liveHttpClient in Syra frontend+studio. Bump 0.3.0. Both apps typecheck clean. 🤖 Generated with Claude Code