### PR TITLE
chore: Bloom design-tokens theme.css in frontend and studio

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.25.2",
+        "@oxyhq/bloom": "^0.29.1",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@tanstack/query-async-storage-persister": "^5.100.0",
@@ -278,7 +278,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.25.2",
+        "@oxyhq/bloom": "^0.29.1",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -995,7 +995,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.25.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-ODWukoGK3YAPYw0SjFTCFUX7uIKf2Gd/a3fiVAjwhqmtrA5APcozGUsli+Zp2VFlJfXsFjRKfMI/VilKEDyDPg=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.29.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-NRNx2G1EejclcWFxprO71S017kGgPmsSYK0elvWJHZqrdbGcZ7Zm4v13BaS/drog/u1JxlAwQO62ueqkz34VkQ=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.9.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-FYKFxecoxZnKOd+Esv2kkzGgS99N0NYGhYNlFUYnNkAaUnqz7rU0omCFwzuK5DpcaUeIq0MNVAxnCMrCaAU9WA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.29.1",
+        "@oxyhq/bloom": "^0.29.3",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@tanstack/query-async-storage-persister": "^5.100.0",
@@ -79,6 +79,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
+        "@oxyhq/bloom": "^0.29.3",
         "@oxyhq/expo-splash": "^0.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
@@ -278,7 +279,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.29.1",
+        "@oxyhq/bloom": "^0.29.3",
         "@oxyhq/core": "^6.0.0",
         "@oxyhq/services": "^15.0.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -995,7 +996,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.29.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-NRNx2G1EejclcWFxprO71S017kGgPmsSYK0elvWJHZqrdbGcZ7Zm4v13BaS/drog/u1JxlAwQO62ueqkz34VkQ=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.29.3", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-QN9ugEFk/apvCZSiGdY+vasZLWBOOOZ19DTxRF5zpL9abBmkl5Z61D516LPuhSfD45FMCjioopd/EtB8KrZizA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.9.1", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-FYKFxecoxZnKOd+Esv2kkzGgS99N0NYGhYNlFUYnNkAaUnqz7rU0omCFwzuK5DpcaUeIq0MNVAxnCMrCaAU9WA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@oxyhq/services": "^15.0.0",
-    "@oxyhq/bloom": "^0.25.2",
+    "@oxyhq/bloom": "^0.29.1",
     "@oxyhq/core": "^6.0.0",
     "@tanstack/react-query": "^5.100.0",
     "@tanstack/react-query-persist-client": "^5.100.0",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@oxyhq/services": "^15.0.0",
-    "@oxyhq/bloom": "^0.29.1",
+    "@oxyhq/bloom": "^0.29.3",
     "@oxyhq/core": "^6.0.0",
+    "@oxyhq/services": "^15.0.0",
+    "@tanstack/query-async-storage-persister": "^5.100.0",
     "@tanstack/react-query": "^5.100.0",
-    "@tanstack/react-query-persist-client": "^5.100.0",
-    "@tanstack/query-async-storage-persister": "^5.100.0"
+    "@tanstack/react-query-persist-client": "^5.100.0"
   },
   "overrides": {
     "@oxyhq/core": "^6.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,6 +35,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
+    "@oxyhq/bloom": "^0.29.3",
     "@oxyhq/expo-splash": "^0.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",

--- a/packages/frontend/styles/global.css
+++ b/packages/frontend/styles/global.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/preflight.css" layer(base);
 @import "tailwindcss/utilities.css";
 @import "nativewind/theme";
+@import "@oxyhq/bloom/design-tokens/theme.css";
 
 @source "../app/**/*.{js,jsx,ts,tsx}";
 @source "../components/**/*.{js,jsx,ts,tsx}";

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.29.1",
+    "@oxyhq/bloom": "^0.29.3",
     "@oxyhq/core": "^6.0.0",
     "@oxyhq/services": "^15.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.25.2",
+    "@oxyhq/bloom": "^0.29.1",
     "@oxyhq/core": "^6.0.0",
     "@oxyhq/services": "^15.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/studio/styles/global.css
+++ b/packages/studio/styles/global.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/preflight.css" layer(base);
 @import "tailwindcss/utilities.css";
 @import "nativewind/theme";
+@import "@oxyhq/bloom/design-tokens/theme.css";
 
 @source "../app/**/*.{js,jsx,ts,tsx}";
 @source "../components/**/*.{js,jsx,ts,tsx}";


### PR DESCRIPTION
## Summary
- Import `@oxyhq/bloom/design-tokens/theme.css` in frontend and studio global styles.
- Bump `@oxyhq/bloom` and refresh lockfile (unrelated `packages/creators/` omitted).

## Test plan
- [ ] `bun run build` for affected packages
- [ ] Smoke web styles on frontend and studio

Made with [Cursor](https://cursor.com)