### PR TITLE
fix(search): restrict Audius background imports

### DIFF
--- a/packages/backend/src/controllers/search.controller.ts
+++ b/packages/backend/src/controllers/search.controller.ts
@@ -435,6 +435,7 @@ export const search = async (req: Request, res: Response, next: NextFunction) =>
     const querySpecificEnough = query.trim().length >= AUDIUS_IMPORT_MIN_QUERY_LENGTH;
     const canImportAudius =
       process.env.AUDIUS_BACKGROUND_IMPORT_ENABLED !== 'false' &&
+      Boolean((req as AuthRequest).user?.id) &&
       isTrackSearch &&
       sparseLocalResults &&
       querySpecificEnough &&

--- a/packages/backend/src/services/sources/audiusBackgroundImport.ts
+++ b/packages/backend/src/services/sources/audiusBackgroundImport.ts
@@ -25,6 +25,12 @@ const MAX_ALBUMS_PER_ARTIST = 3;
 /** Cap on the number of playlists synced per artist per pass. */
 const MAX_PLAYLISTS_PER_ARTIST = 3;
 
+/** Cap on attacker-controlled query keys retained for import throttling. */
+const MAX_IMPORT_THROTTLE_KEYS = 500;
+
+/** Cap on distinct queued imports awaiting the serialized background worker. */
+const MAX_QUEUED_IMPORTS = 25;
+
 // ── Throttle map ──────────────────────────────────────────────────────────────
 
 /**
@@ -34,6 +40,16 @@ const MAX_PLAYLISTS_PER_ARTIST = 3;
 const lastImportAt = new Map<string, number>();
 const queuedImports = new Set<string>();
 let importQueue: Promise<void> = Promise.resolve();
+
+function rememberImportAttempt(key: string, currentTime: number): void {
+  lastImportAt.set(key, currentTime);
+
+  while (lastImportAt.size > MAX_IMPORT_THROTTLE_KEYS) {
+    const oldestKey = lastImportAt.keys().next().value;
+    if (oldestKey === undefined) break;
+    lastImportAt.delete(oldestKey);
+  }
+}
 
 function normalizeQuery(query: string): string {
   return query.trim().toLowerCase();
@@ -134,7 +150,7 @@ export async function runAudiusImport(
   if (lastRun !== undefined && currentTime - lastRun < AUDIUS_IMPORT_TTL_MS) {
     return { imported: 0, skipped: true, albumsSynced: 0, playlistsSynced: 0 };
   }
-  lastImportAt.set(key, currentTime);
+  rememberImportAttempt(key, currentTime);
 
   const tracks = await connector.search(query, AUDIUS_IMPORT_LIMIT);
 
@@ -341,6 +357,10 @@ export function enqueueAudiusImport(query: string, deps?: AudiusImportDeps): voi
   const normalizedQuery = normalizeQuery(query);
   if (!normalizedQuery) return;
   if (queuedImports.has(normalizedQuery)) return;
+  if (queuedImports.size >= MAX_QUEUED_IMPORTS) {
+    logger.warn('[audius-import] queue full; skipping import', { query: normalizedQuery });
+    return;
+  }
   queuedImports.add(normalizedQuery);
 
   importQueue = importQueue


### PR DESCRIPTION
### Motivation

- The public `/api/search` path could enqueue fire-and-forget Audius imports for unauthenticated callers, allowing attackers to trigger persistent catalog writes and unbounded memory growth in the import throttle map.  
- The existing throttle keyed only by normalized query had no eviction and the enqueue path had no queue/backpressure, exposing the service to catalog pollution and amplification of writes.

### Description

- Added an authentication gate to the search controller so background Audius imports are only enqueued when an authenticated Oxy user is present by checking `Boolean((req as AuthRequest).user?.id)` before calling `enqueueAudiusImport` in `packages/backend/src/controllers/search.controller.ts`.  
- Introduced `MAX_IMPORT_THROTTLE_KEYS` with bounded retention and `rememberImportAttempt(key, now)` to evict oldest keys when `lastImportAt` grows beyond the cap in `packages/backend/src/services/sources/audiusBackgroundImport.ts`.  
- Added `MAX_QUEUED_IMPORTS` and a queue-size check in `enqueueAudiusImport` to limit distinct pending imports and emit a warning when the queue is full.  
- Preserved existing TTL-based dedupe and per-track isolation behavior; the changes add practical backpressure and authentication without changing the upsert logic.

### Testing

- Ran `git diff --check` to validate the workspace diff and found no whitespace errors.  
- Attempted unit tests with `bun test packages/backend/src/services/sources/audiusBackgroundImport.test.ts`, which could not run in this environment due to missing runtime dependencies (test failed with `Cannot find package 'mongoose'`), so full test-suite verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40dbda49648323ad0bded352715894)