### PR TITLE
fix(preview): constrain public preview generation and dedupe in-flight work

### DIFF
--- a/packages/backend/src/controllers/preview.controller.ts
+++ b/packages/backend/src/controllers/preview.controller.ts
@@ -7,26 +7,17 @@ import { playableTrackFilter } from '../utils/catalogVisibility';
 import { ensurePreviewClip } from '../services/preview/previewService';
 import type { PreviewSourceRef } from '../services/preview/previewService';
 import { streamFromS3 } from '../services/s3Service';
-import { PREVIEW_CONTENT_TYPE, PREVIEW_DURATION_SEC } from '../services/ingest/previewClip';
+import { PREVIEW_CONTENT_TYPE } from '../services/ingest/previewClip';
 import { logger } from '../utils/logger';
 
-// Preview clips are immutable for a given (trackId, startSec) → cache hard.
+// Public preview clips are fixed to one curated excerpt per track. Keeping the
+// offset constant prevents unauthenticated callers from creating unbounded lazy
+// transcode/cache-miss work or enumerating most of a track through previews.
+const PUBLIC_PREVIEW_START_SEC = 0;
 const PREVIEW_CACHE_CONTROL = 'public, max-age=31536000, immutable';
 
 /**
- * Clamp a requested start offset into `[0, max]`. Non-numeric / negative inputs
- * default to 0. The result is an integer second offset.
- */
-function clampStart(value: unknown, max: number): number {
-  const parsed = typeof value === 'string' ? parseInt(value, 10) : Number.NaN;
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return 0;
-  }
-  return Math.min(Math.trunc(parsed), max);
-}
-
-/**
- * GET /api/preview/:trackId.mp3?start=N
+ * GET /api/preview/:trackId.mp3
  *
  * Public, unauthenticated 30s preview of a track. Serves audio to any visitor
  * (including guests). The clip is lazily generated from the retained source on
@@ -53,10 +44,6 @@ export const getTrackPreview = async (req: Request, res: Response, next: NextFun
       return res.status(404).json({ error: 'Preview not available' });
     }
 
-    const durationSec = Number.isFinite(track.duration) ? track.duration : 0;
-    const maxStart = Math.max(0, Math.floor(durationSec) - PREVIEW_DURATION_SEC);
-    const startSec = clampStart(req.query.start, maxStart);
-
     const trackRef: PreviewSourceRef = {
       id: track._id.toString(),
       artistId: track.artistId,
@@ -66,7 +53,7 @@ export const getTrackPreview = async (req: Request, res: Response, next: NextFun
       hls: track.hls,
     };
 
-    const previewKey = await ensurePreviewClip(trackRef, startSec);
+    const previewKey = await ensurePreviewClip(trackRef, PUBLIC_PREVIEW_START_SEC);
     if (!previewKey) {
       return res.status(404).json({ error: 'Preview not available' });
     }

--- a/packages/backend/src/services/preview/previewService.ts
+++ b/packages/backend/src/services/preview/previewService.ts
@@ -342,6 +342,8 @@ export async function storePreviewFromHls(
 
 // ── Lazy resolver used by the public endpoint ───────────────────────────────────
 
+const previewGenerationInFlight = new Map<string, Promise<string | null>>();
+
 /**
  * Ensure a preview clip exists for `(trackId, startSec)` and return its S3 key.
  *
@@ -354,6 +356,27 @@ export async function ensurePreviewClip(
   startSec: number,
 ): Promise<string | null> {
   const previewKey = getS3PreviewKey(track.id, startSec);
+  if (await objectExists(previewKey)) {
+    return previewKey;
+  }
+
+  const inFlight = previewGenerationInFlight.get(previewKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const generation = generatePreviewClipForTrack(track, startSec, previewKey).finally(() => {
+    previewGenerationInFlight.delete(previewKey);
+  });
+  previewGenerationInFlight.set(previewKey, generation);
+  return generation;
+}
+
+async function generatePreviewClipForTrack(
+  track: PreviewSourceRef,
+  startSec: number,
+  previewKey: string,
+): Promise<string | null> {
   if (await objectExists(previewKey)) {
     return previewKey;
   }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -29,8 +29,7 @@ if (page.hasMore) {
 const track = await syra.getTrack(page.items[0].id);
 
 // Build a public 30s preview URL (directly playable MP3)
-const url = syra.previewUrl(track.id);          // .../api/preview/<id>.mp3?start=0
-const hook = syra.previewUrl(track.id, 45);     // start 45s in
+const url = syra.previewUrl(track.id);          // .../api/preview/<id>.mp3
 
 // Resolve artwork to an absolute URL
 const cover = syra.artworkUrl(track, 'large');
@@ -54,7 +53,7 @@ authenticated transport can be layered in a future version.
 | --- | --- |
 | `searchTracks(query, { limit, offset })` | A `SearchPage<TrackSummary>` of preview-available tracks (`{ items, hasMore, limit, offset }`). |
 | `getTrack(id)` | A single `TrackSummary`, schema-validated. |
-| `previewUrl(id, startSec = 0)` | Public 30s preview URL. |
+| `previewUrl(id)` | Public 30s preview URL for the fixed excerpt. |
 | `artworkUrl(trackOrCoverArt, size?)` | Absolute artwork URL, or `undefined`. |
 | `searchPodcasts(query, { limit, offset })` | A `SearchPage<PodcastSummary>` of podcast shows. |
 | `getPodcast(id)` | A single `PodcastSummary`, schema-validated. |

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -205,20 +205,15 @@ describe('createSyraClient.getTrack', () => {
 // ── previewUrl ────────────────────────────────────────────────────────────────
 
 describe('createSyraClient.previewUrl', () => {
-  it('builds the preview URL with a default start of 0', () => {
+  it('builds the fixed preview URL without caller-controlled offsets', () => {
     const client = createSyraClient({ baseURL: 'https://api.example.test' });
-    expect(client.previewUrl('abc')).toBe('https://api.example.test/api/preview/abc.mp3?start=0');
-  });
-
-  it('uses the provided start offset and clamps to an integer >= 0', () => {
-    const client = createSyraClient({ baseURL: 'https://api.example.test' });
-    expect(client.previewUrl('abc', 42.9)).toBe('https://api.example.test/api/preview/abc.mp3?start=42');
-    expect(client.previewUrl('abc', -5)).toBe('https://api.example.test/api/preview/abc.mp3?start=0');
+    expect(client.previewUrl('abc')).toBe('https://api.example.test/api/preview/abc.mp3');
+    expect(client.previewUrl('abc', 42.9)).toBe('https://api.example.test/api/preview/abc.mp3');
   });
 
   it('defaults to the production base URL', () => {
     const client = createSyraClient();
-    expect(client.previewUrl('abc')).toBe(`${DEFAULT_SYRA_BASE_URL}/api/preview/abc.mp3?start=0`);
+    expect(client.previewUrl('abc')).toBe(`${DEFAULT_SYRA_BASE_URL}/api/preview/abc.mp3`);
   });
 });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -88,7 +88,7 @@ export interface SyraClient {
   searchTracks(query: string, options?: SearchTracksOptions): Promise<SearchPage<TrackSummary>>;
   /** Fetch a single track by id, validated against the track-summary schema. */
   getTrack(id: string): Promise<TrackSummary>;
-  /** Build the public 30s preview URL for a track at the given start offset. */
+  /** Build the public 30s preview URL for a track's fixed excerpt. */
   previewUrl(id: string, startSec?: number): string;
   /**
    * Resolve an absolute artwork URL from a track / cover-art reference. Returns
@@ -243,9 +243,9 @@ export function createSyraClient(options: SyraClientOptions = {}): SyraClient {
       return trackSummarySchema.parse(json);
     },
 
-    previewUrl(id, startSec = 0) {
-      const safeStart = Number.isFinite(startSec) ? Math.max(0, Math.trunc(startSec)) : 0;
-      return `${baseURL}/api/preview/${encodeURIComponent(id)}.mp3?start=${safeStart}`;
+    previewUrl(id, _startSec) {
+      void _startSec;
+      return `${baseURL}/api/preview/${encodeURIComponent(id)}.mp3`;
     },
 
     artworkUrl(source, size) {


### PR DESCRIPTION
### Motivation
- The public preview endpoint accepted caller-controlled offsets and lazily generated a separate immutable S3 object per offset, enabling unauthenticated attackers to force unbounded expensive transcoding/storage I/O. 
- Concurrent requests for the same uncached preview produced duplicate ffmpeg/S3 work due to lack of per-key in-flight deduplication. 
- The goal is to preserve the public 30s preview feature while eliminating the remote resource-exhaustion and enumeration vectors.

### Description
- Force the public preview endpoint to use a single curated excerpt start (fixed `start=0`) by removing caller-controlled offset handling in `packages/backend/src/controllers/preview.controller.ts` and always calling `ensurePreviewClip(..., PUBLIC_PREVIEW_START_SEC)`.
- Add a per-preview-key in-flight generation map and centralized generation function (`previewGenerationInFlight` + `generatePreviewClipForTrack`) in `packages/backend/src/services/preview/previewService.ts` so concurrent requests share one generation promise instead of duplicating work.
- Preserve existing HLS windowing and source-based generation logic while ensuring only the fixed excerpt is generated on the public path.
- Update the SDK helper in `packages/sdk/src/client.ts`, associated tests in `packages/sdk/src/client.test.ts`, and README to emit fixed preview URLs (the optional start argument is tolerated for compatibility but is ignored by the public client).

### Testing
- Ran `git diff --check` to validate diffs and whitespace; check passed. 
- Attempted unit tests for the SDK (`bun test packages/sdk/src/client.test.ts`) but execution was blocked due to missing runtime dependencies (registry fetch failures prevented installing `zod`), so SDK tests could not complete. 
- Attempted backend preview service tests (`bun test packages/backend/src/services/preview/previewService.test.ts`) but execution was blocked due to missing AWS SDK dependencies (`@aws-sdk/client-s3`) for the same dependency-install issue, so backend tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ca21d9f88323b60fcdb586637bf1)