### PR TITLE
fix: restrict copyright admin actions

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -94,3 +94,6 @@ FIREBASE_SERVICE_ACCOUNT_BASE64=
 # LINK_PREVIEW_JPEG_QUALITY=
 # LINK_PREVIEW_PNG_QUALITY=
 # LINK_PREVIEW_WEBP_QUALITY=
+
+# Comma-separated Oxy user IDs allowed to review and resolve copyright reports.
+COPYRIGHT_ADMIN_OXY_USER_IDS=

--- a/packages/backend/src/controllers/audio.controller.helpers.ts
+++ b/packages/backend/src/controllers/audio.controller.helpers.ts
@@ -63,8 +63,8 @@ export async function fetchAndValidateTrack(trackId: string): Promise<TrackValid
 
   const track = await formatTrackWithCoverArt(trackDoc);
 
-  // Check if track is available
-  if (!track.isAvailable) {
+  // Check if track is available and has not been removed for copyright
+  if (!track.isAvailable || track.copyrightRemoved) {
     return {
       isValid: false,
       statusCode: 403,

--- a/packages/backend/src/middleware/copyrightAdmin.test.ts
+++ b/packages/backend/src/middleware/copyrightAdmin.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { isCopyrightAdmin, requireCopyrightAdmin } from './copyrightAdmin';
+import type { OxyAuthRequest } from '@oxyhq/core/server';
+import type { Response, NextFunction } from 'express';
+
+afterEach(() => {
+  delete process.env.COPYRIGHT_ADMIN_OXY_USER_IDS;
+});
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+describe('copyright admin authorization', () => {
+  it('allows only configured Oxy user IDs', () => {
+    process.env.COPYRIGHT_ADMIN_OXY_USER_IDS = 'admin-one, admin-two';
+
+    expect(isCopyrightAdmin('admin-one')).toBe(true);
+    expect(isCopyrightAdmin('admin-two')).toBe(true);
+    expect(isCopyrightAdmin('ordinary-user')).toBe(false);
+    expect(isCopyrightAdmin(undefined)).toBe(false);
+  });
+
+  it('rejects non-admin users before admin copyright handlers run', () => {
+    process.env.COPYRIGHT_ADMIN_OXY_USER_IDS = 'admin-one';
+    const req = { user: { id: 'ordinary-user' } } as unknown as OxyAuthRequest;
+    const res = makeRes();
+    let nextCalled = false;
+    const next: NextFunction = () => {
+      nextCalled = true;
+    };
+
+    requireCopyrightAdmin(req, res as unknown as Response, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'Admin privileges required' });
+    expect(nextCalled).toBe(false);
+  });
+
+  it('passes configured admins to the next handler', () => {
+    process.env.COPYRIGHT_ADMIN_OXY_USER_IDS = 'admin-one';
+    const req = { user: { id: 'admin-one' } } as unknown as OxyAuthRequest;
+    const res = makeRes();
+    let nextCalled = false;
+    const next: NextFunction = () => {
+      nextCalled = true;
+    };
+
+    requireCopyrightAdmin(req, res as unknown as Response, next);
+
+    expect(res.statusCode).toBe(200);
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/packages/backend/src/middleware/copyrightAdmin.ts
+++ b/packages/backend/src/middleware/copyrightAdmin.ts
@@ -1,0 +1,25 @@
+import { Response, NextFunction } from 'express';
+import type { OxyAuthRequest } from '@oxyhq/core/server';
+
+const ADMIN_ENV = 'COPYRIGHT_ADMIN_OXY_USER_IDS';
+
+function getConfiguredAdminIds(): Set<string> {
+  return new Set(
+    (process.env[ADMIN_ENV] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+}
+
+export function isCopyrightAdmin(userId: string | undefined): boolean {
+  return Boolean(userId && getConfiguredAdminIds().has(userId));
+}
+
+export function requireCopyrightAdmin(req: OxyAuthRequest, res: Response, next: NextFunction) {
+  if (!isCopyrightAdmin(req.user?.id)) {
+    return res.status(403).json({ error: 'Admin privileges required' });
+  }
+
+  return next();
+}

--- a/packages/backend/src/routes/copyright.routes.ts
+++ b/packages/backend/src/routes/copyright.routes.ts
@@ -6,6 +6,7 @@ import {
   rejectCopyrightReport,
 } from '../controllers/copyright.controller';
 import { requireOxyAuth as requireAuth } from '@oxyhq/core/server';
+import { requireCopyrightAdmin } from '../middleware/copyrightAdmin';
 
 const router = Router();
 
@@ -13,10 +14,10 @@ const router = Router();
 // This route is mounted in the public API router, so it works for unauthenticated users
 router.post('/report', reportCopyrightViolation);
 
-// Admin routes - require authentication
-router.get('/reports', requireAuth, getCopyrightReports);
-router.post('/reports/:id/approve', requireAuth, approveCopyrightReport);
-router.post('/reports/:id/reject', requireAuth, rejectCopyrightReport);
+// Admin routes - require authentication and explicit copyright admin allowlist membership
+router.get('/reports', requireAuth, requireCopyrightAdmin, getCopyrightReports);
+router.post('/reports/:id/approve', requireAuth, requireCopyrightAdmin, approveCopyrightReport);
+router.post('/reports/:id/reject', requireAuth, requireCopyrightAdmin, rejectCopyrightReport);
 
 export default router;
 

--- a/packages/backend/src/services/strikeService.test.ts
+++ b/packages/backend/src/services/strikeService.test.ts
@@ -103,6 +103,7 @@ describe('addStrike — termination', () => {
     // Track taken down
     const track = await TrackModel.findById(trackId).lean();
     expect(track?.copyrightRemoved).toBe(true);
+    expect(track?.isAvailable).toBe(false);
     expect(track?.removedAt).toBeInstanceOf(Date);
     expect(track?.removedReason).toContain('Repeat-infringer');
   });
@@ -130,7 +131,9 @@ describe('addStrike — termination', () => {
       TrackModel.findById(track2).lean(),
     ]);
     expect(t1?.copyrightRemoved).toBe(true);
+    expect(t1?.isAvailable).toBe(false);
     expect(t2?.copyrightRemoved).toBe(true);
+    expect(t2?.isAvailable).toBe(false);
   });
 
   it('returns null for unknown artistId', async () => {

--- a/packages/backend/src/services/strikeService.ts
+++ b/packages/backend/src/services/strikeService.ts
@@ -20,12 +20,13 @@ export function isRepeatInfringer(strikeCount: number): boolean {
 
 // ── Internals ─────────────────────────────────────────────────────────────────
 
-/** Take down every track owned by the artist — mark copyrightRemoved. */
+/** Take down every track owned by the artist and make it unavailable for playback. */
 async function takeDownArtistTracks(artistId: string, reason: string): Promise<void> {
   await TrackModel.updateMany(
     { artistId, copyrightRemoved: { $ne: true } },
     {
       copyrightRemoved: true,
+      isAvailable: false,
       removedAt: new Date(),
       removedReason: reason,
     },
@@ -48,7 +49,7 @@ function applyTermination(artist: IArtist): void {
  *
  * When the artist's cumulative strike count reaches STRIKE_TERMINATION_THRESHOLD
  * the account is permanently terminated and all their tracks are taken down
- * (copyrightRemoved = true). Termination is irreversible via removeStrike.
+ * (copyrightRemoved = true, isAvailable = false). Termination is irreversible via removeStrike.
  */
 export async function addStrike(
   artistId: string,


### PR DESCRIPTION
### Motivation
- Close a high-severity authorization gap that allowed any authenticated user to approve copyright reports and thereby trigger irreversible artist termination and bulk takedown.
- Prevent a secondary playback bypass where bulk-taken-down tracks were still streamable because `isAvailable` was not set to false.

### Description
- Add `requireCopyrightAdmin` middleware backed by a comma-separated allowlist `COPYRIGHT_ADMIN_OXY_USER_IDS` to enforce explicit admin membership for copyright review endpoints (`packages/backend/src/middleware/copyrightAdmin.ts`).
- Require the new admin middleware on copyright report list/approve/reject routes while leaving the public `/report` endpoint unchanged (`packages/backend/src/routes/copyright.routes.ts`).
- Make the repeat-infringer bulk takedown mark tracks unavailable for playback by setting `isAvailable = false` in addition to `copyrightRemoved` (`packages/backend/src/services/strikeService.ts`).
- Add a defense-in-depth check in audio validation to reject tracks flagged `copyrightRemoved` so older data cannot be streamed (`packages/backend/src/controllers/audio.controller.helpers.ts`).
- Add unit tests for the admin allowlist and update strike-service tests to assert tracks are unavailable after takedown (`packages/backend/src/middleware/copyrightAdmin.test.ts`, `packages/backend/src/services/strikeService.test.ts`).
- Document the new environment variable in the backend example (`packages/backend/.env.example`).

### Testing
- Ran `bun test packages/backend/src/middleware/copyrightAdmin.test.ts` and all tests in that file passed. 
- Ran `bun test packages/backend/src/middleware/copyrightAdmin.test.ts packages/backend/src/services/strikeService.test.ts --timeout 10000` where the middleware tests passed but the strike-service suite could not run due to a missing local `mongoose` package (test runner error), preventing the full suite from executing locally. 
- Attempted backend build (`@syra/backend`) but it was blocked by an unrelated TypeScript deprecation warning regarding existing `baseUrl` compiler settings in the repo; build not completed locally.
- Updated/added tests and code changes were committed and are included in this PR for CI to exercise the full suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40dcadb0588323863a134e951f92db)