### PR TITLE
chore(sdk): bump @oxyhq/bloom to ^0.29.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.25.2",
+        "@oxyhq/bloom": "^0.29.1",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@tanstack/query-async-storage-persister": "^5.100.0",
@@ -278,7 +278,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.25.2",
+        "@oxyhq/bloom": "^0.29.1",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -995,7 +995,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.25.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-ODWukoGK3YAPYw0SjFTCFUX7uIKf2Gd/a3fiVAjwhqmtrA5APcozGUsli+Zp2VFlJfXsFjRKfMI/VilKEDyDPg=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.29.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-NRNx2G1EejclcWFxprO71S017kGgPmsSYK0elvWJHZqrdbGcZ7Zm4v13BaS/drog/u1JxlAwQO62ueqkz34VkQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.9.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-FYKFxecoxZnKOd+Esv2kkzGgS99N0NYGhYNlFUYnNkAaUnqz7rU0omCFwzuK5DpcaUeIq0MNVAxnCMrCaAU9WA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@oxyhq/services": "^15.0.0",
-    "@oxyhq/bloom": "^0.25.2",
+    "@oxyhq/bloom": "^0.29.1",
     "@oxyhq/core": "^6.0.0",
     "@tanstack/react-query": "^5.100.0",
     "@tanstack/react-query-persist-client": "^5.100.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.25.2",
+    "@oxyhq/bloom": "^0.29.1",
     "@oxyhq/core": "^6.0.0",
     "@oxyhq/services": "^15.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
## What

Bumps `@oxyhq/bloom` from `^0.25.2` → `^0.29.1` (current published `latest`).

Files changed:
- `package.json` (root `dependencies`, line 38)
- `packages/studio/package.json` (`dependencies`, line 32)
- `bun.lock` (regenerated in the same commit)

No other `@oxyhq/bloom` pin exists (no `resolutions` block; bloom is not in the root `overrides`). Only bloom was bumped — no other `@oxyhq/*` package touched.

## Peer / native deps

Bloom 0.29.1 adds one new peer, `expo-haptics: *` (vs 0.25.2). It is **already satisfied** by both consumers (`@syra/frontend` and `@syra/studio` each pin `expo-haptics: ~56.0.3`). No native/peer bumps were required or performed. Bloom's bundled `react-native-css@3.0.7` dep is unchanged from 0.25.2 and remains forced to `3.0.6` by the pre-existing root `overrides` — untouched here.

## Gate results (all green)

- `bun install --frozen-lockfile` — PASS, no lockfile drift
- `bun run build:shared-types` — PASS
- `bun run build:sdk` — PASS
- `bun run build:frontend` (expo web export) — PASS
- `bun run build:studio` (expo web export) — PASS
- `packages/frontend` jest — PASS (15 suites, 121 tests)
- `packages/backend` `bun test` — PASS (461 pass, 0 fail)

(`packages/studio` has no jest test files — pre-existing, unrelated to bloom, not a CI gate.)

## Note on stacking

This branch is stacked on `chore/wave2-sdk-bump` (the in-flight wave-2 SDK bump), which is **not yet merged to `main`**. Until wave-2 lands, the diff against `main` includes the wave-2 changes as well. The base can be retargeted onto `chore/wave2-sdk-bump` if the team prefers to review the bloom bump in isolation.

**DO NOT MERGE** until wave-2 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)