### PR TITLE
ci: restrict manual AWS deploys to main

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -40,6 +40,7 @@ jobs:
       - run: cd packages/frontend && bunx jest --ci
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-24.04-arm
     steps:


### PR DESCRIPTION
### Motivation
- Prevent manually-dispatched production deploys from building and deploying arbitrary refs by ensuring the `deploy` job only runs when the selected ref is `refs/heads/main`.

### Description
- Add a job-level ref guard to `.github/workflows/deploy-aws.yml` by inserting `if: github.ref == 'refs/heads/main'` on the `deploy` job so `workflow_dispatch` can no longer cause a deploy from non-main refs while preserving the existing `push`-to-main path and test job.

### Testing
- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-aws.yml"); puts "yaml ok"'` which succeeded. 
- Ran a Python assertion that confirmed `workflow_dispatch:` remains present and that `if: github.ref == 'refs/heads/main'` and the production `role-to-assume` are present in the file, which succeeded. 
- Ran `git diff --check` to ensure no whitespace issues were introduced, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e25ddf988323a24c146d1fbb5c80)