### PR TITLE
Block unverified RSS podcast claims

### DIFF
--- a/packages/backend/src/controllers/podcasts.claim.test.ts
+++ b/packages/backend/src/controllers/podcasts.claim.test.ts
@@ -34,10 +34,10 @@ function makeReq(podcastId: string, userId: string, linkedArtistId?: string): Au
   } as unknown as AuthRequest;
 }
 
-async function makeClaimablePodcast(): Promise<string> {
+async function makeClaimablePodcast(source: 'rss' | 'syra' = 'syra'): Promise<string> {
   const podcast = await PodcastModel.create({
     title: 'Claimable Show',
-    source: 'rss',
+    source,
     feedUrl: `https://feed.example/${Math.random().toString(36).slice(2)}.xml`,
     claimable: true,
   });
@@ -76,7 +76,7 @@ describe('claimPodcast — linkedArtistId IDOR guard', () => {
     expect(after?.linkedArtistId?.toString()).toBe(ownArtist._id.toString());
   });
 
-  it('also accepts a claim with no artist link (200)', async () => {
+  it('also accepts a claim with no artist link for Syra-hosted shows (200)', async () => {
     const podcastId = await makeClaimablePodcast();
 
     const res = makeRes();
@@ -87,4 +87,19 @@ describe('claimPodcast — linkedArtistId IDOR guard', () => {
     expect(after?.claimedByOxyUserId).toBe('owner-A');
     expect(after?.linkedArtistId).toBeUndefined();
   });
+
+  it('rejects RSS podcast claims until ownership verification exists (403)', async () => {
+    const podcastId = await makeClaimablePodcast('rss');
+
+    const res = makeRes();
+    await claimPodcast(makeReq(podcastId, 'attacker-A'), res as unknown as Response);
+
+    expect(res._status).toBe(403);
+    expect(res._body).toEqual({ error: 'RSS podcast claims require ownership verification' });
+    const after = await PodcastModel.findById(podcastId).lean();
+    expect(after?.claimedByOxyUserId).toBeUndefined();
+    expect(after?.ownerOxyUserId).toBeUndefined();
+    expect(after?.claimable).toBe(true);
+  });
+
 });

--- a/packages/backend/src/controllers/podcasts.controller.ts
+++ b/packages/backend/src/controllers/podcasts.controller.ts
@@ -595,8 +595,9 @@ export async function uploadEpisode(req: AuthRequest, res: Response): Promise<vo
 }
 
 /**
- * POST /api/podcasts/:id/claim — claim a claimable show; optionally link an
- * artist the caller owns. Auth + field whitelist.
+ * POST /api/podcasts/:id/claim — claim a non-RSS claimable show; optionally
+ * link an artist the caller owns. Auth + field whitelist. Imported RSS shows
+ * require an ownership-verification flow before they can be claimed.
  */
 export async function claimPodcast(req: AuthRequest, res: Response): Promise<void> {
   const userId = getRequiredOxyUserId(req);
@@ -613,6 +614,10 @@ export async function claimPodcast(req: AuthRequest, res: Response): Promise<voi
   }
   if (podcast.claimable !== true || podcast.claimedByOxyUserId) {
     res.status(409).json({ error: 'Podcast is not claimable' });
+    return;
+  }
+  if (podcast.source === 'rss') {
+    res.status(403).json({ error: 'RSS podcast claims require ownership verification' });
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent low-privileged authenticated users from permanently claiming imported RSS shows that they do not control by requiring ownership verification before assigning ownership fields.

### Description
- Add an early guard in `claimPodcast` to reject claims for `podcast.source === 'rss'` with a `403` and an explanatory error: `RSS podcast claims require ownership verification`.
- Narrow the controller contract comment to document that RSS imports require a future ownership-verification flow before they may be claimed via `POST /api/podcasts/:id/claim`.
- Update `packages/backend/src/controllers/podcasts.claim.test.ts` to parameterize fixture source (`'syra' | 'rss'`) and add a regression test that asserts an RSS-imported, `claimable: true` show is rejected and left unmodified.

### Testing
- Ran `git diff --check` to lint for accidental whitespace or conflict markers and it passed.
- Executed `bun test packages/backend/src/controllers/podcasts.claim.test.ts` but the test run failed to start because the test environment is missing dependencies: `Cannot find package 'mongoose'` (test framework invocation surfaced dependency issues).
- Attempted `bun install` to fetch dependencies but it failed due to the npm registry returning HTTP 403 for package tarballs, preventing a full local test run.
- The updated test suite includes a new case that asserts RSS claims return `403` and do not mutate `claimedByOxyUserId`, `ownerOxyUserId`, or `claimable` (intended to prevent regressions once dependencies are available to run tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ccab0f508323b6d3dee3640d35f1)