### PR TITLE
Protect podcast search import from unauthenticated resource exhaustion

### DIFF
--- a/packages/backend/src/controllers/podcasts.controller.ts
+++ b/packages/backend/src/controllers/podcasts.controller.ts
@@ -24,6 +24,7 @@ import { PodcastModel } from '../models/Podcast';
 import { EpisodeModel } from '../models/Episode';
 import { UserLibraryModel } from '../models/Library';
 import { ArtistModel } from '../models/CatalogEntity';
+import { getRequestUserId } from '../utils/catalogVisibility';
 import { getParam } from '../utils/reqParams';
 import { logger } from '../utils/logger';
 import { searchPodcasts as directorySearch } from '../services/podcasts/PodcastDirectory';
@@ -134,8 +135,9 @@ function episodeVisibilityFilter(
 /**
  * GET /api/podcasts/search?q=&limit=&offset= — instant directory-backed search.
  *
- * `syncPodcastSearch` shallow-upserts the directory candidates first (bounded +
- * throttled, never hangs) so they appear in THIS response like the old discover
+ * For authenticated users, `syncPodcastSearch` shallow-upserts the directory
+ * candidates first (bounded + throttled, never hangs) so they appear in THIS
+ * response like the old discover
  * screen; the heavy feed import runs in the background. Uses a case-insensitive
  * regex (NOT `$text`) to avoid depending on a text index that is not built in
  * production (`autoIndex` is off) — that was the 502/504 cause. Wrapped so the
@@ -155,8 +157,12 @@ export async function searchPodcasts(req: AuthRequest, res: Response): Promise<v
   const offset = parseOffset(req.query.offset);
 
   try {
-    // Instant enrichment (shallow upsert) before we read — bounded + throttled.
-    await syncPodcastSearch(q);
+    // Authenticated-only enrichment before we read — bounded + throttled.
+    // Public searches only read the existing catalog so unauthenticated traffic
+    // cannot enqueue directory/feed/image-processing work.
+    if (getRequestUserId(req)) {
+      await syncPodcastSearch(q);
+    }
 
     const regex = new RegExp(escapeRegex(q), 'i');
     // Over-fetch one row past the page so `hasMore` is known without a separate

--- a/packages/backend/src/controllers/search.controller.ts
+++ b/packages/backend/src/controllers/search.controller.ts
@@ -230,14 +230,18 @@ export const search = async (req: Request, res: Response, next: NextFunction) =>
           ]);
     }
 
-    // Podcast enrichment. For an explicit podcasts search we AWAIT the shallow
+    // Authenticated-only podcast enrichment. For an explicit podcasts search
+    // we AWAIT the shallow
     // upsert of directory candidates so they appear in THIS response (instant,
     // like the old discover); the heavy feed import runs in the background. For
     // 'all' we enrich in the background so the aggregate search stays fast.
+    // Public searches only read the existing catalog so unauthenticated traffic
+    // cannot enqueue unbounded directory/feed/image-processing work.
     // `syncPodcastSearch` is bounded + throttled and never hangs/throws.
     let podcastSyncTriggered = false;
     if (
       process.env.PODCAST_BULK_IMPORT_ENABLED !== 'false' &&
+      getRequestUserId(req as AuthRequest) &&
       query.trim().length >= AUDIUS_IMPORT_MIN_QUERY_LENGTH &&
       searchOffset === 0
     ) {

--- a/packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts
+++ b/packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts
@@ -118,6 +118,21 @@ describe('syncPodcastSearch — shallow upsert + deep scheduling', () => {
     expect(await PodcastModel.countDocuments({})).toBe(1); // not upserted twice
   });
 
+  it('does not count deep imports that are dropped by backpressure', async () => {
+    await PodcastModel.insertMany([
+      { title: 'One', source: 'rss', feedUrl: 'https://feeds.example/1.xml', needsDeepImport: true },
+      { title: 'Two', source: 'rss', feedUrl: 'https://feeds.example/2.xml', needsDeepImport: true },
+    ]);
+
+    const result = await syncPodcastSearch('backpressure', {
+      search: async () => [candidate(1), candidate(2)],
+      enqueue: (feedUrl) => feedUrl.endsWith('/1.xml'),
+      now: () => NOW,
+    });
+
+    expect(result.deepEnqueued).toBe(1);
+  });
+
   it('is a no-op for a blank query', async () => {
     const result = await syncPodcastSearch('   ', { search: async () => [candidate(1)], enqueue: () => {} });
     expect(result).toEqual({ skipped: true, candidates: 0, shallowUpserted: 0, deepEnqueued: 0 });

--- a/packages/backend/src/services/podcasts/podcastBackgroundImport.ts
+++ b/packages/backend/src/services/podcasts/podcastBackgroundImport.ts
@@ -33,6 +33,9 @@ export const MAX_FEEDS_PER_SEARCH = 25;
 /** Hard timeout on the in-request directory call so a search can never hang. */
 const DIRECTORY_TIMEOUT_MS = 3000;
 
+/** Global backpressure for expensive deep imports queued from search. */
+export const MAX_DEEP_IMPORT_QUEUE_SIZE = 100;
+
 /** Re-pull a show's full feed at most this often from search (24h). */
 const DEEP_REFRESH_STALE_MS = 24 * 60 * 60 * 1000;
 
@@ -121,10 +124,18 @@ export async function shallowUpsertCandidates(candidates: PodcastDirectoryCandid
  * Enqueue a SINGLE feed's deep import onto the serialized background queue.
  * Deduped by in-flight feedUrl. Fire-and-forget; never throws.
  */
-export function enqueuePodcastImport(feedUrl: string, directory?: PodcastDirectoryCandidate): void {
+export function enqueuePodcastImport(feedUrl: string, directory?: PodcastDirectoryCandidate): boolean {
   const key = feedUrl.trim().toLowerCase();
-  if (!key) return;
-  if (queuedFeeds.has(key)) return;
+  if (!key) return false;
+  if (queuedFeeds.has(key)) return false;
+  if (queuedFeeds.size >= MAX_DEEP_IMPORT_QUEUE_SIZE) {
+    logger.warn('[podcast-import] deep import queue full; dropping feed import', {
+      feedUrl,
+      queueSize: queuedFeeds.size,
+      maxQueueSize: MAX_DEEP_IMPORT_QUEUE_SIZE,
+    });
+    return false;
+  }
   queuedFeeds.add(key);
 
   importQueue = importQueue
@@ -140,6 +151,8 @@ export function enqueuePodcastImport(feedUrl: string, directory?: PodcastDirecto
         queuedFeeds.delete(key);
       }
     });
+
+  return true;
 }
 
 /**
@@ -150,7 +163,7 @@ export function enqueuePodcastImport(feedUrl: string, directory?: PodcastDirecto
  */
 async function enqueueDeepImports(
   candidates: PodcastDirectoryCandidate[],
-  enqueue: (feedUrl: string, directory?: PodcastDirectoryCandidate) => void,
+  enqueue: (feedUrl: string, directory?: PodcastDirectoryCandidate) => boolean | void,
   now: number,
 ): Promise<number> {
   const feedUrls = candidates.map((c) => c.feedUrl);
@@ -171,8 +184,9 @@ async function enqueueDeepImports(
   let enqueued = 0;
   for (const target of targets) {
     if (!target.feedUrl) continue;
-    enqueue(target.feedUrl, byFeedUrl.get(target.feedUrl));
-    enqueued += 1;
+    if (enqueue(target.feedUrl, byFeedUrl.get(target.feedUrl)) !== false) {
+      enqueued += 1;
+    }
   }
   return enqueued;
 }
@@ -181,7 +195,7 @@ async function enqueueDeepImports(
 
 export interface PodcastSearchSyncDeps {
   search?: (query: string, limit?: number) => Promise<PodcastDirectoryCandidate[]>;
-  enqueue?: (feedUrl: string, directory?: PodcastDirectoryCandidate) => void;
+  enqueue?: (feedUrl: string, directory?: PodcastDirectoryCandidate) => boolean | void;
   now?: () => number;
 }
 


### PR DESCRIPTION
### Motivation
- Public search endpoints could enqueue expensive podcast deep-import work for arbitrary unauthenticated queries, allowing unauthenticated attackers to queue unbounded network/CPU/DB/S3 tasks.
- The background import queue only throttled identical queries and had no global bound or per-request authentication check, amplifying cost due to image re-hosting and Sharp processing.

### Description
- Require an authenticated request before triggering podcast directory synchronization from `GET /api/search` and `GET /api/podcasts/search` by gating `syncPodcastSearch` with `getRequestUserId(req)` so public reads only read the existing catalog and cannot enqueue work. (`packages/backend/src/controllers/search.controller.ts`, `packages/backend/src/controllers/podcasts.controller.ts`)
- Add a global in-memory backpressure cap `MAX_DEEP_IMPORT_QUEUE_SIZE` and make `enqueuePodcastImport` return a boolean to indicate whether a feed import was accepted, dropping new feed imports when the queue is saturated. (`packages/backend/src/services/podcasts/podcastBackgroundImport.ts`)
- Change deep-import scheduling to count only jobs actually accepted by the enqueue layer so `deepEnqueued` reflects accepted work under backpressure. (`packages/backend/src/services/podcasts/podcastBackgroundImport.ts`)
- Update unit tests to cover the backpressure behavior and dropped imports in the deep-import path. (`packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts`)

### Testing
- Ran static checks with `git diff --check` which passed without errors. 
- Attempted unit tests with `bun test packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts`, but execution was blocked due to missing runtime dependencies (`mongoose`) in the environment so tests did not complete. 
- Attempted `bun install --frozen-lockfile` but was blocked by registry access failures (HTTP 403), so full test-suite execution and integration verification could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40cc3419e88323a23883eeb44fdd6e)