### PR TITLE
feat(frontend): artwork-based dynamic ambient theming

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.39.0",
+        "@oxyhq/bloom": "^0.40.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@tanstack/query-async-storage-persister": "^5.101.2",
@@ -78,7 +78,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.39.0",
+        "@oxyhq/bloom": "^0.40.0",
         "@oxyhq/expo-splash": "^0.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
@@ -278,7 +278,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.39.0",
+        "@oxyhq/bloom": "^0.40.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -980,7 +980,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.39.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-72wpbgbULj+KxU4v3MkZf6Za2NCjvaH0rSgIi6lqKm0AViT5xUaZAc975GA7BDvwlvoJ4yqDJ4sc60oBluR+Sg=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.40.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-4MCbnTszTzSzvMqSIUrNVU/Xi04XP20P2KygaqX+ofVg7p+mPRdUA0N9KL2IJZ0auxgL4yvEdmHH2iQrgAMUVw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.16.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-PCUL1xdb+7ynUVASNRC3WP46HwaBIUCOGD+EjXbFc+nUaTnS//+oCxT1DUf/TKVn6sp4ulnXCsjnKBmYJTSPHQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.34.2",
+        "@oxyhq/bloom": "^0.39.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@tanstack/query-async-storage-persister": "^5.101.2",
@@ -78,7 +78,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.34.2",
+        "@oxyhq/bloom": "^0.39.0",
         "@oxyhq/expo-splash": "^0.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
@@ -278,7 +278,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.34.2",
+        "@oxyhq/bloom": "^0.39.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -980,7 +980,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-oiEK04JD5aaJ6pz35Hfui2gnuQU8T2Fc9gTyBQkC7dV8TOESxotNJDpOW9t6AcLoBqpqFuedXwIpofk+/LWuWw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.39.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-72wpbgbULj+KxU4v3MkZf6Za2NCjvaH0rSgIi6lqKm0AViT5xUaZAc975GA7BDvwlvoJ4yqDJ4sc60oBluR+Sg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.16.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-PCUL1xdb+7ynUVASNRC3WP46HwaBIUCOGD+EjXbFc+nUaTnS//+oCxT1DUf/TKVn6sp4ulnXCsjnKBmYJTSPHQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "syra",
       "dependencies": {
-        "@oxyhq/bloom": "^0.40.0",
+        "@oxyhq/bloom": "^0.41.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@tanstack/query-async-storage-persister": "^5.101.2",
@@ -78,7 +78,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.40.0",
+        "@oxyhq/bloom": "^0.41.0",
         "@oxyhq/expo-splash": "^0.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
@@ -278,7 +278,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "^0.40.0",
+        "@oxyhq/bloom": "^0.41.0",
         "@oxyhq/core": "^12.4.1",
         "@oxyhq/services": "^22.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -980,7 +980,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.40.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-4MCbnTszTzSzvMqSIUrNVU/Xi04XP20P2KygaqX+ofVg7p+mPRdUA0N9KL2IJZ0auxgL4yvEdmHH2iQrgAMUVw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.41.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-jyufBluqZxF/6sDTrljs6gJ6PWD8G6uCCoLo3WglJjV++lJVmzyD2tuQsQ0pndYDG7Vr8cm5p4LJeN59iCPf2Q=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.16.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-PCUL1xdb+7ynUVASNRC3WP46HwaBIUCOGD+EjXbFc+nUaTnS//+oCxT1DUf/TKVn6sp4ulnXCsjnKBmYJTSPHQ=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@oxyhq/bloom": "^0.39.0",
+    "@oxyhq/bloom": "^0.40.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@tanstack/query-async-storage-persister": "^5.101.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@oxyhq/bloom": "^0.34.2",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@tanstack/query-async-storage-persister": "^5.101.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@oxyhq/bloom": "^0.40.0",
+    "@oxyhq/bloom": "^0.41.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@tanstack/query-async-storage-persister": "^5.101.2",

--- a/packages/frontend/app/album/[id].tsx
+++ b/packages/frontend/app/album/[id].tsx
@@ -17,6 +17,8 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { pickCatalogImageUrl } from '@/utils/pickImage';
 import { toast } from '@/lib/sonner';
 import { useOxy } from '@oxyhq/services';
+import { AmbientArtworkTheme } from '@/components/AmbientArtworkTheme';
+import { useArtworkSeed } from '@/hooks/useArtworkSeed';
 
 /**
  * Album Screen
@@ -36,6 +38,7 @@ const AlbumScreen: React.FC = () => {
   const toggleLike = useToggleLikeTrack();
   const isSaved = id ? isAlbumSaved(id) : false;
   const [isDownloaded, setIsDownloaded] = useState(false);
+  const { seed, activate: activateSeed, deactivate: deactivateSeed } = useArtworkSeed();
 
   const handleToggleSave = () => {
     if (!id) {
@@ -115,9 +118,93 @@ const AlbumScreen: React.FC = () => {
     );
   }
 
+  const albumCoverImage = pickCatalogImageUrl(undefined, album.coverArt, 'detailArtwork', album.coverArtSizes);
+
+  // Hover the cover → extract its dominant colour → re-theme the album's ambient
+  // surfaces. `AlbumView` reads the scoped theme via `useTheme()` inside the
+  // ambient region, so the whole hero + tracklist eases into the artwork palette;
+  // leaving the cover restores the app preset. Native is a no-op (web-only).
+  return (
+    <AmbientArtworkTheme seed={seed}>
+      <AlbumView
+        album={album}
+        tracks={tracks}
+        albumCoverImage={albumCoverImage}
+        onCoverHoverIn={() => id && activateSeed(id, albumCoverImage)}
+        onCoverHoverOut={deactivateSeed}
+        currentTrack={currentTrack}
+        isPlaying={isPlaying}
+        isSaved={isSaved}
+        isDownloaded={isDownloaded}
+        setIsDownloaded={setIsDownloaded}
+        canPlay={canPlay}
+        shuffle={shuffle}
+        toggleShuffle={toggleShuffle}
+        isTrackLiked={isTrackLiked}
+        onPlayAlbum={handlePlayAlbum}
+        onToggleSave={handleToggleSave}
+        onToggleTrackLike={handleToggleTrackLike}
+        onTrackPress={handleTrackPress}
+        onGoToArtist={() => router.push(`/p/${album.artistId}`)}
+        formatReleaseDate={formatReleaseDate}
+      />
+    </AmbientArtworkTheme>
+  );
+};
+
+interface AlbumViewProps {
+  album: NonNullable<Awaited<ReturnType<typeof musicService.getAlbumById>>>;
+  tracks: Track[];
+  albumCoverImage: string | undefined;
+  onCoverHoverIn: () => void;
+  onCoverHoverOut: () => void;
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  isSaved: boolean;
+  isDownloaded: boolean;
+  setIsDownloaded: (next: boolean) => void;
+  canPlay: boolean;
+  shuffle: 'on' | 'off';
+  toggleShuffle: () => void;
+  isTrackLiked: (id: string) => boolean;
+  onPlayAlbum: () => void;
+  onToggleSave: () => void;
+  onToggleTrackLike: (track: Track, liked: boolean) => void;
+  onTrackPress: (track: Track) => void;
+  onGoToArtist: () => void;
+  formatReleaseDate: (dateString: string) => string;
+}
+
+/**
+ * The album's ambient region. Reads `useTheme()` INSIDE `<AmbientArtworkTheme>`
+ * so its surfaces re-theme to the artwork seed while hovering the cover, then
+ * revert to the app preset on hover-out.
+ */
+const AlbumView: React.FC<AlbumViewProps> = ({
+  album,
+  tracks,
+  albumCoverImage,
+  onCoverHoverIn,
+  onCoverHoverOut,
+  currentTrack,
+  isPlaying,
+  isSaved,
+  isDownloaded,
+  setIsDownloaded,
+  canPlay,
+  shuffle,
+  toggleShuffle,
+  isTrackLiked,
+  onPlayAlbum,
+  onToggleSave,
+  onToggleTrackLike,
+  onTrackPress,
+  onGoToArtist,
+  formatReleaseDate,
+}) => {
+  const theme = useTheme();
   const releaseDateFormatted = formatReleaseDate(album.releaseDate);
   const totalDurationFormatted = formatTotalDuration(album.totalDuration);
-  const albumCoverImage = pickCatalogImageUrl(undefined, album.coverArt, 'detailArtwork', album.coverArtSizes);
   const albumThumbImage = pickCatalogImageUrl(undefined, album.coverArt, 'icon', album.coverArtSizes);
   const gradientColors: readonly [string, string, string] = [
     album.primaryColor ?? theme.colors.backgroundSecondary,
@@ -139,8 +226,16 @@ const AlbumScreen: React.FC = () => {
         <LinearGradient colors={gradientColors} locations={[0, 0.45, 1]} style={styles.heroSection}>
           {/* Header Section */}
           <View style={styles.header}>
-            {/* Album Cover */}
-            <View style={styles.coverContainer}>
+            {/* Album Cover — hover (web) / focus to tint the ambient region */}
+            <Pressable
+              style={styles.coverContainer}
+              onHoverIn={onCoverHoverIn}
+              onHoverOut={onCoverHoverOut}
+              onFocus={onCoverHoverIn}
+              onBlur={onCoverHoverOut}
+              accessibilityRole="image"
+              accessibilityLabel={`${album.title} cover art`}
+            >
               {albumCoverImage ? (
                 <Image
                   source={{ uri: albumCoverImage }}
@@ -152,7 +247,7 @@ const AlbumScreen: React.FC = () => {
                   <Ionicons name="musical-notes" size={64} color={theme.colors.textSecondary} />
                 </View>
               )}
-            </View>
+            </Pressable>
 
             {/* Album Info */}
             <View style={styles.infoContainer}>
@@ -163,7 +258,7 @@ const AlbumScreen: React.FC = () => {
               {/* Artist Info */}
               <Pressable
                 style={styles.artistRow}
-                onPress={() => router.push(`/p/${album.artistId}`)}
+                onPress={onGoToArtist}
               >
                 <Avatar
                   source={albumThumbImage}
@@ -190,7 +285,7 @@ const AlbumScreen: React.FC = () => {
                 { backgroundColor: theme.colors.primary },
                 !canPlay && styles.disabledControl,
               ]}
-              onPress={handlePlayAlbum}
+              onPress={onPlayAlbum}
               disabled={!canPlay}
               accessibilityRole="button"
               accessibilityState={{ disabled: !canPlay }}
@@ -214,7 +309,7 @@ const AlbumScreen: React.FC = () => {
 
             <Pressable
               style={styles.controlButton}
-              onPress={handleToggleSave}
+              onPress={onToggleSave}
               accessibilityRole="button"
               accessibilityState={{ selected: isSaved }}
               accessibilityLabel={isSaved ? 'Remove from your library' : 'Save to your library'}
@@ -280,7 +375,7 @@ const AlbumScreen: React.FC = () => {
                   styles.trackRow,
                   isCurrentTrack && { backgroundColor: theme.colors.backgroundSecondary + '40' },
                 ]}
-                onPress={() => handleTrackPress(track)}
+                onPress={() => onTrackPress(track)}
               >
                 <View style={styles.trackRowLeft}>
                   <View style={styles.trackNumberContainer}>
@@ -329,7 +424,7 @@ const AlbumScreen: React.FC = () => {
                   <Pressable
                     onPress={(e) => {
                       e?.stopPropagation?.();
-                      handleToggleTrackLike(track, isLiked);
+                      onToggleTrackLike(track, isLiked);
                     }}
                     style={styles.trackLikeButton}
                     accessibilityRole="button"

--- a/packages/frontend/components/AmbientArtworkTheme.tsx
+++ b/packages/frontend/components/AmbientArtworkTheme.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { BloomSeedScope } from '@oxyhq/bloom/theme';
+
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import { webViewStyle } from '../utils/webStyles';
+
+interface AmbientArtworkThemeProps {
+  /**
+   * Extracted artwork seed (`#rrggbb`). When `null`/`undefined` the region keeps
+   * the app preset (BloomSeedScope is a no-op), so passing `null` on
+   * mouse-leave/blur restores the default theme.
+   */
+  seed: string | null | undefined;
+  /**
+   * Transition duration for the ambient re-theme, in ms. Snaps instantly when
+   * the user prefers reduced motion. Defaults to 480ms.
+   */
+  durationMs?: number;
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+/**
+ * Scopes a region to an artwork-derived seed palette and eases the ambient
+ * surfaces into the new colours.
+ *
+ * The scope publishes the engine's role colours as `--background` / `--card` /
+ * `--primary` … CSS vars over this subtree, so any `bg-background` / `bg-card`
+ * surface inside re-themes to match the artwork. The wrapper carries a
+ * `background-color` + `color` CSS transition (web) so the swap cross-fades
+ * rather than flashing; reduced-motion callers snap. Native is a no-op wrapper
+ * (seed extraction is web-only today), so the app preset is untouched there.
+ *
+ * Intentionally tints ambient surfaces only — the accent (`--primary`) shifts
+ * with the palette but nothing here hard-flashes it across the whole app.
+ */
+export function AmbientArtworkTheme({
+  seed,
+  durationMs = 480,
+  style,
+  children,
+}: AmbientArtworkThemeProps) {
+  const reducedMotion = usePrefersReducedMotion();
+
+  const transitionStyle = useMemo<ViewStyle>(() => {
+    if (reducedMotion) return {};
+    return webViewStyle({
+      transitionProperty: 'background-color, color, border-color',
+      transitionDuration: `${durationMs}ms`,
+      transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+    });
+  }, [reducedMotion, durationMs]);
+
+  return (
+    <BloomSeedScope seed={seed ?? undefined}>
+      <View style={[{ flex: 1 }, transitionStyle, style]}>{children}</View>
+    </BloomSeedScope>
+  );
+}

--- a/packages/frontend/hooks/useArtworkSeed.ts
+++ b/packages/frontend/hooks/useArtworkSeed.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { extractArtworkSeed } from '../utils/artworkSeed';
+
+/**
+ * Process-wide cache of extracted seeds, keyed by a stable artwork id. Extraction
+ * is deterministic for a given image, so a seed is computed at most once per
+ * artwork and reused across every card/hero that shows it.
+ *
+ * IMPORTANT (React Compiler): this module-level mutable Map is ONLY ever touched
+ * inside event handlers / effects — never read from a render or memoized
+ * position. The rendered value lives in `useState` (`seed`) below, so the
+ * compiler never freezes a stale read of this external store.
+ */
+const seedCache = new Map<string, string | null>();
+
+const DEFAULT_DEBOUNCE_MS = 120;
+
+interface UseArtworkSeedOptions {
+  /** Debounce before extraction kicks off, in ms. Defaults to 120. */
+  debounceMs?: number;
+}
+
+interface UseArtworkSeedResult {
+  /** The extracted seed (`#rrggbb`), or `null` when none is active/available. */
+  seed: string | null;
+  /**
+   * Begin (debounced) extraction for the given artwork. Call on hover-in/focus.
+   * If the id is cached, the seed applies immediately with no recompute.
+   */
+  activate: (artworkId: string | undefined, imageUrl: string | undefined) => void;
+  /** Clear the active seed (restore the app preset). Call on hover-out/blur. */
+  deactivate: () => void;
+}
+
+/**
+ * Manage the seed colour extracted from a piece of artwork for dynamic ambient
+ * theming. Debounces hover so a quick pass over a card never triggers work,
+ * caches per artwork id, and cancels cleanly on unmount.
+ */
+export function useArtworkSeed(options?: UseArtworkSeedOptions): UseArtworkSeedResult {
+  const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const [seed, setSeed] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Monotonic token so a slow extraction that resolves after a newer
+  // activate/deactivate is ignored (last-intent-wins).
+  const requestRef = useRef(0);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const activate = useCallback(
+    (artworkId: string | undefined, imageUrl: string | undefined) => {
+      clearTimer();
+      const requestId = ++requestRef.current;
+
+      if (!artworkId || !imageUrl) return;
+
+      const cached = seedCache.get(artworkId);
+      if (cached !== undefined) {
+        // `null` cached means "extraction known to be impossible" — keep preset.
+        setSeed(cached);
+        return;
+      }
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        void extractArtworkSeed(imageUrl).then((extracted) => {
+          seedCache.set(artworkId, extracted);
+          // Ignore if a newer activate/deactivate has since superseded this one.
+          if (requestRef.current === requestId) setSeed(extracted);
+        });
+      }, debounceMs);
+    },
+    [clearTimer, debounceMs],
+  );
+
+  const deactivate = useCallback(() => {
+    clearTimer();
+    requestRef.current++;
+    setSeed(null);
+  }, [clearTimer]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  return { seed, activate, deactivate };
+}

--- a/packages/frontend/hooks/usePrefersReducedMotion.ts
+++ b/packages/frontend/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+
+/**
+ * Whether the user has requested reduced motion.
+ *
+ * Web reads the `prefers-reduced-motion` media query live (updates if the OS
+ * setting changes). Native defaults to `false` here — the artwork-theming
+ * cross-fade this gates is a web-only affordance, and native RN motion honours
+ * reduced-motion through its own `AccessibilityInfo` paths elsewhere.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined' || !window.matchMedia) {
+      return undefined;
+    }
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+
+  return reduced;
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,7 +35,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.40.0",
+    "@oxyhq/bloom": "^0.41.0",
     "@oxyhq/expo-splash": "^0.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,7 +35,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.34.2",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/expo-splash": "^0.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,7 +35,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.39.0",
+    "@oxyhq/bloom": "^0.40.0",
     "@oxyhq/expo-splash": "^0.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",

--- a/packages/frontend/utils/artworkSeed.ts
+++ b/packages/frontend/utils/artworkSeed.ts
@@ -1,0 +1,17 @@
+/**
+ * Native fallback for artwork seed extraction.
+ *
+ * Reading raw pixels off a rendered image requires a platform-specific bridge
+ * (e.g. a native colour-extraction module). Dynamic artwork theming is a web
+ * (hover/focus) affordance today, so native returns `null` — the ambient region
+ * simply keeps the app preset. The `.web.ts` sibling implements the real
+ * canvas-based extraction.
+ */
+export async function extractArtworkSeed(_imageUrl: string): Promise<string | null> {
+  return null;
+}
+
+/** Web canvas support probe — always false on native. */
+export function canExtractArtworkSeed(): boolean {
+  return false;
+}

--- a/packages/frontend/utils/artworkSeed.web.ts
+++ b/packages/frontend/utils/artworkSeed.web.ts
@@ -1,0 +1,74 @@
+import { argbFromRgb, seedHexFromImagePixels } from '@oxyhq/bloom/theme';
+
+/**
+ * Extract the dominant seed colour (`#rrggbb`) from an artwork image on web.
+ *
+ * Draws the image to a small (~96×96) offscreen canvas, reads back the pixels,
+ * packs each as an ARGB int, and runs Bloom's colour-engine image quantizer
+ * (`seedHexFromImagePixels`) to pick the most theme-suitable seed. Extraction is
+ * deterministic for a given image, so callers can cache the result per artwork.
+ *
+ * Returns `null` (never throws) when extraction is not possible — no canvas
+ * support, the image fails to load, or the canvas is CORS-tainted so
+ * `getImageData` is blocked. The caller then keeps the app preset.
+ */
+const SAMPLE_SIZE = 96;
+
+export async function extractArtworkSeed(imageUrl: string): Promise<string | null> {
+  if (!canExtractArtworkSeed() || !imageUrl) return null;
+
+  const image = await loadImage(imageUrl);
+  if (!image) return null;
+
+  const canvas = document.createElement('canvas');
+  const width = Math.max(1, Math.min(SAMPLE_SIZE, image.naturalWidth || SAMPLE_SIZE));
+  const height = Math.max(1, Math.min(SAMPLE_SIZE, image.naturalHeight || SAMPLE_SIZE));
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) return null;
+
+  context.drawImage(image, 0, 0, width, height);
+
+  let data: Uint8ClampedArray;
+  try {
+    // Throws a SecurityError if the canvas is tainted (cross-origin image
+    // served without permissive CORS headers). Treated as "no seed".
+    data = context.getImageData(0, 0, width, height).data;
+  } catch {
+    return null;
+  }
+
+  const pixels: number[] = [];
+  for (let i = 0; i < data.length; i += 4) {
+    const alpha = data[i + 3];
+    // Skip fully/near-transparent pixels — they are not part of the artwork.
+    if (alpha < 125) continue;
+    pixels.push(argbFromRgb(data[i], data[i + 1], data[i + 2]));
+  }
+  if (pixels.length === 0) return null;
+
+  try {
+    return seedHexFromImagePixels(pixels);
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the current environment can extract a seed from an image. */
+export function canExtractArtworkSeed(): boolean {
+  return typeof document !== 'undefined' && typeof document.createElement === 'function';
+}
+
+function loadImage(url: string): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    // Request CORS so the canvas stays untainted when the server allows it.
+    image.crossOrigin = 'anonymous';
+    image.decoding = 'async';
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = url;
+  });
+}

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.40.0",
+    "@oxyhq/bloom": "^0.41.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.34.2",
+    "@oxyhq/bloom": "^0.39.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "^0.39.0",
+    "@oxyhq/bloom": "^0.40.0",
     "@oxyhq/core": "^12.4.1",
     "@oxyhq/services": "^22.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
Hovering/focusing an album cover extracts its dominant colour (via Bloom's colour engine) and re-themes the album's ambient surfaces (hero + tracklist) to match — Apple Music / Spotify "now playing" ambience. Leaving/blurring restores the app preset, cross-fading and respecting `prefers-reduced-motion`.

- Uses Bloom `0.40.0`'s new `BloomSeedScope` + `buildThemeFromSeed` + public colour-engine exports (`generateRoleColors`, `seedHexFromImagePixels`).
- `utils/artworkSeed.web.ts` (canvas ARGB extraction → seed; never throws) · `hooks/useArtworkSeed.ts` (120ms debounce, per-artwork cache, last-intent-wins, React-Compiler-safe) · `hooks/usePrefersReducedMotion.ts` · `components/AmbientArtworkTheme.tsx` · `app/album/[id].tsx` split into loader + AlbumView reading `useTheme()` inside the scope.
- Verified in real headless Chrome: synthetic artwork → canvas getImageData → seed → ambient background eased then restored; reduced-motion snaps; distinct artwork → distinct deterministic seed. Frontend `tsc`: 0 errors; `--frozen-lockfile`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/syra/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->