### PR TITLE
CrowdSource moderation: the catalog, and rooms for what their hosts wrote

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,3 +39,12 @@ jobs:
         run: |
           cd packages/frontend && bun run lint
           cd ../studio && bun run lint
+      # The backend suite was not run by ANY workflow before this: quality
+      # typechecked and linted, and the deploy workflows only build. A guard that
+      # no job executes is a comment — the moderation integration's invariants
+      # (the intake transaction commits both writes or neither; the webhook
+      # receiver refuses a parsed body) are enforced only by these tests, and
+      # they run against a real in-memory MongoDB replica set rather than a mock,
+      # which is what makes them worth gating on.
+      - name: Backend tests
+        run: bun run --filter @syra/backend test

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,9 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1087.0",
         "@aws-sdk/s3-request-presigner": "^3.1087.0",
+        "@oxyhq/crowdsource": "0.3.0",
+        "@oxyhq/crowdsource-contracts": "0.3.0",
+        "@oxyhq/crowdsource-express": "0.3.0",
         "@socket.io/redis-adapter": "^8.2.0",
         "@syra.fm/sdk": "workspace:*",
         "@syra/shared-types": "workspace:*",
@@ -50,6 +53,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@oxyhq/crowdsource-testing": "0.3.0",
         "@types/bun": "^1.3.14",
         "mongodb-memory-server": "^11.2.0",
         "nodemon": "^3.1.10",
@@ -955,6 +959,14 @@
     "@oxyhq/contracts": ["@oxyhq/contracts@0.18.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-nGdoCp63FIpy29JpAEHSYYVUWl0wH+kHMzfgJJaVa8PvtiKffK8qokEK8bqkneIWRRCUtaR143dp4ZQmQo1eqg=="],
 
     "@oxyhq/core": ["@oxyhq/core@12.11.1", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.18.0", "@oxyhq/protocol": "^0.1.5", "bip39": "^3.1.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^7.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-1v8E6G/w2uYblMKtcd2o/q2bLQ+y+Ma/7ITDHMS3YwIlj8Eqr5ty6WOnQEZGVxbsYa4wxfMg1SPhydDqJl4+EQ=="],
+
+    "@oxyhq/crowdsource": ["@oxyhq/crowdsource@0.3.0", "", { "dependencies": { "zod": "^4.4.3" }, "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-YwLDyeIsXrU9qC8H51DW8KQI571HhdLXS3DjaPlJZ3n9W/Eeb/Xu+bqIHqLdFjViu/3Cvjw+dSYLPz2Zh/VAGg=="],
+
+    "@oxyhq/crowdsource-contracts": ["@oxyhq/crowdsource-contracts@0.3.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-pYCjVFzykva0xuAdbKrmtTuhVV+Xx8Ir6WX3UodIWZCujus9SQ5zfHjCAFFQZUs0D+bkWab9CAuQa2Nl95bpaQ=="],
+
+    "@oxyhq/crowdsource-express": ["@oxyhq/crowdsource-express@0.3.0", "", { "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0", "express": ">=4" } }, "sha512-sMYvLaNli3yLZVLzYWeazcEUygvV4lo0hzdp9KEdLi1PY5HYyY3nJCwGlGaY0+0V4ByO7mEIEcuclhOvt0ZWbg=="],
+
+    "@oxyhq/crowdsource-testing": ["@oxyhq/crowdsource-testing@0.3.0", "", { "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-Yd/cStpexe+Pl7rrSKJFkBJ8SAuid9uLBCj6VmQ30YvEB4WY2ravJUzpoTI/UTQy11gwXBuMAImzoaYxIlO4cA=="],
 
     "@oxyhq/expo-splash": ["@oxyhq/expo-splash@0.1.0", "", { "dependencies": { "@expo/image-utils": ">=0.7.0", "xml2js": "^0.6.0" }, "peerDependencies": { "expo": ">=51.0.0", "expo-splash-screen": ">=0.27.0", "react": ">=18.0.0", "react-native": ">=0.74.0" } }, "sha512-Sdh/3KQbLKpzjkDQ0v8IiFkhKKGDbjNgXPepyH6nomIG+3wU3aa40LFM9hhoOtHCNPg4uX8Z88WZb5l8ZYDA7g=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1087.0",
     "@aws-sdk/s3-request-presigner": "^3.1087.0",
+    "@oxyhq/crowdsource": "0.3.0",
+    "@oxyhq/crowdsource-contracts": "0.3.0",
+    "@oxyhq/crowdsource-express": "0.3.0",
     "@socket.io/redis-adapter": "^8.2.0",
     "@syra.fm/sdk": "workspace:*",
     "@syra/shared-types": "workspace:*",
@@ -56,6 +59,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@oxyhq/crowdsource-testing": "0.3.0",
     "@types/bun": "^1.3.14",
     "mongodb-memory-server": "^11.2.0",
     "nodemon": "^3.1.10",

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -50,6 +50,9 @@ import housesRoutes from './src/routes/houses.routes';
 import seriesRoutes from './src/routes/series.routes';
 import recordingsRoutes from './src/routes/recordings.routes';
 import livekitWebhookRoutes from './src/routes/livekitWebhook.routes';
+import reportsRoutes from './src/routes/reports.routes';
+import { createCrowdSourceWebhookRoutes } from './src/routes/crowdsourceWebhook.routes';
+import { moderationOutboxDispatcher } from './src/moderation/dispatcher';
 import { initializeRoomSocket } from './src/sockets/roomSocket';
 import { initializeIO } from './src/utils/socket';
 import { startRecommendationScheduler } from './src/services/recommendations/scheduler';
@@ -93,6 +96,14 @@ app.use(cors({
 // The route is machine-to-machine and gated entirely by cryptographic signature
 // verification, so it needs no per-request rate limit.
 app.use('/livekit', livekitWebhookRoutes);
+
+// The CrowdSource webhook receiver, mounted here for the SAME reason and with the
+// same consequence if it moves: its HMAC covers the exact bytes that arrived, and
+// it reads the request stream itself. Below the JSON parser it would be verifying
+// a signature over a re-serialization. The route refuses outright rather than
+// falling back (`assertRawBody`), and a test asserts the refusal, because a mount
+// order is not something a type can hold.
+app.use('/webhooks', createCrowdSourceWebhookRoutes());
 
 // Create Redis store for distributed rate limiting
 const redisStore = new RedisStore({ 
@@ -325,6 +336,7 @@ authenticatedApiRouter.use('/recommendations', recommendationsRoutes);
 authenticatedApiRouter.use('/recordings', recordingsRoutes);
 authenticatedApiRouter.use('/houses', housesRoutes);
 authenticatedApiRouter.use('/series', seriesRoutes);
+authenticatedApiRouter.use('/reports', reportsRoutes);
 
 app.use('/api', publicApiRouter);
 app.use('/api', oxy.auth(), authenticatedApiRouter);
@@ -428,6 +440,14 @@ const bootServer = async () => {
   // Periodic re-crawl of subscribed/popular RSS feeds (same lock-guarded timer
   // pattern; skipped when Redis is unavailable).
   startPodcastRefreshScheduler();
+
+  // Drain the moderation outbox. Deliberately NOT lock-guarded like the two
+  // schedulers above: every event is claimed under a Mongo lease with an owner
+  // check, so N instances share the work and a dead instance's lease is reclaimed
+  // rather than stranding a report. No-ops when the integration is disabled — the
+  // loop is gated, never the durable record, so reports taken while it is off
+  // deliver when it is switched on.
+  moderationOutboxDispatcher.start();
 };
 
 if (require.main === module) {

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -83,6 +83,17 @@ const schema = z.object({
   LINK_PREVIEW_PNG_QUALITY: z.coerce.number().default(80),
   LINK_PREVIEW_WEBP_QUALITY: z.coerce.number().default(80),
   LINK_PREVIEW_MAX_FILE_SIZE: z.coerce.number().default(500 * 1024),
+
+  /**
+   * CrowdSource participatory moderation is deliberately NOT declared here.
+   *
+   * `env` is parsed once at import, which is right for every value above and
+   * wrong for this one: the enabled flag, the service credential and the webhook
+   * secret have to be validated as a UNIT (enabled requires both, or Syra sends
+   * reports that can never come back), and that combination has to be
+   * re-derivable rather than frozen at first import. `src/moderation/config.ts`
+   * owns those reads and the validation that makes them meaningful.
+   */
 });
 
 export const env = schema.parse(process.env);

--- a/packages/backend/src/models/ModerationEnforcement.ts
+++ b/packages/backend/src/models/ModerationEnforcement.ts
@@ -1,0 +1,152 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+import type { ModerationEnforcementMode } from '../moderation/config';
+
+/**
+ * What Syra did about a decision, once per decision revision per action.
+ *
+ * Appendix D's idempotency key is `decisionId + revision + action`, and the unique
+ * compound index below IS that key. Every action CLAIMS its row before doing
+ * anything, so a redelivered webhook, a reclaimed outbox lease or a manual replay
+ * loses the insert and does nothing.
+ *
+ * `revision` is part of the key rather than a field beside it, and removing it
+ * would be a silent, serious bug: a correction's `restore` is a DIFFERENT action
+ * from the removal it supersedes, and collapsing them means an accepted appeal can
+ * never put a playlist back in the catalog.
+ *
+ * Every state-changing action records what the state WAS, so a reversal restores
+ * the real previous value rather than a guess at one — a playlist that was
+ * already private before a report must not be made public by a correction.
+ */
+
+/**
+ * The two things Syra can actually do to a published object, reversibly, plus
+ * the two that are notes rather than effects.
+ *
+ * Deliberately NOT a copy of another application's vocabulary. Syra has neither a
+ * content warning nor an editorial promotion flag, so there is no
+ * `label_sensitive` and no `demote` — recording an effect that did not happen
+ * would be worse than mapping honestly. See `moderation/enforcement-plan.ts`.
+ *
+ * `restrict` is deliberately NOT the copyright takedown. That path sets
+ * `copyrightRemoved` (plus `isAvailable: false`) and is irreversible by design,
+ * because a DMCA strike carries statutory consequences. Community moderation
+ * touches `isAvailable` / `visibility` / `status` only, so a jury can never
+ * manufacture a copyright strike and a `restore` can always put the object back.
+ */
+export type ModerationEnforcementAction =
+  /** Take the object out of the catalog, or make it non-public. */
+  | 'restrict'
+  /** Undo what moderation previously did to this subject. */
+  | 'restore'
+  /** Recorded for a human. Never executed automatically. */
+  | 'manual_review'
+  /** An explicit, recorded decision to do nothing. */
+  | 'none';
+
+export const MODERATION_ENFORCEMENT_ACTIONS: readonly ModerationEnforcementAction[] = [
+  'restrict',
+  'restore',
+  'manual_review',
+  'none',
+];
+
+/**
+ * The fields an action replaced, so a reversal can put them back.
+ *
+ * Flat and explicit rather than a `Mixed` blob: a reversal reads these, and a
+ * shape nobody can typecheck is a shape that silently stops being restored.
+ *
+ * `copyrightRemoved` is absent on purpose — community moderation never sets it,
+ * so it never has one to restore.
+ */
+export interface ModerationPreviousState {
+  isAvailable?: boolean;
+  /** A playlist's or house's previous visibility token. */
+  visibility?: string;
+  /** A podcast's or room's previous lifecycle status. */
+  status?: string;
+}
+
+export interface IModerationEnforcement extends Document {
+  decisionId: string;
+  decisionRevision: number;
+  action: ModerationEnforcementAction;
+  caseId: string;
+  /** Syra's own noun (`playlist`, `house`, `artist`, `track`, `room`). */
+  subjectType: string;
+  subjectId: string;
+  outcome: string;
+  /** The CrowdSource recommendation this came from, when it came from one. */
+  recommendedAction?: string;
+  /** Why, in words an operator reads. Never reported material. */
+  reason: string;
+  mode: ModerationEnforcementMode;
+  applied: boolean;
+  appliedAt?: Date;
+  /** Why a claimed action was deliberately not carried out. */
+  skippedReason?: string;
+  previousState?: ModerationPreviousState;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ModerationEnforcementSchema = new Schema<IModerationEnforcement>(
+  {
+    decisionId: { type: String, required: true },
+    decisionRevision: { type: Number, required: true },
+    action: {
+      type: String,
+      enum: MODERATION_ENFORCEMENT_ACTIONS,
+      required: true,
+    },
+    caseId: { type: String, required: true, index: true },
+    subjectType: { type: String, required: true },
+    subjectId: { type: String, required: true },
+    outcome: { type: String, required: true },
+    recommendedAction: { type: String },
+    reason: { type: String, required: true, maxlength: 500 },
+    mode: {
+      type: String,
+      enum: ['observe', 'manual', 'automatic'],
+      required: true,
+    },
+    applied: { type: Boolean, default: false },
+    appliedAt: { type: Date },
+    skippedReason: { type: String, maxlength: 500 },
+    previousState: {
+      type: new Schema<ModerationPreviousState>(
+        {
+          isAvailable: { type: Boolean },
+          visibility: { type: String },
+          status: { type: String },
+        },
+        { _id: false },
+      ),
+      default: undefined,
+    },
+  },
+  { timestamps: true },
+);
+
+/** Appendix D. This index is the idempotency guarantee, not an optimisation. */
+ModerationEnforcementSchema.index(
+  { decisionId: 1, decisionRevision: 1, action: 1 },
+  { unique: true },
+);
+/** A reversal's lookup: the most recent applied action of a kind on a subject. */
+ModerationEnforcementSchema.index({
+  subjectType: 1,
+  subjectId: 1,
+  action: 1,
+  applied: 1,
+  createdAt: -1,
+});
+
+export const ModerationEnforcementModel: Model<IModerationEnforcement> =
+  mongoose.models.ModerationEnforcement ||
+  mongoose.model<IModerationEnforcement>(
+    'ModerationEnforcement',
+    ModerationEnforcementSchema,
+    'moderation_enforcements',
+  );

--- a/packages/backend/src/models/ModerationEvent.ts
+++ b/packages/backend/src/models/ModerationEvent.ts
@@ -1,0 +1,71 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+/**
+ * Every webhook event CrowdSource has delivered, and what became of it.
+ *
+ * Two jobs in one collection, and both need it to be durable.
+ *
+ * **Deduplication.** `_id` is the event id and the index on it is unique, so
+ * inserting the row IS the claim — the duplicate-key error is the answer
+ * "somebody else already has this event", not a failure to work around. Syra runs
+ * several ECS tasks behind one ALB, so the SDK's in-process default store would
+ * deduplicate only the instance that happened to receive both copies of a
+ * redelivery.
+ *
+ * **Audit.** "Did CrowdSource tell us about this case, and when" is the first
+ * question asked when a report looks stuck, so an event carrying nothing to do is
+ * still recorded rather than dropped.
+ */
+
+/**
+ * `claimed` → `queued` | `ignored`.
+ *
+ * A row left at `claimed` means the handler neither queued work nor decided there
+ * was none — it crashed. That is deliberately visible rather than tidied away.
+ */
+export type ModerationEventState = 'claimed' | 'queued' | 'ignored';
+
+export interface IModerationEvent extends Document<string> {
+  _id: string;
+  type?: string;
+  caseId?: string;
+  /** The event as delivered. Opaque here, parsed by the worker that acts on it. */
+  payload?: unknown;
+  state: ModerationEventState;
+  receivedAt: Date;
+  queuedAt?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Long enough to answer "was this event ever delivered" about a case that has
+ * been open for months, and bounded so the collection cannot grow forever.
+ */
+export const MODERATION_EVENT_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+const ModerationEventSchema = new Schema<IModerationEvent>(
+  {
+    _id: { type: String, required: true },
+    type: { type: String },
+    caseId: { type: String, index: true },
+    payload: { type: Schema.Types.Mixed },
+    state: {
+      type: String,
+      enum: ['claimed', 'queued', 'ignored'],
+      default: 'claimed',
+      index: true,
+    },
+    receivedAt: { type: Date, required: true },
+    queuedAt: { type: Date },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, _id: false },
+);
+
+ModerationEventSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const ModerationEventModel: Model<IModerationEvent> =
+  mongoose.models.ModerationEvent ||
+  mongoose.model<IModerationEvent>('ModerationEvent', ModerationEventSchema, 'moderation_events');

--- a/packages/backend/src/models/ModerationOutbox.ts
+++ b/packages/backend/src/models/ModerationOutbox.ts
@@ -1,0 +1,118 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+/**
+ * The durable record of moderation work that has to happen but has not happened
+ * yet.
+ *
+ * This collection is the whole reason a 201 from `POST /reports` can be honest.
+ * The report row and its delivery event commit in ONE transaction — not a call to
+ * CrowdSource — so the user never waits for a third party to be reachable, and no
+ * report is ever answered "received" with nothing that will send it.
+ *
+ * The same shape carries work in the other direction: a decision arriving over a
+ * webhook is answered 2xx as soon as it is recorded here (§10.8) and applied
+ * afterwards. **Nothing is enqueued that is not already written down.** If the
+ * dispatcher, the process or the whole task disappears, every pending piece of
+ * moderation work is re-derivable by reading this collection.
+ */
+export type ModerationOutboxKind = 'report.submit' | 'decision.apply';
+
+/**
+ * `dead_letter` is where retrying stops.
+ *
+ * Every error `@oxyhq/crowdsource` throws answers one question: could delivering
+ * this same payload ever succeed. A 409 (§10.5's "external id reused with a
+ * different body") or a rejected envelope cannot, so retrying forever would hide a
+ * defect behind an ever-growing attempt count. Those events stop, keep their
+ * error, and stay visible.
+ */
+export type ModerationOutboxStatus =
+  | 'pending'
+  | 'processing'
+  | 'processed'
+  | 'dead_letter';
+
+export interface ModerationOutboxPayload {
+  /** The local `Report._id`, for `report.submit`. */
+  reportId?: string;
+  /** The inbound webhook event id, for `decision.apply` (Appendix D). */
+  eventId?: string;
+  /** The CrowdSource case a decision belongs to. */
+  caseId?: string;
+  /**
+   * The decision exactly as CrowdSource published it.
+   *
+   * Stored whole and opaque rather than projected into fields: §10.11 makes the
+   * decision document loose, and a projection would silently drop whatever a newer
+   * CrowdSource added — including a finding the enforcement mapping may later
+   * need. It is validated against the published contract when it is READ, so an
+   * event is never lost to a schema this deployment has not caught up with.
+   */
+  decision?: unknown;
+}
+
+export interface IModerationOutbox extends Document<string> {
+  _id: string;
+  kind: ModerationOutboxKind;
+  payload: ModerationOutboxPayload;
+  status: ModerationOutboxStatus;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner?: string;
+  leaseUntil?: Date;
+  lastError?: string;
+  processedAt?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Retention ceiling, so a stalled dispatcher cannot turn the outbox into an
+ * unbounded collection. Long, because a moderation case can legitimately sit open
+ * for weeks and a `dead_letter` event is evidence somebody still has to look at.
+ * Operational alerts must fire long before this deadline.
+ */
+export const MODERATION_OUTBOX_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+const ModerationOutboxSchema = new Schema<IModerationOutbox>(
+  {
+    /**
+     * The event id IS the idempotency key, and it is derived from the domain
+     * object rather than generated. A transaction retry or two concurrent
+     * duplicate submissions upsert the SAME row instead of queueing two
+     * deliveries.
+     */
+    _id: { type: String, required: true },
+    kind: {
+      type: String,
+      enum: ['report.submit', 'decision.apply'],
+      required: true,
+    },
+    payload: { type: Schema.Types.Mixed, required: true },
+    status: {
+      type: String,
+      enum: ['pending', 'processing', 'processed', 'dead_letter'],
+      default: 'pending',
+      index: true,
+    },
+    attempts: { type: Number, default: 0 },
+    availableAt: { type: Date, required: true },
+    leaseOwner: { type: String },
+    leaseUntil: { type: Date },
+    lastError: { type: String, maxlength: 2000 },
+    processedAt: { type: Date },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, _id: false },
+);
+
+/** The dispatcher's claim query: due work, oldest first. */
+ModerationOutboxSchema.index({ status: 1, availableAt: 1, createdAt: 1 });
+/** Reclaiming a dead worker's lease. */
+ModerationOutboxSchema.index({ status: 1, leaseUntil: 1 });
+ModerationOutboxSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const ModerationOutboxModel: Model<IModerationOutbox> =
+  mongoose.models.ModerationOutbox ||
+  mongoose.model<IModerationOutbox>('ModerationOutbox', ModerationOutboxSchema, 'moderation_outbox');

--- a/packages/backend/src/models/Report.ts
+++ b/packages/backend/src/models/Report.ts
@@ -1,0 +1,220 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+/**
+ * A report a listener filed in Syra.
+ *
+ * Two status axes, because they answer two different questions and one field
+ * cannot hold both. `localStatus` is where the report is in SYRA's pipeline —
+ * stored, queued, delivered, failed, closed. `status` is what a jury concluded. A
+ * report is routinely `submitted` with no verdict yet, and `closed` with a verdict
+ * of `dismissed`.
+ *
+ * ## This is NOT the copyright flow, and the two must never merge
+ *
+ * `CopyrightReport` already exists and is a real DMCA pipeline: reports, admin
+ * resolution, three strikes, artist termination, `copyrightRemoved` takedown. It
+ * stays exactly where it is.
+ *
+ * The reason is not tidiness — the contract itself says so. The universal
+ * taxonomy has forty codes across eleven families and NOT ONE of them is
+ * copyright, infringement or intellectual property; the nearest, `commerce.counterfeit`,
+ * is about goods. That absence is deliberate: DMCA carries statutory process,
+ * counter-notice and safe-harbour consequences, and §7.5 routes material with
+ * legal weight to specialists rather than to a randomly drawn jury. A community
+ * vote is the wrong instrument for it and there is no code to express the
+ * allegation with.
+ *
+ * So: CrowdSource decides conduct and content on the catalog; `CopyrightReport`
+ * decides copyright. Two questions, two processes, no overlap — and deliberately
+ * no `copyright` value in {@link ReportCategory}, so nobody can file one here by
+ * accident.
+ */
+
+/**
+ * What Syra will accept a report ABOUT.
+ *
+ * Wider than what it can deliver, and deliberately so — see
+ * `moderation/subjects/registry.ts`. A type with a subject provider is sent for
+ * community review; a type without one is stored with the reason and never leaves.
+ */
+export enum ReportedType {
+  /** A user's public playlist. */
+  PLAYLIST = 'playlist',
+  /** A user-created house (community). */
+  HOUSE = 'house',
+  /** A Syra artist profile. */
+  ARTIST = 'artist',
+  /** A track in the catalog. */
+  TRACK = 'track',
+  /** A live or ended audio room. */
+  ROOM = 'room',
+  /**
+   * A mirrored podcast show. Accepted, never delivered — see the registry: the
+   * publisher is a third party outside Syra with no Oxy identity.
+   */
+  PODCAST = 'podcast',
+  /** A mirrored podcast episode. Accepted, never delivered, same reason. */
+  EPISODE = 'episode',
+  /**
+   * A listener's account. Accepted, never delivered — Oxy owns identity and a
+   * plain listener has no Syra-side profile to snapshot. (An ARTIST does, which is
+   * why that one is deliverable and this one is not.)
+   */
+  USER = 'user',
+}
+
+/**
+ * What the reporter says is wrong.
+ *
+ * No `copyright` value, on purpose — see the note at the top of this file.
+ */
+export enum ReportCategory {
+  SPAM = 'spam',
+  HARASSMENT = 'harassment',
+  HATE_SPEECH = 'hate_speech',
+  EXPLICIT_CONTENT = 'explicit_content',
+  IMPERSONATION = 'impersonation',
+  VIOLENCE = 'violence',
+  OTHER = 'other',
+}
+
+/** What a jury concluded. `PENDING` until one has. */
+export enum ReportStatus {
+  PENDING = 'pending',
+  REVIEWED = 'reviewed',
+  RESOLVED = 'resolved',
+  DISMISSED = 'dismissed',
+}
+
+/**
+ * Where the report is in Syra's own pipeline.
+ *
+ * `received` and `delivery_failed` are NOT the same claim. `received` means there
+ * was never a route out of this application for this kind of object;
+ * `delivery_failed` means there is one and it did not work this time. Only the
+ * second is worth retrying, and only the first is a deliberate state.
+ */
+export type ModerationLocalStatus =
+  | 'received'
+  | 'queued'
+  | 'submitted'
+  | 'delivery_failed'
+  | 'closed';
+
+export const MODERATION_LOCAL_STATUSES: readonly ModerationLocalStatus[] = [
+  'received',
+  'queued',
+  'submitted',
+  'delivery_failed',
+  'closed',
+];
+
+export interface IReport extends Document {
+  /**
+   * Declared explicitly because a bare `Document` types `_id` as `unknown`, and
+   * the report id IS the `externalReportId` the whole CrowdSource side is keyed on.
+   */
+  _id: mongoose.Types.ObjectId;
+  reportedType: ReportedType;
+  reportedId: string;
+  /** The reporter's Oxy user id, which IS the §11.14 binding proof. */
+  reporter: string;
+  categories: ReportCategory[];
+  details?: string;
+
+  status: ReportStatus;
+  localStatus: ModerationLocalStatus;
+  localStatusReason?: string;
+  lastDeliveryError?: string;
+
+  crowdSourceReportId?: string;
+  crowdSourceCaseId?: string;
+  crowdSourceMerged?: boolean;
+  /** §5.6: the digest of the exact representation that was sent for review. */
+  contentSnapshotHash?: string;
+  submittedAt?: Date;
+
+  decisionId?: string;
+  decisionRevision?: number;
+  decisionOutcome?: string;
+  decisionStatus?: string;
+  decidedAt?: Date;
+  enforcedAction?: string;
+  enforcedAt?: Date;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ReportSchema = new Schema<IReport>(
+  {
+    reportedType: {
+      type: String,
+      enum: Object.values(ReportedType),
+      required: true,
+      index: true,
+    },
+    /**
+     * A String, not an ObjectId. Syra addresses several of its own nouns by
+     * string id already, and this value travels verbatim into the envelope —
+     * casting it through an ObjectId would either throw on a legitimate id or
+     * silently change what a binding proof is checked against.
+     */
+    reportedId: { type: String, required: true },
+    reporter: { type: String, required: true, index: true },
+    categories: {
+      type: [{ type: String, enum: Object.values(ReportCategory) }],
+      required: true,
+      validate: {
+        validator: (categories: string[]) => categories.length > 0,
+        message: 'A report must carry at least one category.',
+      },
+    },
+    details: { type: String, maxlength: 2000 },
+
+    status: {
+      type: String,
+      enum: Object.values(ReportStatus),
+      default: ReportStatus.PENDING,
+      index: true,
+    },
+    localStatus: {
+      type: String,
+      enum: MODERATION_LOCAL_STATUSES,
+      default: 'received',
+      index: true,
+    },
+    localStatusReason: { type: String, maxlength: 300 },
+    lastDeliveryError: { type: String, maxlength: 2000 },
+
+    crowdSourceReportId: { type: String },
+    crowdSourceCaseId: { type: String, index: true },
+    crowdSourceMerged: { type: Boolean },
+    contentSnapshotHash: { type: String },
+    submittedAt: { type: Date },
+
+    decisionId: { type: String },
+    decisionRevision: { type: Number },
+    decisionOutcome: { type: String },
+    decisionStatus: { type: String },
+    decidedAt: { type: Date },
+    enforcedAction: { type: String },
+    enforcedAt: { type: Date },
+  },
+  { timestamps: true },
+);
+
+/**
+ * One report per reporter per object.
+ *
+ * A unique index rather than a check in the handler: two concurrent submissions
+ * from the same client are the ordinary case (a double tap), and a read-then-write
+ * leaves exactly the gap where the second one lands.
+ */
+ReportSchema.index({ reporter: 1, reportedType: 1, reportedId: 1 }, { unique: true });
+ReportSchema.index({ localStatus: 1, createdAt: 1 });
+
+export type LeanReport = Omit<IReport, keyof Document> & { _id: mongoose.Types.ObjectId };
+
+export const ReportModel: Model<IReport> =
+  mongoose.models.Report || mongoose.model<IReport>('Report', ReportSchema);

--- a/packages/backend/src/moderation/client.ts
+++ b/packages/backend/src/moderation/client.ts
@@ -1,0 +1,67 @@
+import { CrowdSource } from '@oxyhq/crowdsource';
+import { crowdSourceConfig } from './config';
+import { logger } from '../utils/logger';
+
+/**
+ * The CrowdSource client, built once and only when configured.
+ *
+ * There is deliberately almost nothing here. The SDK already owns the base URL,
+ * the timeouts, the bounded per-attempt retries, the idempotency key and the error
+ * classification, and a wrapper that re-implemented any of them would be a second
+ * answer to a question that has one. What Syra adds is exactly two things: the
+ * client is absent until the integration is switched on, and it is built once
+ * rather than per delivery.
+ *
+ * `applicationId` appears nowhere — the client reads it off the service key, and
+ * there is no option, field or parameter through which one could be passed.
+ */
+
+let client: CrowdSource | null = null;
+let configurationError: string | null = null;
+
+/**
+ * The client, or `undefined` when the integration is not configured.
+ *
+ * `undefined` rather than a throw: `CROWDSOURCE_ENABLED=false` is the normal state
+ * of a local checkout and of every deployment before rollout, and a report filed
+ * there must still be stored. The delivery worker is what notices there is nowhere
+ * to send it.
+ *
+ * A MISCONFIGURED client — a malformed service key — is a different thing and is
+ * logged once at error level. Once, because the alternative is a line per delivery
+ * attempt per report, which buries the cause it is meant to reveal.
+ */
+export function getCrowdSourceClient(): CrowdSource | undefined {
+  const config = crowdSourceConfig();
+  if (!config.enabled) return undefined;
+  if (client) return client;
+  if (configurationError !== null) return undefined;
+
+  const serviceKey = config.serviceKey;
+  if (!serviceKey) {
+    configurationError = 'CROWDSOURCE_SERVICE_KEY is not set';
+    logger.error('[CrowdSource] enabled but not configured', { reason: configurationError });
+    return undefined;
+  }
+
+  try {
+    client = new CrowdSource({
+      serviceKey,
+      ...(config.baseUrl === undefined ? {} : { baseUrl: config.baseUrl }),
+    });
+    logger.info('[CrowdSource] client ready', { applicationId: client.applicationId });
+    return client;
+  } catch (error: unknown) {
+    // The SDK's configuration errors name which part of the key is wrong and never
+    // echo the secret, so the message is safe to log.
+    configurationError = error instanceof Error ? error.message : String(error);
+    logger.error('[CrowdSource] service key rejected', { reason: configurationError });
+    return undefined;
+  }
+}
+
+/** Test hook. Production builds the client once and keeps it for the process. */
+export function resetCrowdSourceClient(): void {
+  client = null;
+  configurationError = null;
+}

--- a/packages/backend/src/moderation/config.ts
+++ b/packages/backend/src/moderation/config.ts
@@ -1,0 +1,141 @@
+import { logger } from '../utils/logger';
+
+/**
+ * Everything this deployment knows about CrowdSource.
+ *
+ * Read here rather than in `config/env.ts`, which parses every other Syra setting
+ * once at import. That is right for the rest and wrong for this one, for two
+ * reasons that go together:
+ *
+ * - The enabled flag, the service credential and the webhook secret only mean
+ *   anything TOGETHER. A deployment with a service key and no webhook secret
+ *   sends reports that can never come back — cases open, juries decide, and Syra
+ *   never learns the outcome, with nothing failing anywhere to say so. Every
+ *   later stage sees only its own half, so this is the one place it can be
+ *   caught, and a per-field schema cannot express it.
+ * - That combination therefore has to be RE-DERIVABLE rather than frozen at first
+ *   import, which is what {@link resetCrowdSourceConfig} exists for.
+ *
+ * There is deliberately no `CROWDSOURCE_APP_ID`, and one must never be added:
+ * `applicationId` is read off the service credential by the SDK, which exposes no
+ * option through which one could be passed. A variable holding it could only ever
+ * disagree with the credential — and a tenant id the caller can choose is not
+ * isolation, it is an IDOR.
+ */
+
+export type ModerationEnforcementMode = 'observe' | 'manual' | 'automatic';
+
+const ENFORCEMENT_MODES: readonly ModerationEnforcementMode[] = [
+  'observe',
+  'manual',
+  'automatic',
+];
+
+const DEFAULT_OUTBOX_BATCH_SIZE = 50;
+const DEFAULT_OUTBOX_POLL_INTERVAL_MS = 5_000;
+const MIN_OUTBOX_POLL_INTERVAL_MS = 1_000;
+const MAX_OUTBOX_BATCH_SIZE = 500;
+
+export interface CrowdSourceConfig {
+  readonly enabled: boolean;
+  /** `applicationId:credentialId:secret`, ONE opaque value. Never split here. */
+  readonly serviceKey?: string;
+  /** Optional; the SDK defaults to the one deployment. */
+  readonly baseUrl?: string;
+  readonly webhookSecret?: string;
+  /** Both are accepted while a secret is being rotated (§10.8). */
+  readonly webhookPreviousSecret?: string;
+  readonly outboxBatchSize: number;
+  readonly outboxPollIntervalMs: number;
+  readonly enforcementMode: ModerationEnforcementMode;
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const next = value?.trim();
+  return next ? next : undefined;
+}
+
+function boundedInteger(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+/**
+ * The mode, defaulting to `observe`.
+ *
+ * An unrecognised value also becomes `observe`. A typo in an environment variable
+ * must never be the reason a track leaves the catalog — failing towards the mode
+ * that changes nothing is the only safe reading, and it must not stop the service
+ * booting either.
+ */
+function enforcementMode(value: string | undefined): ModerationEnforcementMode {
+  const candidate = trimmed(value);
+  if (candidate === undefined) return 'observe';
+  const match = ENFORCEMENT_MODES.find((mode) => mode === candidate);
+  if (match) return match;
+  logger.warn(
+    '[CrowdSource] unrecognised CROWDSOURCE_ENFORCEMENT_MODE, falling back to observe',
+    { value: candidate },
+  );
+  return 'observe';
+}
+
+function readConfig(): CrowdSourceConfig {
+  const requested = trimmed(process.env.CROWDSOURCE_ENABLED) === 'true';
+  const serviceKey = trimmed(process.env.CROWDSOURCE_SERVICE_KEY);
+  const webhookSecret = trimmed(process.env.CROWDSOURCE_WEBHOOK_SECRET);
+  const enabled = requested && serviceKey !== undefined && webhookSecret !== undefined;
+
+  if (requested && !enabled) {
+    logger.error(
+      '[CrowdSource] CROWDSOURCE_ENABLED=true but the integration is half-configured; staying off',
+      {
+        hasServiceKey: serviceKey !== undefined,
+        hasWebhookSecret: webhookSecret !== undefined,
+      },
+    );
+  }
+
+  const baseUrl = trimmed(process.env.CROWDSOURCE_BASE_URL);
+  const webhookPreviousSecret = trimmed(process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS);
+
+  return {
+    enabled,
+    ...(serviceKey === undefined ? {} : { serviceKey }),
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    ...(webhookSecret === undefined ? {} : { webhookSecret }),
+    ...(webhookPreviousSecret === undefined ? {} : { webhookPreviousSecret }),
+    outboxBatchSize: boundedInteger(
+      process.env.CROWDSOURCE_OUTBOX_BATCH_SIZE,
+      DEFAULT_OUTBOX_BATCH_SIZE,
+      1,
+      MAX_OUTBOX_BATCH_SIZE,
+    ),
+    outboxPollIntervalMs: boundedInteger(
+      process.env.CROWDSOURCE_OUTBOX_POLL_INTERVAL_MS,
+      DEFAULT_OUTBOX_POLL_INTERVAL_MS,
+      MIN_OUTBOX_POLL_INTERVAL_MS,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    enforcementMode: enforcementMode(process.env.CROWDSOURCE_ENFORCEMENT_MODE),
+  };
+}
+
+let cached: CrowdSourceConfig | null = null;
+
+/** The configuration, derived on first use. */
+export function crowdSourceConfig(): CrowdSourceConfig {
+  cached ??= readConfig();
+  return cached;
+}
+
+/** Test hook, and the reason the derivation is a function. */
+export function resetCrowdSourceConfig(): void {
+  cached = null;
+}

--- a/packages/backend/src/moderation/decision-worker.ts
+++ b/packages/backend/src/moderation/decision-worker.ts
@@ -1,0 +1,183 @@
+import { DecisionSchema, type Decision } from '@oxyhq/crowdsource-contracts';
+import { ReportModel, type LeanReport } from '../models/Report';
+import type { ModerationEnforcementAction } from '../models/ModerationEnforcement';
+import { applyDecisionEnforcement } from './enforcement-service';
+import type { ModerationOutboxEvent } from './outbox';
+import { reportStateForDecision } from './report-status';
+import { logger } from '../utils/logger';
+
+/**
+ * Applying a decision that has already been received and recorded.
+ *
+ * The webhook answered 2xx long before this runs (§10.8). What is left is the part
+ * that touches several collections: write the decision onto every report that
+ * opened or joined the case, and enforce it once.
+ *
+ * "Once" is the invariant that shapes this file. A hundred reports about the same
+ * material produce ONE case and ONE consequence, so enforcement is keyed on the
+ * decision and not on the reports — the enforcement service is called a single
+ * time no matter how many reports are updated, and its own unique index makes even
+ * that call safe to repeat.
+ */
+
+/** A failure that will not be fixed by trying again. */
+export class ModerationDecisionRejectedError extends Error {
+  /** Read by the outbox: `false` dead-letters instead of retrying (§10.5). */
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModerationDecisionRejectedError';
+  }
+}
+
+/** A failure that a later attempt can still resolve. */
+export class ModerationDecisionDeferredError extends Error {
+  readonly retryable = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModerationDecisionDeferredError';
+  }
+}
+
+/**
+ * Write the decision onto one report.
+ *
+ * The filter carries the revision guard, so it is the DATABASE that refuses a
+ * stale write rather than a read-then-write in this process. Deliveries can
+ * overlap — §10.9 retries for 24 hours, and a correction can arrive while the
+ * decision it supersedes is still being applied — and an older revision landing
+ * last would otherwise overwrite the current answer with a stale one.
+ */
+async function applyToReport(
+  report: Pick<LeanReport, '_id'>,
+  decision: Decision,
+  enforcedAction: ModerationEnforcementAction | undefined,
+): Promise<boolean> {
+  const state = reportStateForDecision({
+    outcome: decision.outcome,
+    decisionStatus: decision.status,
+  });
+
+  const result = await ReportModel.updateOne(
+    {
+      _id: report._id,
+      $or: [
+        { decisionRevision: { $exists: false } },
+        { decisionRevision: { $lte: decision.revision } },
+      ],
+    },
+    {
+      $set: {
+        status: state.status,
+        localStatus: state.localStatus,
+        decisionId: decision.id,
+        decisionRevision: decision.revision,
+        decisionOutcome: decision.outcome,
+        decisionStatus: decision.status,
+        decidedAt: new Date(decision.publishedAt),
+        ...(enforcedAction === undefined ? {} : { enforcedAction, enforcedAt: new Date() }),
+      },
+    },
+  );
+  return result.matchedCount === 1;
+}
+
+/**
+ * The action worth recording on the report.
+ *
+ * One field, several planned actions, so it has to be the one that answers "what
+ * happened to this object". A state-changing action beats a note for a human,
+ * which beats an explicit nothing — and `manual_review` still reaches the report,
+ * because a reporter told "nothing happened" when a human is about to look is
+ * being told something untrue.
+ */
+const ACTION_PRECEDENCE: readonly ModerationEnforcementAction[] = [
+  'restrict',
+  'restore',
+  'manual_review',
+  'none',
+];
+
+function primaryAction(
+  actions: readonly ModerationEnforcementAction[],
+): ModerationEnforcementAction | undefined {
+  for (const candidate of ACTION_PRECEDENCE) {
+    if (actions.includes(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Handle one `decision.apply` outbox event. */
+export async function applyDecisionOutboxEvent(
+  event: ModerationOutboxEvent,
+): Promise<void> {
+  const caseId = event.payload.caseId;
+  if (caseId === undefined) {
+    throw new ModerationDecisionRejectedError('A decision.apply event carried no caseId.');
+  }
+
+  /**
+   * Parsed HERE rather than at the webhook.
+   *
+   * The receiver's job was to prove the bytes came from CrowdSource and to record
+   * them; refusing an unrecognised shape at the door would put a real decision back
+   * on a retry schedule until it expired. Parsing at the point of use means an
+   * event this deployment cannot yet read waits in the outbox until it can.
+   */
+  const parsed = DecisionSchema.safeParse(event.payload.decision);
+  if (!parsed.success) {
+    throw new ModerationDecisionRejectedError(
+      `The decision for case ${caseId} does not match the published contract: ${parsed.error.issues
+        .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+        .join('; ')}`,
+    );
+  }
+  const decision = parsed.data;
+
+  const reports = await ReportModel.find({ crowdSourceCaseId: caseId })
+    .select('_id reportedType reportedId')
+    .lean<Pick<LeanReport, '_id' | 'reportedType' | 'reportedId'>[]>();
+
+  if (reports.length === 0) {
+    /**
+     * Retryable, and the race is real rather than theoretical: CrowdSource can
+     * decide a case and deliver the webhook while the response that carried the
+     * case id back to this deployment is still being written, or while a delivery
+     * is being retried. Backing off is correct; dead-lettering would throw the
+     * decision away.
+     */
+    throw new ModerationDecisionDeferredError(
+      `No local report is linked to case ${caseId} yet.`,
+    );
+  }
+
+  /**
+   * One subject per case. §7.3's dedup key includes `subject.externalId`, so every
+   * report merged into a case is about the same object — the first report names it.
+   */
+  const [first] = reports;
+  const outcomes = await applyDecisionEnforcement({
+    decision,
+    caseId,
+    subject: { type: first.reportedType, id: first.reportedId },
+  });
+
+  const enforcedAction = primaryAction(outcomes.map((outcome) => outcome.action));
+
+  let updated = 0;
+  for (const report of reports) {
+    if (await applyToReport(report, decision, enforcedAction)) updated += 1;
+  }
+
+  logger.info('[CrowdSource] decision applied', {
+      caseId,
+      decisionId: decision.id,
+      revision: decision.revision,
+      outcome: decision.outcome,
+      reportsMatched: reports.length,
+      reportsUpdated: updated,
+      actions: outcomes.map((outcome) => `${outcome.action}:${outcome.result}`).join(','),
+    });
+}

--- a/packages/backend/src/moderation/delivery-worker.ts
+++ b/packages/backend/src/moderation/delivery-worker.ts
@@ -1,0 +1,164 @@
+import { ReportModel, type LeanReport } from '../models/Report';
+import { getCrowdSourceClient } from './client';
+import { buildModerationReportInput } from './evidence-snapshot';
+import type { ModerationOutboxEvent } from './outbox';
+import { logger } from '../utils/logger';
+
+/**
+ * Delivering a stored report to CrowdSource.
+ *
+ * Everything hard about this is handled elsewhere and the shape of this file is
+ * what is left over: the SDK owns the envelope, the idempotency key, the timeouts,
+ * the per-attempt retries and the classification of failures; the outbox owns
+ * durability, backoff and dead-lettering. What remains is to describe the
+ * material, hand it over, and write down what came back.
+ *
+ * The failures are as important as the success:
+ *
+ * - **Nowhere to send it.** The integration is not configured. The event stays
+ *   pending, untouched, and delivers when it is — a delay, never a loss.
+ * - **The object is gone, or is not somebody's published work.** Deleted between
+ *   the report and its delivery, or a built-in skill. There is nothing for a jury
+ *   to review, so the report closes locally instead of retrying for days.
+ * - **The type has no provider.** Unreachable by design — such a report never gets
+ *   a delivery event — so an event that reaches it is a defect and is dead-lettered
+ *   rather than retried or filed as a state.
+ * - **Anything else** is the SDK's `retryable` to answer, and the outbox obeys it.
+ */
+
+/** Thrown when there is nowhere to deliver to yet. Always retryable. */
+export class CrowdSourceUnavailableError extends Error {
+  readonly retryable = true;
+
+  constructor() {
+    super('The CrowdSource integration is not configured in this deployment.');
+    this.name = 'CrowdSourceUnavailableError';
+  }
+}
+
+/**
+ * A delivery event that cannot become deliverable.
+ *
+ * `retryable: false` is the field the outbox reads to dead-letter instead of
+ * backing off — the same contract every error from `@oxyhq/crowdsource` answers.
+ */
+export class ModerationDeliveryRejectedError extends Error {
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModerationDeliveryRejectedError';
+  }
+}
+
+/** Close a report there is genuinely nothing left to do about. */
+async function closeUndeliverable(reportId: string, reason: string): Promise<void> {
+  await ReportModel.updateOne(
+    { _id: reportId },
+    { $set: { localStatus: 'closed', localStatusReason: reason } },
+  );
+}
+
+/** Handle one `report.submit` outbox event. */
+export async function deliverReportOutboxEvent(
+  event: ModerationOutboxEvent,
+): Promise<void> {
+  const reportId = event.payload.reportId;
+  if (reportId === undefined) {
+    throw new ModerationDeliveryRejectedError('A report.submit event carried no reportId.');
+  }
+
+  const report = await ReportModel.findById(reportId).lean<LeanReport | null>();
+  if (!report) {
+    /**
+     * The report is gone but its delivery event survived. Nothing to deliver and
+     * nothing to fix, so the event completes — retrying would keep looking for a
+     * row that no longer exists.
+     */
+    logger.warn('[CrowdSource] delivery event has no report', { reportId });
+    return;
+  }
+
+  const crowdsource = getCrowdSourceClient();
+  if (!crowdsource) throw new CrowdSourceUnavailableError();
+
+  /**
+   * A `ModerationSubjectUnsupportedError` from here is NOT caught. It carries
+   * `retryable: false`, so the outbox dead-letters the event — which is the right
+   * channel for a defect that needs a human. Catching it and writing a local state
+   * would put the report somewhere nothing alerts on.
+   */
+  const input = await buildModerationReportInput({
+    id: String(report._id),
+    reportedType: report.reportedType,
+    reportedId: report.reportedId,
+    reporter: report.reporter,
+    categories: report.categories,
+    details: report.details,
+    createdAt: report.createdAt,
+  });
+
+  if (input === null) {
+    await closeUndeliverable(
+      reportId,
+      'The reported content is no longer available for review, so there is nothing to review.',
+    );
+    logger.info('[CrowdSource] report closed: content unavailable', {
+      reportId,
+      result: 'content_unavailable',
+    });
+    return;
+  }
+
+  let receipt: Awaited<ReturnType<typeof crowdsource.reports.create>>;
+  try {
+    receipt = await crowdsource.reports.create(input.reportInput);
+  } catch (error: unknown) {
+    /**
+     * The failure is visible on the report itself, not only in the outbox row.
+     * `delivery_failed` is what a reporter's receipt and any operational sweep both
+     * read; leaving the report at `queued` while the outbox quietly backed off
+     * would hide the problem in a collection nobody looks at. Written before
+     * rethrowing so the outbox still applies its own backoff or dead-letters the
+     * event.
+     */
+    await ReportModel.updateOne(
+      { _id: reportId },
+      {
+        $set: {
+          localStatus: 'delivery_failed',
+          lastDeliveryError: (error instanceof Error
+            ? error.message
+            : String(error)
+          ).slice(0, 2_000),
+        },
+      },
+    );
+    logger.warn('[CrowdSource] report delivery failed', {
+      reportId,
+      result: 'failed',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  await ReportModel.updateOne(
+    { _id: reportId },
+    {
+      $set: {
+        localStatus: 'submitted',
+        crowdSourceReportId: receipt.reportId,
+        crowdSourceCaseId: receipt.caseId,
+        crowdSourceMerged: receipt.merged,
+        contentSnapshotHash: input.snapshotHash,
+        submittedAt: new Date(),
+      },
+      $unset: { lastDeliveryError: '', localStatusReason: '' },
+    },
+  );
+  logger.info('[CrowdSource] report delivered', {
+    reportId,
+    caseId: receipt.caseId,
+    result: receipt.merged ? 'merged' : 'delivered',
+  });
+}

--- a/packages/backend/src/moderation/dispatcher.ts
+++ b/packages/backend/src/moderation/dispatcher.ts
@@ -1,0 +1,142 @@
+import { crowdSourceConfig } from './config';
+import { applyDecisionOutboxEvent } from './decision-worker';
+import { deliverReportOutboxEvent } from './delivery-worker';
+import { dispatchModerationOutbox, type ModerationOutboxEvent } from './outbox';
+import { assertTransactionalTopology } from './topology';
+import { logger } from '../utils/logger';
+
+/**
+ * The loop that drains the moderation outbox.
+ *
+ * A bounded interval, one batch in flight at a time, and an abort signal that
+ * stops claiming new work but lets the event already being handled reach a durable
+ * state.
+ *
+ * It is NOT leader-gated, and that is a property of the claim rather than an
+ * oversight. Every event is taken under a lease with an owner check, so N tasks
+ * draining the same collection simply share the work — and a task dying
+ * mid-delivery has its lease expire and its event reclaimed, which a single leader
+ * would not give us.
+ *
+ * `CROWDSOURCE_ENABLED` gates the LOOP, never the durable record. Reports taken
+ * while the integration is off keep their outbox rows and deliver when it is
+ * switched on; running the loop instead would count attempts against a deployment
+ * that has nowhere to send anything and dead-letter the backlog it was supposed to
+ * preserve.
+ */
+
+/** Route an event to the worker that owns its kind. */
+export async function handleModerationOutboxEvent(
+  event: ModerationOutboxEvent,
+): Promise<void> {
+  switch (event.kind) {
+    case 'report.submit':
+      await deliverReportOutboxEvent(event);
+      return;
+    case 'decision.apply':
+      await applyDecisionOutboxEvent(event);
+      return;
+  }
+}
+
+export class ModerationOutboxDispatcher {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private abortController: AbortController | null = null;
+  private running = false;
+  private starting: Promise<void> | null = null;
+
+  /**
+   * Begin draining, once the deployment has been shown able to do it safely.
+   *
+   * Synchronous to the caller because `index.ts` starts a dozen subsystems in a
+   * row and none of them blocks boot. The topology check runs in the background
+   * and the interval only starts if it passes — a deployment that cannot run
+   * transactions gets one loud error line and no dispatcher, rather than a loop
+   * that claims events it can never complete.
+   */
+  start(): void {
+    if (this.running || this.starting) return;
+    const config = crowdSourceConfig();
+    if (!config.enabled) {
+      logger.info('[CrowdSource] outbox dispatcher not started: integration disabled');
+      return;
+    }
+
+    this.starting = assertTransactionalTopology()
+      .then((topology) => {
+        if (!topology.ok) {
+          logger.error('[CrowdSource] outbox dispatcher not started: MongoDB cannot run transactions', { reason: topology.reason });
+          return;
+        }
+        this.beginTicking();
+      })
+      .catch((error: unknown) => {
+        logger.error('[CrowdSource] outbox dispatcher failed to start', { error: error instanceof Error ? error.message : String(error) });
+      })
+      .finally(() => {
+        this.starting = null;
+      });
+  }
+
+  private beginTicking(): void {
+    const config = crowdSourceConfig();
+    this.running = true;
+    this.abortController = new AbortController();
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, config.outboxPollIntervalMs);
+    this.timer.unref?.();
+    logger.info('[CrowdSource] outbox dispatcher started', {
+        intervalMs: config.outboxPollIntervalMs,
+        batchSize: config.outboxBatchSize,
+        enforcementMode: config.enforcementMode,
+      });
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    // A stop that raced the topology check must not leave a loop starting behind
+    // it — awaiting the start settles that ordering.
+    await this.starting;
+    this.running = false;
+    const controller = this.abortController;
+    controller?.abort();
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.inFlight;
+    if (this.abortController === controller) {
+      this.abortController = null;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.running) return;
+    if (this.inFlight) return this.inFlight;
+    const work = dispatchModerationOutbox({
+      handler: handleModerationOutboxEvent,
+      batchSize: crowdSourceConfig().outboxBatchSize,
+      signal: this.abortController?.signal,
+    })
+      .then(({ processed, failed, deadLettered }) => {
+        if (processed > 0 || failed > 0) {
+          logger.info('[CrowdSource] outbox batch complete', { processed, failed, deadLettered });
+        }
+      })
+      .catch((error: unknown) => {
+        // Claim/database failures happen outside the per-event retry block. Keep
+        // the interval alive and avoid an unhandled rejection.
+        logger.error('[CrowdSource] outbox tick failed', { error: error instanceof Error ? error.message : String(error) });
+      })
+      .finally(() => {
+        if (this.inFlight === work) this.inFlight = null;
+      });
+    this.inFlight = work;
+    return work;
+  }
+}
+
+export const moderationOutboxDispatcher = new ModerationOutboxDispatcher();

--- a/packages/backend/src/moderation/enforcement-plan.test.ts
+++ b/packages/backend/src/moderation/enforcement-plan.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'bun:test';
+import { decisionFixture } from '@oxyhq/crowdsource-testing';
+import {
+  RECOMMENDED_ACTIONS,
+  type Decision,
+  type RecommendedAction,
+} from '@oxyhq/crowdsource-contracts';
+import { planEnforcement } from './enforcement-plan';
+import {
+  MODERATION_ENFORCEMENT_ACTIONS,
+  type ModerationEnforcementAction,
+} from '../models/ModerationEnforcement';
+
+/**
+ * `planEnforcement` is pure, so it can be pinned as a table. That is the whole
+ * reason it is pure: the alternative is proving these mappings through a database,
+ * a webhook and an enforcement run, which tests the plumbing and not the policy.
+ */
+
+function withRecommendations(
+  actions: readonly RecommendedAction[],
+  outcome: Decision['outcome'] = 'violation',
+): Decision {
+  return {
+    ...decisionFixture({ outcome }),
+    recommendedActions: actions.map((action) => ({ action })),
+  };
+}
+
+describe('planEnforcement', () => {
+  describe('recommendation mapping', () => {
+    const cases: ReadonlyArray<[RecommendedAction, ModerationEnforcementAction]> = [
+      ['remove', 'restrict'],
+      ['remove_or_restrict', 'restrict'],
+      ['hide', 'restrict'],
+      ['reduce_distribution', 'manual_review'],
+      ['allow', 'none'],
+      ['no_action', 'none'],
+      ['no_global_effect', 'none'],
+      ['restore', 'restore'],
+      ['suspend_user', 'manual_review'],
+      ['freeze_transaction', 'manual_review'],
+      ['request_changes', 'manual_review'],
+      ['request_more_context', 'manual_review'],
+      ['hold', 'manual_review'],
+      ['local_manual_review', 'manual_review'],
+      ['keep_restricted_temporarily', 'manual_review'],
+      ['escalate', 'manual_review'],
+      ['specialist_queue', 'manual_review'],
+      ['legal_queue', 'manual_review'],
+      ['safety_queue', 'manual_review'],
+    ];
+
+    for (const [recommendation, expected] of cases) {
+      it(`maps ${recommendation} to ${expected}`, () => {
+        const plan = planEnforcement(withRecommendations([recommendation]));
+        expect(plan.map((entry) => entry.action)).toEqual([expected]);
+        expect(plan[0].recommendedAction).toBe(recommendation);
+      });
+    }
+
+    /**
+     * The three that are deliberately NOT folded into an effect Alia does have.
+     *
+     * Alia renders no content warning, spoiler or age gate anywhere. `demote` is
+     * the nearest available lever and using it would record "we warned the user"
+     * when what happened was "we made it slightly harder to find". If somebody
+     * later gives Alia a real warning surface, this test is what tells them to
+     * revisit the mapping rather than discover it in an audit.
+     */
+    for (const recommendation of [
+      'label',
+      'allow_with_label',
+      'age_gate',
+      'reduce_distribution',
+    ] as const) {
+      it(`refuses to upgrade ${recommendation} into a takedown`, () => {
+        const plan = planEnforcement(withRecommendations([recommendation]));
+        expect(plan.map((entry) => entry.action)).toEqual(['manual_review']);
+        // The danger on this platform is the opposite of understating: the only
+        // effect Syra HAS is removal from the catalog, which is far stronger than
+        // any of these four asked for.
+        expect(plan.map((entry) => entry.action)).not.toContain('restrict');
+      });
+    }
+
+    it('covers every recommendation the contract can send', () => {
+      for (const action of RECOMMENDED_ACTIONS) {
+        const plan = planEnforcement(withRecommendations([action]));
+        expect(plan.length).toBeGreaterThan(0);
+        for (const entry of plan) {
+          expect(MODERATION_ENFORCEMENT_ACTIONS).toContain(entry.action);
+        }
+      }
+    });
+  });
+
+  describe('collapsing', () => {
+    it('lets restrict absorb a bare allow — one effect happened', () => {
+      const plan = planEnforcement(withRecommendations(['remove', 'allow']));
+      expect(plan.map((entry) => entry.action)).toEqual(['restrict']);
+    });
+
+    it('keeps manual_review alongside a real effect', () => {
+      const plan = planEnforcement(withRecommendations(['remove', 'suspend_user']));
+      expect(plan.map((entry) => entry.action).sort()).toEqual([
+        'manual_review',
+        'restrict',
+      ]);
+    });
+
+    it('drops none when anything else is planned', () => {
+      const plan = planEnforcement(withRecommendations(['allow', 'suspend_user']));
+      expect(plan.map((entry) => entry.action)).toEqual(['manual_review']);
+    });
+
+    it('never returns an empty plan', () => {
+      const plan = planEnforcement(withRecommendations(['allow']));
+      expect(plan).toHaveLength(1);
+      expect(plan[0].action).toBe('none');
+    });
+  });
+
+  describe('no_violation always restores', () => {
+    /**
+     * The failure this guards is very easy to ship and impossible to see. A
+     * correction is a revision whose outcome is `no_violation` and whose
+     * recommendation is frequently `no_action` — "take no NEW action", not "leave
+     * what you already did in place". Mapping it straight through plans `none`,
+     * and the agent an earlier revision unpublished stays unpublished forever with
+     * no error anywhere.
+     */
+    it('adds a restore even when the recommendation is no_action', () => {
+      const plan = planEnforcement(withRecommendations(['no_action'], 'no_violation'));
+      expect(plan.map((entry) => entry.action)).toContain('restore');
+    });
+
+    it('adds a restore even when the recommendation is allow', () => {
+      const plan = planEnforcement(withRecommendations(['allow'], 'no_violation'));
+      expect(plan.map((entry) => entry.action)).toContain('restore');
+    });
+
+    it('does not duplicate an explicit restore', () => {
+      const plan = planEnforcement(withRecommendations(['restore'], 'no_violation'));
+      expect(plan.filter((entry) => entry.action === 'restore')).toHaveLength(1);
+    });
+
+    it('restores when the decision recommended nothing at all', () => {
+      const decision: Decision = {
+        ...decisionFixture({ outcome: 'no_violation' }),
+        recommendedActions: [],
+      };
+      expect(planEnforcement(decision).map((entry) => entry.action)).toEqual(['restore']);
+    });
+  });
+
+  describe('severity fallback for a violation with no recommendation', () => {
+    function violationWithSeverity(severity: 'low' | 'medium' | 'high' | 'critical'): Decision {
+      const base = decisionFixture({ outcome: 'violation' });
+      return {
+        ...base,
+        recommendedActions: [],
+        findings: base.findings.map((finding) => ({ ...finding, severity })),
+      };
+    }
+
+    it('restricts on high', () => {
+      expect(planEnforcement(violationWithSeverity('high')).map((e) => e.action)).toEqual([
+        'restrict',
+      ]);
+    });
+
+    /**
+     * No middle lever exists, so `medium` asks a person rather than reaching for
+     * the only tool available, which is removal from the catalog.
+     */
+    it('asks a human on medium rather than removing', () => {
+      expect(planEnforcement(violationWithSeverity('medium')).map((e) => e.action)).toEqual([
+        'manual_review',
+      ]);
+    });
+
+    /**
+     * Both ends go to a human, and for different reasons: `low` is not worth
+     * unpublishing somebody's work over, and `critical` is specialist/legal
+     * territory that a webhook-driven removal is not.
+     */
+    it('asks a human on low', () => {
+      expect(planEnforcement(violationWithSeverity('low')).map((e) => e.action)).toEqual([
+        'manual_review',
+      ]);
+    });
+
+    /**
+     * The copyright boundary, asserted rather than assumed: no severity, no
+     * outcome and no recommendation may ever produce something that looks like a
+     * DMCA strike. `restrict` touches `isAvailable` only and is reversible.
+     */
+    it('never plans an action outside the four Syra can reverse', () => {
+      for (const severity of ['low', 'medium', 'high', 'critical'] as const) {
+        for (const entry of planEnforcement(violationWithSeverity(severity))) {
+          expect(MODERATION_ENFORCEMENT_ACTIONS).toContain(entry.action);
+        }
+      }
+    });
+
+    it('asks a human on critical rather than removing automatically', () => {
+      expect(
+        planEnforcement(violationWithSeverity('critical')).map((e) => e.action),
+      ).toEqual(['manual_review']);
+    });
+
+    it('asks a human when a violation carries no finding this version understands', () => {
+      const decision: Decision = {
+        ...decisionFixture({ outcome: 'violation' }),
+        recommendedActions: [],
+        findings: [],
+      };
+      expect(planEnforcement(decision).map((e) => e.action)).toEqual(['manual_review']);
+    });
+  });
+
+  describe('outcomes with no recommendation', () => {
+    function bare(outcome: Decision['outcome']): Decision {
+      return { ...decisionFixture({ outcome: 'no_violation' }), outcome, recommendedActions: [] };
+    }
+
+    /**
+     * Absence of consensus is neither guilt nor innocence. None of these may
+     * produce an effect on their own, and none may look like `no_violation`.
+     */
+    for (const outcome of ['insufficient_context', 'inconclusive', 'escalated'] as const) {
+      it(`asks a human on ${outcome} and changes nothing`, () => {
+        const plan = planEnforcement(bare(outcome));
+        expect(plan.map((entry) => entry.action)).toEqual(['manual_review']);
+        expect(plan.map((entry) => entry.action)).not.toContain('restore');
+        expect(plan.map((entry) => entry.action)).not.toContain('restrict');
+      });
+    }
+
+    for (const outcome of ['content_unavailable', 'duplicate'] as const) {
+      it(`plans an explicit none on ${outcome}`, () => {
+        expect(planEnforcement(bare(outcome)).map((entry) => entry.action)).toEqual(['none']);
+      });
+    }
+
+    /**
+     * §10.11: a newer CrowdSource must not break an older client. The safe reading
+     * of an outcome this version has never seen is a human, never a default effect.
+     */
+    it('asks a human for an outcome this version does not know', () => {
+      const decision: Decision = {
+        ...decisionFixture(),
+        recommendedActions: [],
+        outcome: 'a_future_outcome' as Decision['outcome'],
+      };
+      expect(planEnforcement(decision).map((entry) => entry.action)).toEqual([
+        'manual_review',
+      ]);
+    });
+  });
+});

--- a/packages/backend/src/moderation/enforcement-plan.ts
+++ b/packages/backend/src/moderation/enforcement-plan.ts
@@ -1,0 +1,275 @@
+import type { Decision, RecommendedAction, Severity } from '@oxyhq/crowdsource-contracts';
+import type { ModerationEnforcementAction } from '../models/ModerationEnforcement';
+
+/**
+ * Deciding what Syra will do about a decision — and nothing else.
+ *
+ * Pure: no database, no clock, no configuration. A decision in, a plan out. That
+ * is what makes the mapping testable as a table rather than as an integration
+ * scenario, and it is why `observe` mode is a real audit rather than a comment —
+ * the plan is computed identically in every mode and only its EXECUTION is gated.
+ *
+ * ## Syra maps recommendations, not findings
+ *
+ * The jury classified the material and the consensus engine turned that into a
+ * recommendation under a versioned policy (§7.6). An application that re-derived
+ * its action from raw severity would be quietly re-deciding the case with a
+ * second, unversioned policy of its own — and the two would diverge the first time
+ * CrowdSource's policy was updated. Severity is a fallback only, for a `violation`
+ * that arrives with no recommendation at all, because a violation Syra did nothing
+ * about would be worse than a mapped one.
+ *
+ * ## Syra has ONE content lever, and that shapes everything below
+ *
+ * `restrict` is the whole of it: a track or album leaves the catalog
+ * (`isAvailable: false`), a playlist or house stops being public (`visibility`),
+ * a room changes lifecycle `status`. `restore` puts back exactly what was there,
+ * read off the row that changed it.
+ *
+ * **`restrict` is deliberately NOT the copyright takedown.** That path also sets
+ * `copyrightRemoved`, feeds `strikeService`, and is irreversible because a DMCA
+ * strike carries statutory consequences. Community moderation never touches it,
+ * so a jury can never manufacture a strike and every action here can be undone.
+ *
+ * **There is no content-warning action and no promotion action, and adding
+ * either would be a lie.** Syra renders no warning, no spoiler and no age gate,
+ * and has no editorial promotion flag to withdraw. The tempting move is to fold
+ * `label`, `allow_with_label`, `age_gate` and `reduce_distribution` into the
+ * nearest available effect — but here the nearest available effect is removal
+ * from the catalog, which is enormously STRONGER than any of them. §7.6 lets an
+ * application refuse or adapt a recommendation provided it records what it did,
+ * so all four become `manual_review`: recorded, visible, and honest about needing
+ * a person. A declined recommendation must never look like one that never
+ * arrived — and on this platform it must never be silently upgraded into a
+ * takedown either.
+ *
+ * `suspend_user` is Oxy's to carry out, not Syra's; `legal_queue` needs a human.
+ * Same treatment, same reason.
+ */
+
+export interface PlannedEnforcementAction {
+  readonly action: ModerationEnforcementAction;
+  /** Why, in words an operator reads. Never reported material. */
+  readonly reason: string;
+  /** The recommendation this came from, when it came from one. */
+  readonly recommendedAction?: RecommendedAction;
+}
+
+/** What a recommended action becomes in Syra. */
+const RECOMMENDATION_TO_ACTION: Readonly<
+  Record<RecommendedAction, ModerationEnforcementAction>
+> = Object.freeze({
+  remove: 'restrict',
+  remove_or_restrict: 'restrict',
+  hide: 'restrict',
+
+
+  allow: 'none',
+  no_action: 'none',
+  no_global_effect: 'none',
+  restore: 'restore',
+
+  // Syra can display no warning and has no distribution dial. Recorded for a
+  // human rather than silently UPGRADED into the only effect it does have, which
+  // is removal from the catalog.
+  label: 'manual_review',
+  allow_with_label: 'manual_review',
+  age_gate: 'manual_review',
+  reduce_distribution: 'manual_review',
+
+  // Syra holds none of the levers these ask for. Recorded, queued for a human.
+  suspend_user: 'manual_review',
+  freeze_transaction: 'manual_review',
+  request_changes: 'manual_review',
+  request_more_context: 'manual_review',
+  hold: 'manual_review',
+  local_manual_review: 'manual_review',
+  keep_restricted_temporarily: 'manual_review',
+  escalate: 'manual_review',
+  specialist_queue: 'manual_review',
+  legal_queue: 'manual_review',
+  safety_queue: 'manual_review',
+});
+
+/**
+ * The action a violation gets when the decision recommended nothing.
+ *
+ * Severity only, and deliberately cautious at both ends. A `low`-severity
+ * violation with no recommendation is not something to remove somebody's work
+ * over, so it goes to a human; `critical` goes to a human too, because §7.5 routes
+ * that material to a specialist team under legal protocol and an automatic removal
+ * driven by a webhook is not that. The difference between them is a policy decision
+ * with legal weight, and a mapping table is the wrong place to make it.
+ */
+const SEVERITY_FALLBACK: Readonly<Record<Severity, ModerationEnforcementAction>> =
+  Object.freeze({
+    critical: 'manual_review',
+    high: 'restrict',
+    // No middle lever exists, so anything below `high` asks a person rather
+    // than reaching for the only tool available, which is removal.
+    medium: 'manual_review',
+    low: 'manual_review',
+  });
+
+const SEVERITY_ORDER: readonly Severity[] = ['low', 'medium', 'high', 'critical'];
+
+function highestSeverity(decision: Decision): Severity | undefined {
+  let highest: Severity | undefined;
+  for (const finding of decision.findings) {
+    if (
+      highest === undefined ||
+      SEVERITY_ORDER.indexOf(finding.severity) > SEVERITY_ORDER.indexOf(highest)
+    ) {
+      highest = finding.severity;
+    }
+  }
+  return highest;
+}
+
+/**
+ * `no_violation` always carries a restore, whatever it recommended.
+ *
+ * This exists because of a failure that is very easy to ship and very hard to see.
+ * A correction is a new revision whose outcome is `no_violation`, and its
+ * recommendation is frequently `no_action` — which is CrowdSource saying "take no
+ * NEW action", not "leave what you already did in place". Mapping that straight
+ * through plans `none`, and the playlist an earlier revision hid stays
+ * hidden forever: the appeal succeeded, the case says the listing was fine,
+ * and nothing in Syra ever puts it back. No error, no log line, no failing test
+ * anywhere else.
+ *
+ * §7.6 lists `allow`, `restore` and `no_action` together as the application's
+ * options for `no_violation` precisely because choosing between them needs
+ * knowledge only the application has — whether it did something earlier. So the
+ * plan always includes the restore, and the executor records "there was nothing to
+ * undo" when that is the case, which is evidence rather than a silent no-op.
+ */
+function withRestoreForNoViolation(
+  decision: Decision,
+  planned: readonly PlannedEnforcementAction[],
+): readonly PlannedEnforcementAction[] {
+  if (decision.outcome !== 'no_violation') return planned;
+  if (planned.some((entry) => entry.action === 'restore')) return planned;
+  return [
+    ...planned,
+    { action: 'restore', reason: 'No violation: undo any earlier enforcement' },
+  ];
+}
+
+/**
+ * Collapse a plan to the actions that can coexist.
+ *
+ * A decision may recommend both removal and a note for a human; recording
+ * `restrict` alongside `none` or `restore` would claim two contradictory effects
+ * where one happened. `restrict` therefore absorbs `none` and `restore`, and
+ * `none` never survives alongside anything else. `manual_review` always survives —
+ * it is a note for a human, and dropping it because something else was also done
+ * is how a `suspend_user` recommendation gets lost.
+ */
+function collapse(
+  actions: readonly PlannedEnforcementAction[],
+): PlannedEnforcementAction[] {
+  const byAction = new Map<ModerationEnforcementAction, PlannedEnforcementAction>();
+  for (const planned of actions) {
+    if (!byAction.has(planned.action)) byAction.set(planned.action, planned);
+  }
+
+  if (byAction.has('restrict')) {
+    byAction.delete('none');
+    byAction.delete('restore');
+  }
+  if (byAction.size > 1) byAction.delete('none');
+
+  return Array.from(byAction.values());
+}
+
+/**
+ * What Syra will do about this decision.
+ *
+ * Never empty: a decision that produces no action produces an explicit `none`,
+ * because a row saying "we decided to do nothing, and why" is evidence and an
+ * absent row is a question.
+ */
+export function planEnforcement(decision: Decision): PlannedEnforcementAction[] {
+  const fromRecommendations = decision.recommendedActions.map(
+    (recommended): PlannedEnforcementAction => ({
+      action: RECOMMENDATION_TO_ACTION[recommended.action] ?? 'manual_review',
+      reason: `CrowdSource recommended ${recommended.action}`,
+      recommendedAction: recommended.action,
+    }),
+  );
+
+  if (fromRecommendations.length > 0) {
+    const collapsed = collapse(withRestoreForNoViolation(decision, fromRecommendations));
+    return collapsed.length > 0
+      ? collapsed
+      : [{ action: 'none', reason: 'No recommended action maps to a Syra effect' }];
+  }
+
+  switch (decision.outcome) {
+    case 'violation': {
+      const severity = highestSeverity(decision);
+      /**
+       * A `violation` with no findings cannot happen — the contract refuses it —
+       * so an absent severity here means a newer CrowdSource sent something this
+       * code has not seen. A human looks at it rather than a default removing
+       * somebody's work from the catalog.
+       */
+      if (severity === undefined) {
+        return [
+          {
+            action: 'manual_review',
+            reason: 'Violation carried no finding severity this version understands',
+          },
+        ];
+      }
+      return [
+        {
+          action: SEVERITY_FALLBACK[severity],
+          reason: `Violation with no recommended action, highest severity ${severity}`,
+        },
+      ];
+    }
+
+    case 'no_violation':
+      /**
+       * A restore, always planned — even when nothing was enforced. The executor
+       * records it as not applied with the reason, which is how "we checked and
+       * there was nothing to undo" is distinguishable from "we never looked".
+       */
+      return [{ action: 'restore', reason: 'No violation: undo any earlier enforcement' }];
+
+    case 'insufficient_context':
+    case 'inconclusive':
+    case 'escalated':
+      /**
+       * §7.6 offers `keep_restricted_temporarily`, `escalate` and internal review
+       * for these. None of them is "remove", and none is "it was fine": absence of
+       * consensus is neither guilt nor innocence, so Syra changes nothing on its
+       * own and asks a human.
+       */
+      return [
+        {
+          action: 'manual_review',
+          reason: `Outcome ${decision.outcome}: no automatic action, internal review`,
+        },
+      ];
+
+    case 'content_unavailable':
+    case 'duplicate':
+      return [{ action: 'none', reason: `Outcome ${decision.outcome}: nothing to enforce` }];
+
+    default:
+      /**
+       * An outcome §9.6 does not currently define. §10.11 requires a newer server
+       * not to break an older client, and the safe reading of an unknown outcome
+       * is a human, never a default effect.
+       */
+      return [
+        {
+          action: 'manual_review',
+          reason: 'Decision outcome not recognised by this version of Syra',
+        },
+      ];
+  }
+}

--- a/packages/backend/src/moderation/enforcement-service.ts
+++ b/packages/backend/src/moderation/enforcement-service.ts
@@ -1,0 +1,409 @@
+import mongoose from 'mongoose';
+import type { Decision } from '@oxyhq/crowdsource-contracts';
+import { PlaylistVisibility } from '@syra/shared-types';
+import { PlaylistModel } from '../models/Playlist';
+import HouseModel from '../models/House';
+import RoomModel from '../models/Room';
+import { TrackModel } from '../models/Track';
+import { ReportedType } from '../models/Report';
+import {
+  ModerationEnforcementModel,
+  type IModerationEnforcement,
+  type ModerationEnforcementAction,
+  type ModerationPreviousState,
+} from '../models/ModerationEnforcement';
+import { crowdSourceConfig, type ModerationEnforcementMode } from './config';
+import { planEnforcement, type PlannedEnforcementAction } from './enforcement-plan';
+import { logger } from '../utils/logger';
+
+/**
+ * Carrying out a decision, exactly once.
+ *
+ * **Once.** Appendix D's key is `decisionId + revision + action`, and the unique
+ * index on `ModerationEnforcement` is that key. Each action CLAIMS its row before
+ * doing anything; a second attempt — a redelivered webhook, a reclaimed outbox
+ * lease, a manual replay — loses the insert and does nothing.
+ *
+ * **Reversibly.** Every action that changes state records what the state WAS, and
+ * a reversal puts that back. A playlist that was already private before anyone
+ * reported it must not be made public by a correction.
+ *
+ * **And never as a copyright strike.** Nothing here touches `copyrightRemoved` or
+ * `strikeService`. A DMCA takedown carries statutory consequences and is
+ * irreversible by design; community moderation reaches `isAvailable`,
+ * `visibility` and `status` only, so a jury can never manufacture a strike and
+ * every action here can be undone.
+ *
+ * `observe` mode runs all of this except the effect: the plan, the claim and the
+ * record are identical to production, so the mode proves exactly what will happen
+ * when it is switched off.
+ */
+
+export interface EnforcementSubject {
+  /** Syra's own noun (`playlist`, `house`, `artist`, `track`, `room`). */
+  type: string;
+  id: string;
+}
+
+export interface EnforcementOutcome {
+  action: ModerationEnforcementAction;
+  /**
+   * `applied` — the effect happened. `recorded` — claimed and deliberately not
+   * carried out (observe/manual mode, or nothing to do). `duplicate` — another
+   * delivery of this same decision revision already handled it.
+   */
+  result: 'applied' | 'recorded' | 'duplicate';
+}
+
+type EffectResult =
+  | { changed: true; previousState: ModerationPreviousState }
+  | { changed: false; reason: string };
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    Number((error as { code?: unknown }).code) === 11000
+  );
+}
+
+/** The most recent APPLIED action of a kind against this subject. */
+async function lastApplied(
+  subject: EnforcementSubject,
+  action: ModerationEnforcementAction,
+): Promise<Pick<IModerationEnforcement, 'previousState'> | null> {
+  return await ModerationEnforcementModel.findOne({
+    subjectType: subject.type,
+    subjectId: subject.id,
+    action,
+    applied: true,
+  })
+    .sort({ createdAt: -1 })
+    .lean<Pick<IModerationEnforcement, 'previousState'> | null>();
+}
+
+/**
+ * Take one object out of public reach, or explain why there was nothing to do.
+ *
+ * Each branch touches the field that noun's own read path already gates on, so a
+ * restriction removes the object from listing, search and playback at once with
+ * no query anywhere else to edit:
+ *
+ * - a track leaves the catalog through `isAvailable`, which is what
+ *   `playableTrackFilter` and `isTrackPlayable` both check;
+ * - a playlist stops being public through `visibility`, which `canViewPlaylist`
+ *   is the single authority on;
+ * - a house the same way, through its discovery axis;
+ * - a room is archived, which is the only lever a room has that does not end a
+ *   live session out from under the people in it.
+ *
+ * **An artist has no branch**, and that is deliberate rather than missing. The
+ * levers an artist profile has — `terminated`, `uploadsDisabled` — belong to the
+ * DMCA repeat-infringer path, and reaching for them here would let a community
+ * decision produce something indistinguishable from a copyright termination
+ * while carrying none of its process. A decision about an artist profile is
+ * recorded and handed to a human.
+ */
+async function restrict(subject: EnforcementSubject): Promise<EffectResult> {
+  if (!mongoose.isValidObjectId(subject.id)) {
+    return { changed: false, reason: 'The reported object no longer exists' };
+  }
+
+  switch (subject.type) {
+    case ReportedType.TRACK: {
+      const track = await TrackModel.findById(subject.id)
+        .select('isAvailable')
+        .lean<{ isAvailable?: boolean } | null>();
+      if (!track) return { changed: false, reason: 'The reported track no longer exists' };
+      if (track.isAvailable === false) {
+        return { changed: false, reason: 'The track was already out of the catalog' };
+      }
+      // `copyrightRemoved` is deliberately untouched — see the file header.
+      await TrackModel.updateOne({ _id: subject.id }, { $set: { isAvailable: false } });
+      return { changed: true, previousState: { isAvailable: true } };
+    }
+
+    case ReportedType.PLAYLIST: {
+      const playlist = await PlaylistModel.findById(subject.id)
+        .select('visibility')
+        .lean<{ visibility?: string } | null>();
+      if (!playlist) {
+        return { changed: false, reason: 'The reported playlist no longer exists' };
+      }
+      if (playlist.visibility !== PlaylistVisibility.PUBLIC) {
+        return { changed: false, reason: 'The playlist was already not public' };
+      }
+      await PlaylistModel.updateOne(
+        { _id: subject.id },
+        { $set: { visibility: PlaylistVisibility.PRIVATE } },
+      );
+      return { changed: true, previousState: { visibility: PlaylistVisibility.PUBLIC } };
+    }
+
+    case ReportedType.HOUSE: {
+      const house = await HouseModel.findById(subject.id)
+        .select('visibility')
+        .lean<{ visibility?: { discovery?: string } } | null>();
+      if (!house) return { changed: false, reason: 'The reported house no longer exists' };
+      const discovery = house.visibility?.discovery;
+      if (discovery === 'hidden') {
+        return { changed: false, reason: 'The house was already hidden' };
+      }
+      await HouseModel.updateOne(
+        { _id: subject.id },
+        { $set: { 'visibility.discovery': 'hidden' } },
+      );
+      return {
+        changed: true,
+        previousState: { visibility: discovery ?? 'public' },
+      };
+    }
+
+    case ReportedType.ROOM: {
+      const room = await RoomModel.findById(subject.id)
+        .select('archived')
+        .lean<{ archived?: boolean } | null>();
+      if (!room) return { changed: false, reason: 'The reported room no longer exists' };
+      if (room.archived === true) {
+        return { changed: false, reason: 'The room was already archived' };
+      }
+      await RoomModel.updateOne({ _id: subject.id }, { $set: { archived: true } });
+      return { changed: true, previousState: { status: 'unarchived' } };
+    }
+
+    default:
+      return {
+        changed: false,
+        reason: `Syra has no reversible restriction for a reported ${subject.type}`,
+      };
+  }
+}
+
+/**
+ * Put back exactly what a previous revision changed.
+ *
+ * Read off the enforcement row that made the change rather than reset to a
+ * hardcoded default: a playlist that was private before anybody reported it must
+ * not become public because a correction arrived.
+ */
+async function restore(subject: EnforcementSubject): Promise<EffectResult> {
+  const restriction = await lastApplied(subject, 'restrict');
+  if (!restriction?.previousState) {
+    return { changed: false, reason: 'There was no earlier restriction to undo' };
+  }
+  if (!mongoose.isValidObjectId(subject.id)) {
+    return { changed: false, reason: 'The reported object no longer exists' };
+  }
+  const previous = restriction.previousState;
+
+  switch (subject.type) {
+    case ReportedType.TRACK: {
+      if (previous.isAvailable !== true) {
+        return { changed: false, reason: 'The track was not available before the restriction' };
+      }
+      const result = await TrackModel.updateOne(
+        { _id: subject.id },
+        { $set: { isAvailable: true } },
+      );
+      if (result.matchedCount === 0) {
+        return { changed: false, reason: 'The reported track no longer exists' };
+      }
+      return { changed: true, previousState: { isAvailable: false } };
+    }
+
+    case ReportedType.PLAYLIST: {
+      if (previous.visibility === undefined) {
+        return { changed: false, reason: 'No previous playlist visibility was recorded' };
+      }
+      const result = await PlaylistModel.updateOne(
+        { _id: subject.id },
+        { $set: { visibility: previous.visibility } },
+      );
+      if (result.matchedCount === 0) {
+        return { changed: false, reason: 'The reported playlist no longer exists' };
+      }
+      return { changed: true, previousState: { visibility: PlaylistVisibility.PRIVATE } };
+    }
+
+    case ReportedType.HOUSE: {
+      if (previous.visibility === undefined) {
+        return { changed: false, reason: 'No previous house visibility was recorded' };
+      }
+      const result = await HouseModel.updateOne(
+        { _id: subject.id },
+        { $set: { 'visibility.discovery': previous.visibility } },
+      );
+      if (result.matchedCount === 0) {
+        return { changed: false, reason: 'The reported house no longer exists' };
+      }
+      return { changed: true, previousState: { visibility: 'hidden' } };
+    }
+
+    case ReportedType.ROOM: {
+      const result = await RoomModel.updateOne(
+        { _id: subject.id },
+        { $set: { archived: false } },
+      );
+      if (result.matchedCount === 0) {
+        return { changed: false, reason: 'The reported room no longer exists' };
+      }
+      return { changed: true, previousState: { status: 'archived' } };
+    }
+
+    default:
+      return {
+        changed: false,
+        reason: `Syra has no reversible restriction for a reported ${subject.type}`,
+      };
+  }
+}
+
+async function applyEffect(
+  action: ModerationEnforcementAction,
+  subject: EnforcementSubject,
+): Promise<EffectResult> {
+  switch (action) {
+    case 'none':
+    case 'manual_review':
+      return { changed: false, reason: `Action '${action}' has no effect by definition` };
+    case 'restrict':
+      return await restrict(subject);
+    case 'restore':
+      return await restore(subject);
+  }
+}
+
+/**
+ * Whether the current mode allows this action to actually happen.
+ *
+ * `observe` allows nothing — that is the mode. `manual` allows only `restore`:
+ * putting something back gives it BACK, and holding that behind a human review
+ * means a wrongly-removed track stays removed while somebody reads a queue.
+ * Taking anything down still waits for a person. `automatic` allows the mapped
+ * set.
+ */
+function modeAllows(
+  mode: ModerationEnforcementMode,
+  action: ModerationEnforcementAction,
+): boolean {
+  switch (mode) {
+    case 'observe':
+      return false;
+    case 'manual':
+      return action === 'restore';
+    case 'automatic':
+      return true;
+  }
+}
+
+export interface ApplyDecisionEnforcementInput {
+  decision: Decision;
+  caseId: string;
+  subject: EnforcementSubject;
+  /** Defaults to the configured mode. Explicit in tests. */
+  mode?: ModerationEnforcementMode;
+}
+
+/** Plan and carry out everything this decision revision asks for. */
+export async function applyDecisionEnforcement(
+  input: ApplyDecisionEnforcementInput,
+): Promise<EnforcementOutcome[]> {
+  const mode = input.mode ?? crowdSourceConfig().enforcementMode;
+  const plan = planEnforcement(input.decision);
+  const outcomes: EnforcementOutcome[] = [];
+
+  for (const planned of plan) {
+    outcomes.push(await applyOne(planned, input, mode));
+  }
+  return outcomes;
+}
+
+async function applyOne(
+  planned: PlannedEnforcementAction,
+  input: ApplyDecisionEnforcementInput,
+  mode: ModerationEnforcementMode,
+): Promise<EnforcementOutcome> {
+  const { decision, caseId, subject } = input;
+
+  /**
+   * The claim. The unique index refuses a second row for this
+   * `decisionId + revision + action`, so losing this insert is the answer
+   * "another delivery already handled it" and not an error.
+   */
+  let record: IModerationEnforcement;
+  try {
+    record = await ModerationEnforcementModel.create({
+      decisionId: decision.id,
+      decisionRevision: decision.revision,
+      action: planned.action,
+      caseId,
+      subjectType: subject.type,
+      subjectId: subject.id,
+      outcome: decision.outcome,
+      ...(planned.recommendedAction === undefined
+        ? {}
+        : { recommendedAction: planned.recommendedAction }),
+      reason: planned.reason,
+      mode,
+      applied: false,
+    });
+  } catch (error: unknown) {
+    if (isDuplicateKeyError(error)) {
+      return { action: planned.action, result: 'duplicate' };
+    }
+    throw error;
+  }
+
+  if (!modeAllows(mode, planned.action)) {
+    await ModerationEnforcementModel.updateOne(
+      { _id: record._id },
+      {
+        $set: {
+          skippedReason:
+            mode === 'observe'
+              ? 'observe mode: recorded, not applied'
+              : `${mode} mode does not apply '${planned.action}' automatically`,
+        },
+      },
+    );
+    return { action: planned.action, result: 'recorded' };
+  }
+
+  try {
+    const effect = await applyEffect(planned.action, subject);
+    if (!effect.changed) {
+      await ModerationEnforcementModel.updateOne(
+        { _id: record._id },
+        { $set: { skippedReason: effect.reason } },
+      );
+      return { action: planned.action, result: 'recorded' };
+    }
+
+    await ModerationEnforcementModel.updateOne(
+      { _id: record._id },
+      {
+        $set: {
+          applied: true,
+          appliedAt: new Date(),
+          previousState: effect.previousState,
+        },
+      },
+    );
+    return { action: planned.action, result: 'applied' };
+  } catch (error: unknown) {
+    /**
+     * The claim goes back so a retry can try again. Keeping it would make a
+     * transient failure permanent: the action would be deduplicated away forever
+     * and the decision would silently never be carried out.
+     */
+    await ModerationEnforcementModel.deleteOne({ _id: record._id });
+    logger.error('[CrowdSource] enforcement effect failed, claim released', {
+      decisionId: decision.id,
+      revision: decision.revision,
+      action: planned.action,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}

--- a/packages/backend/src/moderation/event-store.ts
+++ b/packages/backend/src/moderation/event-store.ts
@@ -1,0 +1,66 @@
+import type { ProcessedEventStore } from '@oxyhq/crowdsource-express';
+import {
+  ModerationEventModel,
+  MODERATION_EVENT_RETENTION_SECONDS,
+} from '../models/ModerationEvent';
+
+/**
+ * The webhook dedupe store, in Mongo.
+ *
+ * `@oxyhq/crowdsource-express` defaults to an in-process store and says exactly
+ * when that is not enough: two instances behind a load balancer each keep their
+ * own, so a redelivery landing on the other instance is not deduplicated. Syra
+ * runs several ECS tasks behind one ALB, so this is that case.
+ *
+ * The claim/release contract is the store's, and it is the right one. A row
+ * inserted BEFORE the handler runs means a concurrent redelivery cannot also run
+ * it; deleting that row when the handler THROWS means §10.9's retry schedule can
+ * still deliver the event later. Recording the id only after success would let two
+ * copies run at once; recording it before and never releasing would make a
+ * transient failure permanent and lose a decision silently.
+ */
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    Number((error as { code?: unknown }).code) === 11000
+  );
+}
+
+export function mongoProcessedEventStore(): ProcessedEventStore {
+  return {
+    /**
+     * True when this call took the claim.
+     *
+     * The insert IS the claim: `_id` is the event id and the index on it is
+     * unique, so the duplicate-key error is not an error condition to work around
+     * — it is the answer "somebody else has this event".
+     */
+    async claim(eventId: string): Promise<boolean> {
+      const now = new Date();
+      try {
+        await ModerationEventModel.create({
+          _id: eventId,
+          state: 'claimed',
+          receivedAt: now,
+          expiresAt: new Date(now.getTime() + MODERATION_EVENT_RETENTION_SECONDS * 1_000),
+        });
+        return true;
+      } catch (error: unknown) {
+        if (isDuplicateKeyError(error)) return false;
+        // Anything else — a lost connection, a failover — is NOT "already
+        // processed". Rethrowing makes the middleware answer non-2xx so the event
+        // stays on the sender's retry schedule; swallowing it here would answer
+        // 200 and retire a decision nobody ever handled.
+        throw error;
+      }
+    },
+
+    /** Give the claim back so a redelivery can be processed. */
+    async release(eventId: string): Promise<void> {
+      await ModerationEventModel.deleteOne({ _id: eventId });
+    },
+  };
+}

--- a/packages/backend/src/moderation/evidence-snapshot.ts
+++ b/packages/backend/src/moderation/evidence-snapshot.ts
@@ -1,0 +1,161 @@
+import { createHash } from 'crypto';
+import type { ReportInput } from '@oxyhq/crowdsource';
+import { REPORT_TAXONOMY_VERSION, allegationsForCategories } from './report-taxonomy';
+import { subjectProviderFor } from './subjects/registry';
+import type { ModerationSubjectSnapshot } from './subjects/types';
+import type { IReport } from '../models/Report';
+
+/**
+ * Turning a stored report into the thing the SDK delivers.
+ *
+ * What this module produces is the SDK's `ReportInput` — a description of the
+ * material — and the SDK derives the envelope from it: resource ids, relations,
+ * digests, pseudonymous principal refs, the identity binding proof, the pinned
+ * policy version, the privacy terms and the idempotency key.
+ *
+ * That is not a technicality. Those derived values are exactly what §7.3's dedup
+ * key is computed over, so an application that composed its own envelope would be
+ * the reason two reporters about one agent opened two cases — and "one penalty per
+ * incident" would fail in production with nothing failing in a test. Building the
+ * description and letting the SDK build the document is what keeps that property
+ * true for every application at once.
+ *
+ * So this module does three things and no more: ask the registry for a snapshot of
+ * the reported object, translate the reporter's categories into allegations, and
+ * assemble both with the report's own identity.
+ *
+ * **Nothing composed here may vary between two deliveries of the same report.**
+ * Ingress fingerprints the whole envelope to detect §10.5's payload conflict, so
+ * an invented timestamp, a random id or an unsorted list turns a legitimate outbox
+ * retry into a permanent 409 — silently, days later, as a report stuck in a queue.
+ * Hence `submittedAt` is the report's own `createdAt`, allegation codes are sorted,
+ * and category metadata is sorted before it is joined.
+ */
+
+/**
+ * The material could not be described, because nothing can describe it.
+ *
+ * This is a DEFECT, not a state, and it should be unreachable. A report whose type
+ * has no subject provider never gets a delivery event in the first place — intake
+ * decides that from the same registry this module reads — so an event that arrives
+ * here has been created by something that bypassed intake, or by a deployment
+ * where a provider was removed while its reports were still in flight.
+ *
+ * `retryable: false` therefore dead-letters the outbox event so a human looks. The
+ * alternative — writing a local state — would file a genuine defect in the one
+ * place that looks identical to the deliberate local-only reports, where nothing
+ * would ever alert on it.
+ *
+ * Separate from "the object is gone": a deleted object is a fact about the world
+ * and closes the report normally.
+ */
+export class ModerationSubjectUnsupportedError extends Error {
+  readonly retryable = false;
+
+  constructor(reportedType: string) {
+    super(`No moderation subject provider is registered for '${reportedType}'.`);
+    this.name = 'ModerationSubjectUnsupportedError';
+  }
+}
+
+/**
+ * SHA-256 of the snapshot, stored on the report (§5.6).
+ *
+ * Taken over the described MATERIAL, not over the whole `ReportInput`: the report
+ * id, the reporter and the allegations are properties of the report, and including
+ * them would mean two people reporting identical content produced different hashes
+ * — which is the opposite of what this hash is for. Key order is fixed by the
+ * literal below rather than by `Object.keys`, so the digest is stable across Node
+ * versions and across a refactor that reorders a field.
+ */
+export function snapshotHash(snapshot: ModerationSubjectSnapshot): string {
+  const canonical = JSON.stringify({
+    subject: {
+      externalId: snapshot.subject.externalId,
+      type: snapshot.subject.type,
+      author: snapshot.subject.author?.oxyUserId ?? null,
+    },
+    content: snapshot.content,
+    attachments: snapshot.attachments ?? [],
+    context: snapshot.context ?? [],
+  });
+  return `sha256:${createHash('sha256').update(canonical, 'utf8').digest('hex')}`;
+}
+
+export interface ModerationReportInput {
+  /** What the SDK delivers. */
+  readonly reportInput: ReportInput;
+  /** The digest to store on the local report. */
+  readonly snapshotHash: string;
+}
+
+/**
+ * Describe a stored report for delivery, or report why it cannot be described.
+ *
+ * Returns `null` when the reported object no longer exists, or when the provider
+ * declines it (a built-in skill is not somebody's published work — see
+ * `subjects/skill-subject.ts`). Neither is an error: content deleted between the
+ * report and its delivery is ordinary, and a report about Syra's own seeded
+ * content is a support question rather than a case.
+ */
+export async function buildModerationReportInput(
+  report: Pick<
+    IReport,
+    'reportedType' | 'reportedId' | 'reporter' | 'categories' | 'details' | 'createdAt'
+  > & { id: string },
+): Promise<ModerationReportInput | null> {
+  const provider = subjectProviderFor(report.reportedType);
+  if (!provider) throw new ModerationSubjectUnsupportedError(report.reportedType);
+
+  const snapshot = await provider.snapshot(report.reportedId);
+  if (!snapshot) return null;
+
+  const allegationCodes = allegationsForCategories(report.categories);
+  const details = report.details?.trim();
+
+  return {
+    reportInput: {
+      externalReportId: report.id,
+      subject: snapshot.subject,
+      content: snapshot.content,
+      ...(snapshot.attachments === undefined
+        ? {}
+        : { attachments: snapshot.attachments }),
+      ...(snapshot.context === undefined ? {} : { context: snapshot.context }),
+      /**
+       * The reporter's own words ride on the FIRST allegation only.
+       *
+       * Repeating one free-text field across every code would say the reporter
+       * wrote it about each of them separately, and §6.2 is explicit that details
+       * are the reporter's claim and never evidence for it.
+       */
+      allegations: allegationCodes.map((code, index) =>
+        index === 0 && details ? { code, details } : { code },
+      ),
+      /**
+       * The Oxy subject IS the binding proof (§11.14). Syra stores reporters as
+       * Oxy user ids, so there is no separate binding step to implement here.
+       */
+      reportedBy: { oxyUserId: report.reporter },
+      /**
+       * The moment the USER reported it — the local report's own timestamp, not
+       * the moment of delivery. Any value invented per attempt would make every
+       * retry from the outbox a permanent 409 (§10.5).
+       */
+      submittedAt: report.createdAt,
+      metadata: {
+        /** So a case can be read back against the mapping that produced it. */
+        aliaTaxonomyVersion: REPORT_TAXONOMY_VERSION,
+        aliaCategories: [...report.categories].sort().join(','),
+        /**
+         * Declared, because it cannot yet be attached. An agent's avatar is a bare
+         * string with no digest recorded anywhere — see `subjects/agent-subject.ts`
+         * — so a jury that can see material exists which it was not given can
+         * answer `insufficient_context` for the right reason.
+         */
+        evidenceAttachmentsSupported: false,
+      },
+    },
+    snapshotHash: snapshotHash(snapshot),
+  };
+}

--- a/packages/backend/src/moderation/inbound-service.ts
+++ b/packages/backend/src/moderation/inbound-service.ts
@@ -1,0 +1,117 @@
+import mongoose, { type ClientSession } from 'mongoose';
+import { ModerationEventModel } from '../models/ModerationEvent';
+import { decisionApplyEventId, enqueueModerationOutboxEvent } from './outbox';
+
+/**
+ * What happens between "a signed decision arrived" and "2xx".
+ *
+ * §10.8: answer quickly and queue the processing. So exactly two writes happen
+ * here, in ONE transaction — the event's audit row is completed and a durable
+ * `decision.apply` event is created — and the dispatcher does the rest.
+ *
+ * The transaction is what makes the dedupe safe. The middleware has already
+ * claimed the event id by inserting the row (see `event-store.ts`); if completing
+ * that row and queueing the work were two operations, a crash between them would
+ * leave an event that is permanently deduplicated with no work queued — a decision
+ * silently lost, with a row that says it arrived. Committing both together means
+ * the only two possible outcomes are "recorded and queued" or "neither", and
+ * "neither" releases the claim and gets redelivered.
+ */
+
+const TRANSACTION_OPTIONS = {
+  readPreference: 'primary' as const,
+  readConcern: { level: 'snapshot' as const },
+  writeConcern: { w: 'majority' as const },
+};
+
+async function inTransaction(
+  operation: (session: ClientSession) => Promise<void>,
+): Promise<void> {
+  const session = await mongoose.startSession();
+  try {
+    await session.withTransaction(async () => {
+      await operation(session);
+    }, TRANSACTION_OPTIONS);
+  } finally {
+    await session.endSession();
+  }
+}
+
+export interface RecordDecisionEventInput {
+  eventId: string;
+  type: string;
+  caseId: string;
+  /**
+   * The decision as delivered.
+   *
+   * `unknown`, deliberately. It is stored whole and parsed against the published
+   * contract by the worker that acts on it — §10.11 makes these payloads loose,
+   * and validating here would mean an event whose shape this deployment does not
+   * recognise yet is refused at the door and retried until it dead-letters,
+   * instead of being kept until the code catches up.
+   */
+  decision: unknown;
+}
+
+/** Record a decision-bearing event and queue its application. */
+export async function recordDecisionEvent(
+  input: RecordDecisionEventInput,
+): Promise<void> {
+  await inTransaction(async (session) => {
+    const now = new Date();
+    await ModerationEventModel.updateOne(
+      { _id: input.eventId },
+      {
+        $set: {
+          type: input.type,
+          caseId: input.caseId,
+          payload: { caseId: input.caseId, decision: input.decision },
+          state: 'queued',
+          queuedAt: now,
+          updatedAt: now,
+        },
+      },
+      { session },
+    );
+
+    await enqueueModerationOutboxEvent(
+      {
+        eventId: decisionApplyEventId(input.eventId),
+        kind: 'decision.apply',
+        payload: {
+          eventId: input.eventId,
+          caseId: input.caseId,
+          decision: input.decision,
+        },
+      },
+      session,
+    );
+  });
+}
+
+/**
+ * Record an event there is nothing to do about.
+ *
+ * `case.created`, `case.escalated`, `case.closed` and any type a newer CrowdSource
+ * introduces. No outbox row, because no work — but the row is kept, because "did
+ * CrowdSource tell us about this case, and when" is the first question asked when
+ * a report looks stuck, and it has to be answerable.
+ */
+export async function recordIgnoredEvent(input: {
+  eventId: string;
+  type: string;
+  caseId?: string;
+}): Promise<void> {
+  const now = new Date();
+  await ModerationEventModel.updateOne(
+    { _id: input.eventId },
+    {
+      $set: {
+        type: input.type,
+        ...(input.caseId === undefined ? {} : { caseId: input.caseId }),
+        state: 'ignored',
+        updatedAt: now,
+      },
+    },
+  );
+}

--- a/packages/backend/src/moderation/intake.test.ts
+++ b/packages/backend/src/moderation/intake.test.ts
@@ -225,6 +225,41 @@ describe('enqueueModerationOutboxEvent', () => {
    * concurrent duplicate submissions upsert the SAME row rather than queueing two
    * deliveries.
    */
+  /**
+   * A repeated enqueue must not WRITE, not merely not duplicate.
+   *
+   * `$setOnInsert` promises the row is left alone once it exists, and with
+   * `timestamps: true` Mongoose quietly breaks that promise by adding its own
+   * `$set: { updatedAt }` — measured before the fix as `modifiedCount: 1` with
+   * `updatedAt` moving on the second call. That is a write this function has no
+   * business making, and a transaction retry touching a row the dispatcher is
+   * concurrently claiming is a write conflict that aborts the intake. The row's
+   * own timestamp is the only thing that can witness it, since the document is
+   * otherwise identical either way.
+   */
+  it('does not touch the row when the same event is enqueued twice', async () => {
+    const session = await mongoose.startSession();
+    const enqueue = () =>
+      session.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: reportSubmitEventId('r2'), kind: 'report.submit', payload: { reportId: 'r2' } },
+          session,
+        );
+      });
+    try {
+      await enqueue();
+      const first = await ModerationOutboxModel.findById(reportSubmitEventId('r2')).lean();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await enqueue();
+      const second = await ModerationOutboxModel.findById(reportSubmitEventId('r2')).lean();
+
+      expect(first?.updatedAt).toBeDefined();
+      expect(second?.updatedAt?.getTime()).toBe(first?.updatedAt?.getTime() as number);
+    } finally {
+      await session.endSession();
+    }
+  });
+
   it('upserts the same row when called twice for one report', async () => {
     const session = await mongoose.startSession();
     try {

--- a/packages/backend/src/moderation/intake.test.ts
+++ b/packages/backend/src/moderation/intake.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'bun:test';
+import mongoose from 'mongoose';
+import { connect, clear, disconnect } from '../test/mongo';
+import { ReportModel, ReportCategory, ReportedType } from '../models/Report';
+import { ModerationOutboxModel } from '../models/ModerationOutbox';
+import { createReport, DuplicateReportError } from './intake';
+import {
+  ModerationOutboxTransactionError,
+  enqueueModerationOutboxEvent,
+  reportSubmitEventId,
+} from './outbox';
+
+/**
+ * The intake coupling, against a REAL transaction.
+ *
+ * These run on a single-member replica set rather than a standalone precisely so
+ * the transaction is real: a mocked session proves the code calls
+ * `withTransaction`, but only a real one proves the two writes actually commit
+ * together and roll back together. That is the whole guarantee.
+ */
+
+beforeAll(connect);
+afterEach(clear);
+afterAll(disconnect);
+
+const REPORTER = 'oxy-user-1';
+
+async function makePlaylist(): Promise<string> {
+  const id = new mongoose.Types.ObjectId();
+  return id.toHexString();
+}
+
+describe('createReport', () => {
+  describe('the report and its delivery event commit together', () => {
+    it('stores both for a type with a subject provider', async () => {
+      const playlistId = await makePlaylist();
+      const result = await createReport({
+        reporter: REPORTER,
+        reportedType: ReportedType.PLAYLIST,
+        reportedId: playlistId,
+        categories: [ReportCategory.SPAM],
+      });
+
+      const stored = await ReportModel.findById(result.report._id).lean();
+      expect(stored?.localStatus).toBe('queued');
+      expect(stored?.localStatusReason).toBeUndefined();
+
+      const event = await ModerationOutboxModel.findById(
+        reportSubmitEventId(result.report._id.toHexString()),
+      ).lean();
+      expect(event).not.toBeNull();
+      expect(event?.kind).toBe('report.submit');
+      expect(event?.payload?.reportId).toBe(result.report._id.toHexString());
+      expect(event?.status).toBe('pending');
+    });
+
+    /**
+     * A type with no provider is STORED, not refused, and gets no outbox row at
+     * all — never one a worker skips later, which would dead-letter a report that
+     * is not defective. "There was never a route out of this application for this
+     * kind of object" is a different claim from "delivery failed".
+     */
+    it('stores a type with no provider and enqueues nothing', async () => {
+      const result = await createReport({
+        reporter: REPORTER,
+        reportedType: ReportedType.PODCAST,
+        reportedId: 'external-show-1',
+        categories: [ReportCategory.SPAM],
+      });
+
+      expect(result.outboxEventId).toBeUndefined();
+      const stored = await ReportModel.findById(result.report._id).lean();
+      expect(stored?.localStatus).toBe('received');
+      expect(stored?.localStatusReason).toContain('no moderation subject provider');
+      expect(await ModerationOutboxModel.countDocuments({})).toBe(0);
+    });
+
+    it('accepts a listener report and keeps it local too', async () => {
+      const result = await createReport({
+        reporter: REPORTER,
+        reportedType: ReportedType.USER,
+        reportedId: 'oxy-user-2',
+        categories: [ReportCategory.HARASSMENT],
+      });
+      expect(result.outboxEventId).toBeUndefined();
+      expect(await ModerationOutboxModel.countDocuments({})).toBe(0);
+    });
+
+    /**
+     * The rollback half, which a mocked session cannot show. If anything after the
+     * report write throws, the report must not survive either — a committed report
+     * with no delivery event is the silent failure this design exists to prevent.
+     */
+    it('rolls the report back when the outbox write fails', async () => {
+      const playlistId = await makePlaylist();
+      const eventId = reportSubmitEventId('unused');
+      // Occupy the outbox id space with a document whose shape violates the
+      // schema on update, forcing the second write to throw inside the
+      // transaction. A duplicate `_id` upsert is the closest real-world analogue.
+      const original = ModerationOutboxModel.updateOne.bind(ModerationOutboxModel);
+      let threw = false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ModerationOutboxModel as any).updateOne = async () => {
+        threw = true;
+        throw new Error('simulated outbox failure');
+      };
+      try {
+        await expect(
+          createReport({
+            reporter: REPORTER,
+            reportedType: ReportedType.PLAYLIST,
+            reportedId: playlistId,
+            categories: [ReportCategory.SPAM],
+          }),
+        ).rejects.toThrow('simulated outbox failure');
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (ModerationOutboxModel as any).updateOne = original;
+      }
+
+      expect(threw).toBe(true);
+      void eventId;
+      // The report must be gone. If this ever finds a row, a user was told 201
+      // for a report nothing will ever deliver.
+      expect(await ReportModel.countDocuments({})).toBe(0);
+    });
+  });
+
+  describe('identifier guards', () => {
+    /**
+     * A type is erased at runtime and a truthiness check passes `{$ne: null}`.
+     * Handed that, `findOne` matches an UNRELATED report and the caller is told
+     * "you already reported this" about somebody else's row.
+     */
+    it('refuses a query operator smuggled in as an identifier', async () => {
+      await expect(
+        createReport({
+          reporter: { $ne: null },
+          reportedType: ReportedType.PLAYLIST,
+          reportedId: 'x',
+          categories: [ReportCategory.SPAM],
+        } as never),
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(await ReportModel.countDocuments({})).toBe(0);
+    });
+
+    it('refuses an unknown reported type', async () => {
+      await expect(
+        createReport({
+          reporter: REPORTER,
+          reportedType: 'not_a_type' as ReportedType,
+          reportedId: 'x',
+          categories: [ReportCategory.SPAM],
+        }),
+      ).rejects.toBeInstanceOf(TypeError);
+    });
+
+    it('refuses a report with no category', async () => {
+      await expect(
+        createReport({
+          reporter: REPORTER,
+          reportedType: ReportedType.PLAYLIST,
+          reportedId: 'x',
+          categories: [],
+        }),
+      ).rejects.toBeInstanceOf(TypeError);
+    });
+  });
+
+  it('refuses a second report of the same object by the same reporter', async () => {
+    const playlistId = await makePlaylist();
+    const input = {
+      reporter: REPORTER,
+      reportedType: ReportedType.PLAYLIST,
+      reportedId: playlistId,
+      categories: [ReportCategory.SPAM],
+    };
+    await createReport(input);
+    await expect(createReport(input)).rejects.toBeInstanceOf(DuplicateReportError);
+    expect(await ReportModel.countDocuments({})).toBe(1);
+  });
+});
+
+describe('enqueueModerationOutboxEvent', () => {
+  /**
+   * THE invariant. Nothing may be enqueued that is not already recorded in the
+   * same transaction as the domain write.
+   *
+   * The type already makes the session mandatory. This runtime check is what makes
+   * it mandatory that a transaction is actually OPEN — a bare `startSession()`
+   * satisfies the parameter, type-checks perfectly, and commits the row on its
+   * own.
+   */
+  it('refuses to write outside a transaction, and writes nothing when it refuses', async () => {
+    const session = await mongoose.startSession();
+    try {
+      await expect(
+        enqueueModerationOutboxEvent(
+          { eventId: 'moderation:report.submit:x', kind: 'report.submit', payload: {} },
+          session,
+        ),
+      ).rejects.toBeInstanceOf(ModerationOutboxTransactionError);
+    } finally {
+      await session.endSession();
+    }
+    expect(await ModerationOutboxModel.countDocuments({})).toBe(0);
+  });
+
+  it('says why in terms of the consequence rather than the rule', async () => {
+    const session = await mongoose.startSession();
+    try {
+      await expect(
+        enqueueModerationOutboxEvent(
+          { eventId: 'moderation:report.submit:x', kind: 'report.submit', payload: {} },
+          session,
+        ),
+      ).rejects.toThrow(/answered 201 and never delivered/);
+    } finally {
+      await session.endSession();
+    }
+  });
+
+  /**
+   * Derived from the domain object, never generated: a transaction retry or two
+   * concurrent duplicate submissions upsert the SAME row rather than queueing two
+   * deliveries.
+   */
+  it('upserts the same row when called twice for one report', async () => {
+    const session = await mongoose.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: reportSubmitEventId('r1'), kind: 'report.submit', payload: { reportId: 'r1' } },
+          session,
+        );
+        await enqueueModerationOutboxEvent(
+          { eventId: reportSubmitEventId('r1'), kind: 'report.submit', payload: { reportId: 'r1' } },
+          session,
+        );
+      });
+    } finally {
+      await session.endSession();
+    }
+    expect(await ModerationOutboxModel.countDocuments({})).toBe(1);
+  });
+});

--- a/packages/backend/src/moderation/intake.ts
+++ b/packages/backend/src/moderation/intake.ts
@@ -1,0 +1,220 @@
+import mongoose, { type ClientSession } from 'mongoose';
+import {
+  ReportModel,
+  ReportCategory,
+  ReportStatus,
+  ReportedType,
+  type IReport,
+  type LeanReport,
+} from '../models/Report';
+import { enqueueModerationOutboxEvent, reportSubmitEventId } from './outbox';
+import { subjectProviderFor } from './subjects/registry';
+
+/**
+ * Storing a report and, when there is somewhere to send it, the promise to deliver
+ * it — in one operation.
+ *
+ * This is the only thing in the integration that a user waits for. A 201 from
+ * `POST /reports` means the report row and its outbox event committed together. It
+ * does NOT mean CrowdSource accepted anything — CrowdSource may be unreachable,
+ * mid-deploy or not yet configured, and the reporter is told their report was
+ * received either way, because it was.
+ *
+ * The transaction is the whole mechanism. Two writes outside one would give two
+ * failure modes that are both silent: a report with no delivery event (the report
+ * exists, nothing will ever send it, and nobody finds out until somebody asks why
+ * a case never opened) or a delivery event with no report (a worker looking up an
+ * id that was rolled back). Neither surfaces as an error at the moment it happens,
+ * which is exactly why this has to be atomic rather than carefully ordered.
+ *
+ * **There is deliberately no non-transactional fallback.** Syra used no
+ * transactions before this feature, so a deployment could in principle be pointed
+ * at a standalone MongoDB — and the tempting accommodation is to catch the
+ * topology error and do the two writes separately. That would convert a loud,
+ * immediate failure into precisely the silent one this design exists to prevent.
+ * A `POST /reports` that 500s on a misconfigured deployment is found on the first
+ * report; a report that quietly never delivers is found months later, if at all.
+ * The dispatcher asserts the topology at boot so it is normally found earlier
+ * still — see `dispatcher.ts`.
+ *
+ * The one report with NO delivery event is the one whose type has no subject
+ * provider, and that is a different claim entirely: not "delivery failed" but
+ * "there was never a route out of this application for this kind of object". Those
+ * two must not be conflated, which is why they are different `localStatus` values
+ * and why the absent route is written down as a reason rather than inferred from a
+ * missing row.
+ */
+
+const TRANSACTION_OPTIONS = {
+  readPreference: 'primary' as const,
+  readConcern: { level: 'snapshot' as const },
+  writeConcern: { w: 'majority' as const },
+};
+
+export class DuplicateReportError extends Error {
+  readonly existing: LeanReport;
+
+  constructor(existing: LeanReport) {
+    super('This item has already been reported by this reporter.');
+    this.name = 'DuplicateReportError';
+    this.existing = existing;
+  }
+}
+
+/**
+ * Refuses an identifier that is not a string, at the point the QUERY is built.
+ *
+ * `CreateReportInput` types these as strings and the route rejects a missing one,
+ * but a type is erased at runtime and a truthiness check passes `{$ne: null}`.
+ * Handed that, `findOne` matches an UNRELATED report and this function answers
+ * "you already reported this" about somebody else's row — and the create would
+ * then store an operator where an id belongs.
+ *
+ * The check lives here rather than at the route because `createReport` is
+ * exported: a queue worker, a reconciliation script or a future admin path is
+ * under no obligation to have passed the route's validation, and a guard that only
+ * exists at one caller is a guard that holds until the second one arrives.
+ */
+function requireIdentifier(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`createReport: '${field}' must be a non-empty string.`);
+  }
+  return value;
+}
+
+/**
+ * Narrows a checked string to the enum.
+ *
+ * A type predicate rather than a cast, so the runtime check and the compile-time
+ * claim are the same statement. A cast would keep compiling if a value were
+ * removed from `ReportedType`, which is exactly when the check matters.
+ */
+function isReportedType(value: string): value is ReportedType {
+  return (Object.values(ReportedType) as string[]).includes(value);
+}
+
+export interface CreateReportInput {
+  reporter: string;
+  reportedType: ReportedType;
+  reportedId: string;
+  categories: ReportCategory[];
+  details?: string;
+}
+
+export interface CreateReportResult {
+  report: IReport;
+  /**
+   * The durable delivery event.
+   *
+   * Absent exactly when the reported type has no subject provider — the report was
+   * stored and there is nothing to deliver it, by design rather than by failure.
+   */
+  outboxEventId?: string;
+}
+
+/**
+ * Why a report is not going anywhere, in words an operator can read.
+ *
+ * Stored on the row rather than left to be inferred from a missing outbox event. A
+ * missing row is also what a lost write looks like, and the two need to be
+ * distinguishable months later without re-deriving which types had providers at
+ * the time. Bounded by the schema's 300-character limit.
+ */
+function localOnlyReason(reportedType: string): string {
+  return (
+    `Syra has no moderation subject provider for '${reportedType}', so this report is ` +
+    'recorded locally and is not sent for community review.'
+  );
+}
+
+async function inTransaction<T>(
+  operation: (session: ClientSession) => Promise<T>,
+): Promise<T> {
+  const session = await mongoose.startSession();
+  let result: T | undefined;
+  try {
+    await session.withTransaction(async () => {
+      result = await operation(session);
+    }, TRANSACTION_OPTIONS);
+    if (result === undefined) {
+      throw new Error('Report intake transaction completed without a result');
+    }
+    return result;
+  } finally {
+    await session.endSession();
+  }
+}
+
+/**
+ * Store the report, and queue its delivery in the same transaction.
+ *
+ * Delivery is queued when — and only when — the reported type has a subject
+ * provider. A type without one is stored at `received` with the reason recorded,
+ * which is a real state rather than a failure.
+ *
+ * That branch is the reason the two writes stay in one transaction rather than
+ * being ordered carefully. The condition is read BEFORE the transaction body
+ * decides anything, so `localStatus` and the presence of an outbox row are decided
+ * together from one fact — a report can never commit as `queued` with nothing to
+ * deliver it, nor as `received` with a delivery event that will try anyway.
+ *
+ * Intake deliberately does not read `CROWDSOURCE_ENABLED`. A report taken while
+ * the integration is off still gets its delivery event, so turning the flag on
+ * delivers the backlog instead of stranding it — the dispatcher is what is gated,
+ * not the durable record. Nothing here is conditional on a third party's state;
+ * only on whether this application knows how to describe the object at all.
+ */
+export async function createReport(
+  input: CreateReportInput,
+): Promise<CreateReportResult> {
+  const reporter = requireIdentifier(input.reporter, 'reporter');
+  const reportedId = requireIdentifier(input.reportedId, 'reportedId');
+  const reportedTypeValue = requireIdentifier(input.reportedType, 'reportedType');
+  if (!isReportedType(reportedTypeValue)) {
+    throw new TypeError(
+      `createReport: reportedType '${reportedTypeValue}' is not a reportable type.`,
+    );
+  }
+  const reportedType: ReportedType = reportedTypeValue;
+  if (!Array.isArray(input.categories) || input.categories.length === 0) {
+    throw new TypeError('createReport: at least one category is required.');
+  }
+  const deliverable = subjectProviderFor(reportedType) !== undefined;
+
+  return await inTransaction(async (session) => {
+    const existing = await ReportModel.findOne({ reporter, reportedId, reportedType })
+      .session(session)
+      .lean<LeanReport | null>();
+    if (existing) throw new DuplicateReportError(existing);
+
+    const [report] = await ReportModel.create(
+      [
+        {
+          reportedType,
+          reportedId,
+          reporter,
+          categories: input.categories,
+          details: input.details,
+          status: ReportStatus.PENDING,
+          localStatus: deliverable ? 'queued' : 'received',
+          ...(deliverable ? {} : { localStatusReason: localOnlyReason(reportedType) }),
+        },
+      ],
+      { session },
+    );
+
+    if (!deliverable) return { report };
+
+    const reportId = report._id.toHexString();
+    const outboxEventId = await enqueueModerationOutboxEvent(
+      {
+        eventId: reportSubmitEventId(reportId),
+        kind: 'report.submit',
+        payload: { reportId },
+      },
+      session,
+    );
+
+    return { report, outboxEventId };
+  });
+}

--- a/packages/backend/src/moderation/outbox.ts
+++ b/packages/backend/src/moderation/outbox.ts
@@ -1,0 +1,432 @@
+import { randomUUID } from 'crypto';
+import type { ClientSession } from 'mongoose';
+import {
+  ModerationOutboxModel,
+  MODERATION_OUTBOX_RETENTION_SECONDS,
+  type ModerationOutboxKind,
+  type ModerationOutboxPayload,
+} from '../models/ModerationOutbox';
+import { logger } from '../utils/logger';
+
+/**
+ * Claiming, completing and failing moderation outbox events.
+ *
+ * At-least-once: handlers MUST make every downstream effect idempotent using the
+ * event `_id`, because an expired lease is reclaimable and a worker can die
+ * mid-delivery.
+ *
+ * What is unusual here is where retrying STOPS. A delivery failure the SDK marks
+ * as not retryable is a defect in the payload, not a blip — see
+ * {@link failModerationOutboxEvent}.
+ */
+
+const DEFAULT_LEASE_MS = 60_000;
+const DEFAULT_BATCH_SIZE = 50;
+const MAX_BATCH_SIZE = 500;
+const MAX_BACKOFF_MS = 6 * 60 * 60 * 1_000;
+const MIN_LEASE_RENEW_INTERVAL_MS = 250;
+
+/**
+ * Attempts after which a retryable failure is treated as permanent.
+ *
+ * Generous: a retryable failure means CrowdSource might still accept this exact
+ * payload, and with `MAX_BACKOFF_MS` capped at six hours this is several days of
+ * trying. A report that has not landed by then needs a human, not another attempt.
+ */
+const MAX_RETRYABLE_ATTEMPTS = 25;
+
+export interface ModerationOutboxEvent {
+  _id: string;
+  kind: ModerationOutboxKind;
+  payload: ModerationOutboxPayload;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner?: string;
+  leaseUntil?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+/**
+ * The event id for delivering a report.
+ *
+ * Derived from the report, not from the request: a transaction retry or two
+ * concurrent duplicate submissions upsert the SAME event rather than queueing two
+ * deliveries. There is exactly one delivery event per report for the life of the
+ * report, which is also what makes the CrowdSource-side idempotency key stable.
+ */
+export function reportSubmitEventId(reportId: string): string {
+  return `moderation:report.submit:${reportId}`;
+}
+
+/**
+ * The event id for applying an inbound decision (Appendix D).
+ *
+ * The webhook event id is the key, so a redelivery of the same event can never
+ * queue the work twice even if the dedupe claim were somehow released.
+ */
+export function decisionApplyEventId(eventId: string): string {
+  return `moderation:decision.apply:${eventId}`;
+}
+
+/**
+ * Raised when an outbox event is written outside a transaction.
+ *
+ * Never expected at runtime. It exists so the invariant is ENFORCED rather than
+ * reviewed — see {@link enqueueModerationOutboxEvent}.
+ */
+export class ModerationOutboxTransactionError extends Error {
+  constructor(eventId: string) {
+    super(
+      `Refusing to enqueue moderation outbox event '${eventId}' outside a transaction: ` +
+        'the domain write and this row must commit together, or a report is answered 201 ' +
+        'and never delivered.',
+    );
+    this.name = 'ModerationOutboxTransactionError';
+  }
+}
+
+/**
+ * Write the event with the CALLER's session.
+ *
+ * The session is required, not optional. This is the whole point of the
+ * collection: the domain write and this row commit together or not at all. An
+ * overload that let a caller enqueue outside a transaction would be the one line
+ * that quietly reintroduces "the report was answered 201 and then vanished".
+ *
+ * The type makes the session mandatory; the runtime check below makes it mandatory
+ * that the session is ACTUALLY IN a transaction. A required parameter is satisfied
+ * by any session — including a bare `startSession()` nobody opened a transaction
+ * on, which type-checks perfectly and commits the row on its own. That is the
+ * shape of the mistake worth catching: it looks exactly like correct code, it
+ * passes any test that only asserts the row exists, and it fails as lost
+ * moderation work with no trace on the day something restarts between the two
+ * writes.
+ *
+ * This function is also the ONLY writer of this collection — the dispatcher claims
+ * existing rows and never creates one — so there is no second queue that can drift
+ * out of sync with the outbox. A job is never the only evidence that work exists,
+ * because the row IS the job.
+ */
+export async function enqueueModerationOutboxEvent(
+  input: {
+    eventId: string;
+    kind: ModerationOutboxKind;
+    payload: ModerationOutboxPayload;
+  },
+  session: ClientSession,
+): Promise<string> {
+  if (!session.inTransaction()) {
+    throw new ModerationOutboxTransactionError(input.eventId);
+  }
+
+  /**
+   * `createdAt` and `updatedAt` are deliberately NOT in `$setOnInsert`.
+   *
+   * The schema sets `timestamps: true`, so Mongoose adds `updatedAt` to `$set` on
+   * every upsert. Naming it in `$setOnInsert` too makes MongoDB refuse the whole
+   * write with "Updating the path 'updatedAt' would create a conflict at
+   * 'updatedAt'" (code 40) — which, inside the intake transaction, aborts the
+   * report as well. Mongoose already fills `createdAt` on insert.
+   */
+  const now = new Date();
+  await ModerationOutboxModel.updateOne(
+    { _id: input.eventId },
+    {
+      $setOnInsert: {
+        _id: input.eventId,
+        kind: input.kind,
+        payload: input.payload,
+        status: 'pending',
+        attempts: 0,
+        availableAt: now,
+        expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
+      },
+    },
+    { upsert: true, session },
+  );
+  return input.eventId;
+}
+
+function claimFilter(now: Date, eventId?: string): Record<string, unknown> {
+  return {
+    ...(eventId ? { _id: eventId } : {}),
+    $or: [
+      { status: 'pending', availableAt: { $lte: now } },
+      { status: 'processing', leaseUntil: { $lte: now } },
+    ],
+  };
+}
+
+/**
+ * Atomically claim one due event. An expired `processing` lease is reclaimable, so
+ * a dead worker cannot strand moderation work forever.
+ */
+export async function claimModerationOutboxEvent(options: {
+  leaseOwner: string;
+  eventId?: string;
+  now?: Date;
+  leaseMs?: number;
+}): Promise<ModerationOutboxEvent | null> {
+  const now = options.now ?? new Date();
+  const leaseMs = Math.max(1_000, options.leaseMs ?? DEFAULT_LEASE_MS);
+  return await ModerationOutboxModel.findOneAndUpdate(
+    claimFilter(now, options.eventId),
+    {
+      $set: {
+        status: 'processing',
+        leaseOwner: options.leaseOwner,
+        leaseUntil: new Date(now.getTime() + leaseMs),
+        updatedAt: now,
+      },
+      $inc: { attempts: 1 },
+      $unset: { lastError: '' },
+    },
+    { new: true, sort: { createdAt: 1 } },
+  )
+    .select('_id kind payload attempts availableAt leaseOwner leaseUntil expiresAt createdAt')
+    .lean<ModerationOutboxEvent | null>();
+}
+
+/** Complete only the lease this dispatcher currently owns. */
+export async function completeModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const result = await ModerationOutboxModel.updateOne(
+    { _id: eventId, status: 'processing', leaseOwner, leaseUntil: { $gt: now } },
+    {
+      $set: { status: 'processed', processedAt: now, updatedAt: now },
+      $unset: { leaseOwner: '', leaseUntil: '', lastError: '' },
+    },
+  );
+  return result.modifiedCount === 1;
+}
+
+/** Extend only a live lease still owned by this dispatcher. */
+export async function renewModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  leaseMs: number,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const result = await ModerationOutboxModel.updateOne(
+    { _id: eventId, status: 'processing', leaseOwner, leaseUntil: { $gt: now } },
+    {
+      $set: {
+        leaseUntil: new Date(now.getTime() + Math.max(1_000, leaseMs)),
+        updatedAt: now,
+      },
+    },
+  );
+  return result.matchedCount === 1;
+}
+
+function nextAttemptAt(attempts: number, now: Date): Date {
+  const exponent = Math.max(0, Math.min(attempts - 1, 20));
+  return new Date(now.getTime() + Math.min(1_000 * 2 ** exponent, MAX_BACKOFF_MS));
+}
+
+/**
+ * A failure that says whether trying the same payload again could ever work.
+ *
+ * Every error `@oxyhq/crowdsource` throws carries `retryable`, which is the only
+ * thing a delivery worker needs from it. Anything else — a bug in this code, a
+ * Mongo error — is treated as retryable, because assuming a defect is permanent is
+ * how a recoverable outage becomes lost moderation work.
+ */
+export function isRetryableDeliveryError(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null && 'retryable' in error) {
+    const retryable: unknown = (error as { retryable: unknown }).retryable;
+    if (typeof retryable === 'boolean') return retryable;
+  }
+  return true;
+}
+
+export interface ModerationOutboxFailure {
+  released: boolean;
+  deadLettered: boolean;
+}
+
+/**
+ * Release a failed claim, with backoff — or stop.
+ *
+ * Stopping is not an optimisation. A 409 means this `externalReportId` already
+ * exists at CrowdSource with a different body, and no number of retries turns two
+ * payloads into one report; a 422 means the envelope is not processable. Both need
+ * the payload to change, so they become `dead_letter` immediately and stay visible
+ * with their error rather than accumulating attempts nobody reads.
+ */
+export async function failModerationOutboxEvent(
+  event: Pick<ModerationOutboxEvent, '_id' | 'attempts'>,
+  leaseOwner: string,
+  error: unknown,
+  now: Date = new Date(),
+): Promise<ModerationOutboxFailure> {
+  const message = error instanceof Error ? error.message : String(error);
+  const retryable = isRetryableDeliveryError(error);
+  const deadLettered = !retryable || event.attempts >= MAX_RETRYABLE_ATTEMPTS;
+
+  const result = await ModerationOutboxModel.updateOne(
+    { _id: event._id, status: 'processing', leaseOwner, leaseUntil: { $gt: now } },
+    {
+      $set: {
+        status: deadLettered ? 'dead_letter' : 'pending',
+        availableAt: deadLettered ? now : nextAttemptAt(event.attempts, now),
+        lastError: message.slice(0, 2_000),
+        updatedAt: now,
+      },
+      $unset: { leaseOwner: '', leaseUntil: '' },
+    },
+  );
+  return { released: result.modifiedCount === 1, deadLettered };
+}
+
+export type ModerationOutboxHandler = (event: ModerationOutboxEvent) => Promise<void>;
+
+interface LeaseHeartbeatResult {
+  lost: boolean;
+  error?: unknown;
+}
+
+function startLeaseHeartbeat(options: {
+  eventId: string;
+  leaseOwner: string;
+  leaseMs: number;
+}): { stop: () => Promise<LeaseHeartbeatResult> } {
+  const renewIntervalMs = Math.max(
+    MIN_LEASE_RENEW_INTERVAL_MS,
+    Math.floor(options.leaseMs / 3),
+  );
+  let stopped = false;
+  let lost = false;
+  let renewalError: unknown;
+  let renewalInFlight: Promise<void> | null = null;
+
+  const renew = (): void => {
+    if (stopped || lost || renewalInFlight) return;
+    const renewal = renewModerationOutboxEvent(
+      options.eventId,
+      options.leaseOwner,
+      options.leaseMs,
+    )
+      .then((stillOwner) => {
+        if (!stillOwner) lost = true;
+      })
+      .catch((error: unknown) => {
+        lost = true;
+        renewalError = error;
+      })
+      .finally(() => {
+        if (renewalInFlight === renewal) renewalInFlight = null;
+      });
+    renewalInFlight = renewal;
+  };
+
+  const timer = setInterval(renew, renewIntervalMs);
+  timer.unref?.();
+
+  return {
+    async stop(): Promise<LeaseHeartbeatResult> {
+      stopped = true;
+      clearInterval(timer);
+      await renewalInFlight;
+      return { lost, error: renewalError };
+    },
+  };
+}
+
+export interface ModerationDispatchResult {
+  processed: number;
+  failed: number;
+  deadLettered: number;
+}
+
+/** Drain up to `batchSize` due events. Bounded, at-least-once, lease-protected. */
+export async function dispatchModerationOutbox(options: {
+  handler: ModerationOutboxHandler;
+  leaseOwner?: string;
+  batchSize?: number;
+  leaseMs?: number;
+  signal?: AbortSignal;
+}): Promise<ModerationDispatchResult> {
+  const leaseOwner = options.leaseOwner ?? `moderation:${process.pid}:${randomUUID()}`;
+  const batchSize = Math.min(
+    Math.max(1, options.batchSize ?? DEFAULT_BATCH_SIZE),
+    MAX_BATCH_SIZE,
+  );
+  const leaseMs = Math.max(1_000, options.leaseMs ?? DEFAULT_LEASE_MS);
+  let processed = 0;
+  let failed = 0;
+  let deadLettered = 0;
+
+  for (let index = 0; index < batchSize; index += 1) {
+    // Shutdown stops claiming new work but lets the event already in flight reach
+    // a durable state.
+    if (options.signal?.aborted) break;
+
+    const event = await claimModerationOutboxEvent({ leaseOwner, leaseMs });
+    if (!event) break;
+
+    const heartbeat = startLeaseHeartbeat({ eventId: event._id, leaseOwner, leaseMs });
+    let deliveryError: unknown;
+    try {
+      await options.handler(event);
+    } catch (error: unknown) {
+      deliveryError = error;
+    }
+
+    // No completion/failure transition may race an owner-checked renewal.
+    const heartbeatResult = await heartbeat.stop();
+    if (heartbeatResult.lost) {
+      failed += 1;
+      logger.warn('[CrowdSource] outbox event lease lost during delivery', {
+          eventId: event._id,
+          kind: event.kind,
+          attempts: event.attempts,
+          error:
+            heartbeatResult.error instanceof Error
+              ? heartbeatResult.error.message
+              : heartbeatResult.error
+                ? String(heartbeatResult.error)
+                : 'owner or lease expiry changed',
+        });
+      continue;
+    }
+
+    if (deliveryError) {
+      failed += 1;
+      const outcome = await failModerationOutboxEvent(event, leaseOwner, deliveryError);
+      const context = {
+        eventId: event._id,
+        kind: event.kind,
+        attempts: event.attempts,
+        error:
+          deliveryError instanceof Error ? deliveryError.message : String(deliveryError),
+      };
+      // A dead letter is moderation work that will not happen without a human, so
+      // it must not be discoverable only by reading a warn-level log line.
+      if (outcome.deadLettered) {
+        deadLettered += 1;
+        logger.error('[CrowdSource] outbox event dead-lettered', context);
+      } else {
+        logger.warn('[CrowdSource] outbox event delivery failed, will retry', context);
+      }
+      if (!outcome.released) {
+        logger.warn('[CrowdSource] lease lost before failure release', { eventId: event._id, kind: event.kind });
+      }
+      continue;
+    }
+
+    const completed = await completeModerationOutboxEvent(event._id, leaseOwner);
+    if (!completed) {
+      failed += 1;
+      logger.warn('[CrowdSource] lease lost before completion', { eventId: event._id, kind: event.kind, attempts: event.attempts });
+      continue;
+    }
+    processed += 1;
+  }
+
+  return { processed, failed, deadLettered };
+}

--- a/packages/backend/src/moderation/outbox.ts
+++ b/packages/backend/src/moderation/outbox.ts
@@ -121,13 +121,27 @@ export async function enqueueModerationOutboxEvent(
   }
 
   /**
-   * `createdAt` and `updatedAt` are deliberately NOT in `$setOnInsert`.
+   * `timestamps: false`, with `createdAt` and `updatedAt` supplied by hand.
+   *
+   * Two bugs live here and the obvious fix only cures the first.
    *
    * The schema sets `timestamps: true`, so Mongoose adds `updatedAt` to `$set` on
-   * every upsert. Naming it in `$setOnInsert` too makes MongoDB refuse the whole
-   * write with "Updating the path 'updatedAt' would create a conflict at
-   * 'updatedAt'" (code 40) — which, inside the intake transaction, aborts the
-   * report as well. Mongoose already fills `createdAt` on insert.
+   * every upsert. Naming it in `$setOnInsert` TOO puts one path in two operators
+   * and MongoDB refuses the whole write — "Updating the path 'updatedAt' would
+   * create a conflict at 'updatedAt'" (code 40) — which, inside the intake
+   * transaction, aborts the report with it. Every report would fail.
+   *
+   * Dropping the two fields stops the conflict but leaves Mongoose's own
+   * `$set: { updatedAt }` in place, so a REPEATED enqueue still modifies a row
+   * that `$setOnInsert` says it should leave alone. Measured: the second call
+   * reports `modifiedCount: 1` and moves `updatedAt`. That is a write this
+   * function has no business making, and a transaction retry that touches a row
+   * the dispatcher is concurrently claiming is a write conflict that aborts the
+   * intake.
+   *
+   * Turning timestamps off for this ONE call removes both. Mongoose then fills
+   * neither field, so both are supplied here — on insert only, which is what the
+   * operator promised. `claim`'s `sort: { createdAt: 1 }` still works.
    */
   const now = new Date();
   await ModerationOutboxModel.updateOne(
@@ -141,9 +155,12 @@ export async function enqueueModerationOutboxEvent(
         attempts: 0,
         availableAt: now,
         expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
+        createdAt: now,
+        updatedAt: now,
       },
     },
-    { upsert: true, session },
+    // `timestamps: false` is what makes `$setOnInsert` mean what it says.
+    { upsert: true, session, timestamps: false },
   );
   return input.eventId;
 }

--- a/packages/backend/src/moderation/registry.test.ts
+++ b/packages/backend/src/moderation/registry.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  SubjectTypeSchema,
+  TaxonomyCodeSchema,
+  UNIVERSAL_TAXONOMY_CODES,
+} from '@oxyhq/crowdsource-contracts';
+import { deliverableTypes, subjectProviderFor } from './subjects/registry';
+import { allegationsForCategories, REPORT_TAXONOMY_VERSION } from './report-taxonomy';
+import { ReportCategory, ReportedType } from '../models/Report';
+
+describe('subject registry', () => {
+  it('delivers exactly the five nouns Syra can describe', () => {
+    expect(deliverableTypes().sort()).toEqual([
+      'artist',
+      'house',
+      'playlist',
+      'room',
+      'track',
+    ]);
+  });
+
+  it('declares §5.4-valid subject types', () => {
+    for (const reportedType of deliverableTypes()) {
+      const provider = subjectProviderFor(reportedType);
+      expect(provider).toBeDefined();
+      expect(SubjectTypeSchema.safeParse(provider?.subjectType).success).toBe(true);
+    }
+  });
+
+  /**
+   * A room IS reportable, and that is the correction worth pinning: `Room` is a
+   * durable document whose title, description, topic and stream fields are all
+   * host-authored, so §5.6 has something to pin and a jury has something to
+   * answer. What the provider withholds — the conversation, the participant list
+   * and the recording — is asserted in the provider's own tests.
+   */
+  it('reports a room, with the host as its author', () => {
+    expect(subjectProviderFor(ReportedType.ROOM)?.subjectType).toBe('custom.syra.room');
+  });
+
+  /**
+   * An artist has a Syra-side profile; a listener does not. That difference is
+   * the whole reason one is deliverable and the other is not — Oxy owns identity,
+   * and there is nothing Syra could snapshot for a plain account.
+   */
+  it('reports an artist profile but not a listener account', () => {
+    expect(subjectProviderFor(ReportedType.ARTIST)?.subjectType).toBe('identity.profile');
+    expect(subjectProviderFor(ReportedType.USER)).toBeUndefined();
+  });
+
+  /**
+   * Mirrored from external RSS: the publisher is not a Syra user, has no Oxy
+   * identity, and would never learn a jury had judged them. Accepted so the
+   * report surface keeps working, never delivered.
+   */
+  it('accepts a mirrored podcast and episode but delivers neither', () => {
+    for (const type of [ReportedType.PODCAST, ReportedType.EPISODE]) {
+      expect(Object.values(ReportedType)).toContain(type);
+      expect(subjectProviderFor(type)).toBeUndefined();
+      expect(deliverableTypes()).not.toContain(type);
+    }
+  });
+
+  it('answers undefined for a type it has never heard of', () => {
+    expect(subjectProviderFor('not_a_type')).toBeUndefined();
+  });
+});
+
+describe('report taxonomy', () => {
+  it('emits a valid universal code for every category Syra offers', () => {
+    for (const category of Object.values(ReportCategory)) {
+      const codes = allegationsForCategories([category]);
+      expect(codes).toHaveLength(1);
+      expect(TaxonomyCodeSchema.safeParse(codes[0]).success).toBe(true);
+    }
+  });
+
+  /**
+   * The copyright boundary, asserted from BOTH sides.
+   *
+   * Syra offers no `copyright` category, and the universal taxonomy offers no code
+   * that could receive one — which is the contract declining the question rather
+   * than overlooking it. DMCA carries statutory process and lives in
+   * `CopyrightReport` + `strikeService`; a community vote must never be able to
+   * produce something that looks like a strike but carries none of the process one
+   * legally requires.
+   *
+   * If a future contracts release ever adds an infringement code, this test fails
+   * and the decision gets made deliberately instead of by import.
+   */
+  it('has no copyright category, because the taxonomy has no code for one', () => {
+    expect(Object.values(ReportCategory)).not.toContain('copyright' as ReportCategory);
+    const infringementCodes = UNIVERSAL_TAXONOMY_CODES.filter((code) =>
+      /copyright|infring|intellectual|dmca/i.test(code),
+    );
+    expect(infringementCodes).toEqual([]);
+  });
+
+  /**
+   * On an audio platform the usual complaint is about depiction, not about a
+   * threat aimed at a person. `violence.threat` is a much stronger claim about
+   * intent, and alleging it by default would put words in the reporter's mouth.
+   */
+  it('reads a violence report as depiction, not as a threat', () => {
+    expect(allegationsForCategories([ReportCategory.VIOLENCE])).toEqual(['violence.graphic']);
+  });
+
+  it('maps impersonation to the integrity code', () => {
+    expect(allegationsForCategories([ReportCategory.IMPERSONATION])).toEqual([
+      'integrity.impersonation',
+    ]);
+  });
+
+  /**
+   * Order is not cosmetic. Ingress fingerprints the whole envelope to detect
+   * §10.5's "same external id, different body", so a list whose order followed the
+   * client's would turn a legitimate outbox retry into a permanent 409.
+   */
+  it('produces the same bytes whatever order the client sent', () => {
+    const a = allegationsForCategories([
+      ReportCategory.SPAM,
+      ReportCategory.HARASSMENT,
+      ReportCategory.VIOLENCE,
+    ]);
+    const b = allegationsForCategories([
+      ReportCategory.VIOLENCE,
+      ReportCategory.HARASSMENT,
+      ReportCategory.SPAM,
+    ]);
+    expect(a).toEqual(b);
+    expect(a).toEqual([...a].sort());
+  });
+
+  it('deduplicates and never yields an empty list', () => {
+    expect(allegationsForCategories([ReportCategory.SPAM, ReportCategory.SPAM])).toHaveLength(1);
+    expect(allegationsForCategories([ReportCategory.OTHER]).length).toBeGreaterThan(0);
+  });
+
+  it('carries a version so a case can be read back against this mapping', () => {
+    expect(REPORT_TAXONOMY_VERSION).toMatch(/^\d{4}\.\d{2}$/);
+  });
+});

--- a/packages/backend/src/moderation/report-status.ts
+++ b/packages/backend/src/moderation/report-status.ts
@@ -1,0 +1,72 @@
+import { ReportStatus, type ModerationLocalStatus } from '../models/Report';
+
+/**
+ * The one place a report's two status axes are decided.
+ *
+ * Two status fields maintained by two call sites is how they drift, so both are
+ * derived here — from the decision, not from each other — and every writer in the
+ * moderation pipeline goes through {@link reportStateForDecision}.
+ *
+ * The mapping is deliberately conservative about the difference between "a jury
+ * looked at this" and "this was a violation". `resolved` and `dismissed` are the
+ * two values that carry a verdict, so only an outcome that IS a verdict may
+ * produce them:
+ *
+ * - `violation` → `resolved`: the case reached a conclusion Syra can act on.
+ * - `no_violation` → `dismissed`: the allegation was not upheld.
+ * - `insufficient_context`, `inconclusive`, `content_unavailable`, `duplicate`,
+ *   `escalated` → `reviewed`: a jury engaged and produced no verdict. Mapping any
+ *   of these to `dismissed` would turn "we could not tell" into "nothing was
+ *   wrong", which is the exact collapse the invariants forbid — absence of
+ *   consensus is neither guilt nor innocence.
+ *
+ * An outcome this version does not know also maps to `reviewed`: a newer
+ * CrowdSource must not be able to silently produce `dismissed` here.
+ */
+
+/**
+ * The outcome, as a string.
+ *
+ * Not typed as `DecisionOutcome` on purpose: this is reached from the decision
+ * worker with a value that came off the wire, and §10.11 requires an unrecognised
+ * outcome to be handled rather than to throw. The known values are matched
+ * explicitly and everything else falls through.
+ */
+export function legacyStatusForOutcome(outcome: string): ReportStatus {
+  switch (outcome) {
+    case 'violation':
+      return ReportStatus.RESOLVED;
+    case 'no_violation':
+      return ReportStatus.DISMISSED;
+    default:
+      return ReportStatus.REVIEWED;
+  }
+}
+
+export interface ReportDecisionState {
+  status: ReportStatus;
+  localStatus: ModerationLocalStatus;
+}
+
+/**
+ * Decision statuses that end Syra's side of the case.
+ *
+ * A `provisional` decision leaves the report at `submitted`: §9.6 allows a later
+ * revision to supersede it, and a report Syra had already closed would have to be
+ * reopened. `superseded` is not here either — a superseded revision is not the
+ * current answer and must never be the one that closes the report.
+ */
+const TERMINAL_DECISION_STATUSES: ReadonlySet<string> = new Set(['final', 'corrected']);
+
+/** Both axes for a report whose case has been decided. */
+export function reportStateForDecision(input: {
+  outcome: string;
+  decisionStatus: string;
+}): ReportDecisionState {
+  return {
+    status: legacyStatusForOutcome(input.outcome),
+    localStatus: TERMINAL_DECISION_STATUSES.has(input.decisionStatus)
+      ? 'closed'
+      : 'submitted',
+  };
+}

--- a/packages/backend/src/moderation/report-taxonomy.ts
+++ b/packages/backend/src/moderation/report-taxonomy.ts
@@ -1,0 +1,77 @@
+import type { TaxonomyCode } from '@oxyhq/crowdsource-contracts';
+import { ReportCategory } from '../models/Report';
+
+/**
+ * Syra's report categories, translated into CrowdSource's universal taxonomy.
+ *
+ * The categories on the left are what a reporter picked in Syra's UI. The codes on
+ * the right are ALLEGATIONS (§6.2) — what is claimed, never what is true. A jury
+ * classifies the material itself and may confirm a different code entirely.
+ *
+ * ## Why this is versioned
+ *
+ * §6.4 requires every decision to record the policy version it was decided under,
+ * and this mapping is upstream of that: change what `spam` means and two reports
+ * filed a month apart are no longer the same allegation.
+ * {@link REPORT_TAXONOMY_VERSION} is stamped into the report metadata so a case
+ * can always be read back against the mapping that produced it. Bump it in the
+ * same change that alters a row.
+ *
+ * ## There is no copyright row, and there must never be one
+ *
+ * The obvious gap on a music platform is copyright, and it is deliberate on both
+ * sides. `ReportCategory` has no `copyright` value, and the universal taxonomy has
+ * no code that could receive one — forty codes across eleven families and not a
+ * single infringement code; `commerce.counterfeit` is about goods.
+ *
+ * That is the contract declining the question rather than overlooking it. DMCA
+ * carries statutory process, counter-notice and safe-harbour consequences, and
+ * §7.5 routes material with legal weight to specialists rather than to a randomly
+ * drawn jury. Syra already has that pipeline — `CopyrightReport` plus
+ * `strikeService` — and it stays separate. Adding a row here would let a community
+ * vote produce something that looks like a strike but carries none of the process
+ * a strike legally requires.
+ *
+ * ## The row worth arguing about
+ *
+ * **`violence` maps to `violence.graphic`, not `violence.threat`.** On an audio
+ * platform the usual complaint is about depiction — a track, a title, a room
+ * description — rather than about a threat directed at someone. `violence.threat`
+ * is a much stronger claim about intent toward a person, and a jury that finds one
+ * will say so; alleging it by default would put words in the reporter's mouth. A
+ * threat aimed at a person is harassment in Syra's UI, and
+ * `harassment.targeted_abuse` is where that lands.
+ */
+export const REPORT_TAXONOMY_VERSION = '2026.07';
+
+const CATEGORY_TO_ALLEGATION: Readonly<Record<ReportCategory, TaxonomyCode>> =
+  Object.freeze({
+    [ReportCategory.SPAM]: 'integrity.spam',
+    [ReportCategory.HARASSMENT]: 'harassment.targeted_abuse',
+    [ReportCategory.HATE_SPEECH]: 'hate.protected_targeting',
+    [ReportCategory.EXPLICIT_CONTENT]: 'sexual_content.explicit_activity',
+    [ReportCategory.IMPERSONATION]: 'integrity.impersonation',
+    [ReportCategory.VIOLENCE]: 'violence.graphic',
+    [ReportCategory.OTHER]: 'other.unclassifiable',
+  });
+
+/**
+ * The allegation codes for a report's categories, deduplicated and ORDERED.
+ *
+ * Order is not cosmetic. Ingress fingerprints the whole envelope to detect §10.5's
+ * "same external id, different body", so a list whose order depended on how a
+ * client happened to send its categories would turn a legitimate outbox retry into
+ * a permanent 409 — days later, as a report silently stuck in a queue.
+ */
+export function allegationsForCategories(
+  categories: readonly ReportCategory[],
+): TaxonomyCode[] {
+  const codes = new Set<TaxonomyCode>();
+  for (const category of categories) {
+    const code = CATEGORY_TO_ALLEGATION[category];
+    // A category the map does not cover cannot silently become nothing: a report
+    // with no allegation is not a report.
+    codes.add(code ?? 'other.unclassifiable');
+  }
+  return Array.from(codes).sort();
+}

--- a/packages/backend/src/moderation/roomSubject.test.ts
+++ b/packages/backend/src/moderation/roomSubject.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'bun:test';
+import mongoose from 'mongoose';
+import { connect, clear, disconnect } from '../test/mongo';
+import RoomModel, { RoomStatus, RoomType, OwnerType } from '../models/Room';
+import RecordingModel, { RecordingStatus, RecordingAccess } from '../models/Recording';
+import { PlaylistModel } from '../models/Playlist';
+import { subjectProviderFor } from './subjects/registry';
+import { ReportedType } from '../models/Report';
+import type { ModerationResource } from './subjects/types';
+
+/**
+ * What a room report does and does not carry.
+ *
+ * This is the file that holds the answer to "a live room is too ephemeral to
+ * report". It is not: the host-authored text is durable and answerable. What is
+ * withheld is the conversation and the recording, and each omission is asserted
+ * rather than left to a comment, because both are the kind of thing a later
+ * change would quietly add.
+ */
+
+beforeAll(connect);
+afterEach(clear);
+afterAll(disconnect);
+
+const HOST = 'oxy-host-1';
+
+async function makeRoom(overrides: Record<string, unknown> = {}) {
+  return await RoomModel.create({
+    title: 'Late night talk',
+    description: 'A description the host wrote',
+    topic: 'music',
+    tags: ['jazz', 'live'],
+    host: HOST,
+    ownerType: OwnerType.PROFILE,
+    type: RoomType.TALK,
+    status: RoomStatus.LIVE,
+    participants: ['listener-a', 'listener-b'],
+    speakers: ['speaker-a'],
+    streamTitle: 'Stream title',
+    streamDescription: 'Stream description',
+    ...overrides,
+  });
+}
+
+const provider = subjectProviderFor(ReportedType.ROOM);
+
+describe('room subject provider', () => {
+  it('is registered', () => {
+    expect(provider).toBeDefined();
+  });
+
+  it('pins the host-authored text and names the host as author', async () => {
+    const room = await makeRoom();
+    const snapshot = await provider?.snapshot(String(room._id));
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.subject.type).toBe('custom.syra.room');
+    expect(snapshot?.subject.externalId).toBe(String(room._id));
+    // The host wrote the title and description, so the host is answerable for them.
+    expect(snapshot?.subject.author?.oxyUserId).toBe(HOST);
+
+    const content = snapshot?.content as ModerationResource;
+    expect(content.type).toBe('metadata');
+    expect(content).toMatchObject({
+      data: {
+        title: 'Late night talk',
+        description: 'A description the host wrote\n\nStream description',
+        topicAndTags: 'music, jazz, live',
+        streamTitle: 'Stream title',
+      },
+    });
+  });
+
+  /**
+   * The participant list changes every few seconds, so pinning it would describe
+   * a roster that was never true of the session as a whole — and it would name
+   * people who did nothing but listen. Neither participants nor speakers may
+   * appear anywhere in the snapshot.
+   */
+  it('never carries the participant or speaker list', async () => {
+    const room = await makeRoom();
+    const snapshot = await provider?.snapshot(String(room._id));
+    const serialised = JSON.stringify(snapshot);
+
+    expect(serialised).not.toContain('listener-a');
+    expect(serialised).not.toContain('listener-b');
+    expect(serialised).not.toContain('speaker-a');
+    expect(snapshot?.content).toMatchObject({ data: { participantsIncluded: false } });
+  });
+
+  /**
+   * Syra records rooms by default and keeps them for months, so the temptation to
+   * attach one is real. It is refused on a privacy argument AND a mechanical one:
+   * recordings live in object storage addressed by `objectKey` with no digest, so
+   * there is no bare Oxy `fileId` an `AssetRef` could carry — only a URL on Syra's
+   * own host, which evidence must never be.
+   *
+   * The EXISTENCE is declared, so a jury can answer `insufficient_context` for the
+   * right reason instead of assuming the title was all there was.
+   */
+  it('declares that a recording exists without attaching it', async () => {
+    const room = await makeRoom();
+    await RecordingModel.create({
+      roomId: String(room._id),
+      roomTitle: room.title,
+      host: HOST,
+      status: RecordingStatus.READY,
+      egressId: 'egress-1',
+      objectKey: 'recordings/room-1.ogg',
+      startedAt: new Date(),
+      access: RecordingAccess.PUBLIC,
+      expiresAt: new Date(Date.now() + 1_000_000),
+    });
+
+    const snapshot = await provider?.snapshot(String(room._id));
+    expect(snapshot?.content).toMatchObject({
+      data: { recordingExists: true, recordingAttached: false },
+    });
+    // No attachment, and nothing that could be dereferenced back to Syra.
+    expect(snapshot?.attachments).toBeUndefined();
+    const serialised = JSON.stringify(snapshot);
+    expect(serialised).not.toContain('objectKey');
+    expect(serialised).not.toContain('recordings/room-1.ogg');
+    expect(serialised).not.toContain('egress-1');
+  });
+
+  it('says so plainly when there is no recording', async () => {
+    const room = await makeRoom();
+    const snapshot = await provider?.snapshot(String(room._id));
+    expect(snapshot?.content).toMatchObject({ data: { recordingExists: false } });
+  });
+
+  it('returns null for a deleted room and for an id that is not one', async () => {
+    expect(await provider?.snapshot(new mongoose.Types.ObjectId().toHexString())).toBeNull();
+    expect(await provider?.snapshot('not-an-object-id')).toBeNull();
+  });
+});
+
+describe('playlist subject provider', () => {
+  const playlistProvider = subjectProviderFor(ReportedType.PLAYLIST);
+
+  /**
+   * A private playlist has no audience, so a report about one either came from its
+   * owner — who can simply edit it — or from somebody who should not have seen it.
+   * Handing it to a jury of strangers would disclose more than the report ever
+   * justified.
+   */
+  it('declines a private playlist', async () => {
+    const playlist = await PlaylistModel.create({
+      name: 'Private mix',
+      ownerOxyUserId: 'oxy-user-9',
+      ownerUsername: 'owner9',
+      visibility: 'private',
+    });
+    expect(await playlistProvider?.snapshot(String(playlist._id))).toBeNull();
+  });
+
+  it('describes a public playlist and names its owner', async () => {
+    const playlist = await PlaylistModel.create({
+      name: 'Public mix',
+      description: 'Words the owner wrote',
+      ownerOxyUserId: 'oxy-user-9',
+      ownerUsername: 'owner9',
+      visibility: 'public',
+    });
+    const snapshot = await playlistProvider?.snapshot(String(playlist._id));
+    expect(snapshot?.subject.author?.oxyUserId).toBe('oxy-user-9');
+    expect(snapshot?.content).toMatchObject({
+      type: 'listing',
+      data: { title: 'Public mix', description: 'Words the owner wrote' },
+    });
+  });
+});

--- a/packages/backend/src/moderation/roomSubject.test.ts
+++ b/packages/backend/src/moderation/roomSubject.test.ts
@@ -124,6 +124,31 @@ describe('room subject provider', () => {
     expect(serialised).not.toContain('egress-1');
   });
 
+  /**
+   * The credential question, not the disclosure one.
+   *
+   * `rtmpStreamKey` + `rtmpUrl` are what a broadcaster authenticates with, so a
+   * juror who read them could broadcast into the very room they were asked to
+   * judge. This is the test that keeps the provider's projection a whitelist: it
+   * fails if anyone widens it to a bare `findById()`.
+   */
+  it('never carries the RTMP stream credential a juror could broadcast with', async () => {
+    const room = await makeRoom({
+      rtmpUrl: 'rtmp://ingress.example/live',
+      rtmpStreamKey: 'sk_live_super_secret_stream_key',
+      activeStreamUrl: 'https://cdn.example/stream.m3u8',
+    });
+
+    const snapshot = await provider?.snapshot(String(room._id));
+    const serialised = JSON.stringify(snapshot);
+
+    expect(serialised).not.toContain('sk_live_super_secret_stream_key');
+    expect(serialised).not.toContain('rtmp://ingress.example/live');
+    expect(serialised).not.toContain('rtmpStreamKey');
+    // The report is still a real report — the room's own text survives.
+    expect(snapshot?.content).toMatchObject({ data: { title: 'Late night talk' } });
+  });
+
   it('says so plainly when there is no recording', async () => {
     const room = await makeRoom();
     const snapshot = await provider?.snapshot(String(room._id));

--- a/packages/backend/src/moderation/subjects/providers.ts
+++ b/packages/backend/src/moderation/subjects/providers.ts
@@ -335,6 +335,21 @@ function roomProvider(): ModerationSubjectProvider {
 
     async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
       if (!mongoose.isValidObjectId(reportedId)) return null;
+      /**
+       * A WHITELIST, and the exclusion is the point rather than a side effect.
+       *
+       * The question to ask of any reported document is not only "what would a
+       * jury learn that it should not" but "is there anything here a jury could
+       * USE". On a room there is: `rtmpStreamKey` and `rtmpUrl` together are the
+       * credential for broadcasting INTO the room. A juror who read them could
+       * take over the stream of the room they were asked to judge.
+       *
+       * They are excluded at the Mongo projection so they are never loaded into
+       * this process at all — not filtered out later, where a future field added
+       * to a snapshot object could quietly pick them up again. Never widen this
+       * to a bare `findById()`; `roomSubject.test.ts` fails if the key ever
+       * reaches a snapshot.
+       */
       const room = await RoomModel.findById(reportedId)
         .select('title description topic tags host status streamTitle streamDescription createdAt')
         .lean<{

--- a/packages/backend/src/moderation/subjects/providers.ts
+++ b/packages/backend/src/moderation/subjects/providers.ts
@@ -1,0 +1,419 @@
+import mongoose from 'mongoose';
+import { CONTRACT_LIMITS } from '@oxyhq/crowdsource-contracts';
+import { PlaylistVisibility } from '@syra/shared-types';
+import { PlaylistModel } from '../../models/Playlist';
+import HouseModel from '../../models/House';
+import RoomModel from '../../models/Room';
+import RecordingModel from '../../models/Recording';
+import { TrackModel } from '../../models/Track';
+import { ArtistModel } from '../../models/CatalogEntity';
+import { ReportedType } from '../../models/Report';
+import type {
+  ModerationContextResource,
+  ModerationResource,
+  ModerationSubjectProvider,
+  ModerationSubjectSnapshot,
+} from './types';
+
+/**
+ * Syra's five deliverable nouns, described as universal material.
+ *
+ * One file rather than five, because every provider here is the same twenty
+ * lines — load the row, clamp its text, name its owner — and splitting them would
+ * put five imports and five headers around functions that share their whole
+ * shape. The seam that matters is {@link ModerationSubjectProvider}; where the
+ * implementations live is not load-bearing.
+ */
+
+const WEB_ORIGIN = process.env.FRONTEND_URL || 'https://syra.fm';
+
+/** A non-empty string clamped to a contract limit, or nothing. */
+function bounded(value: string | undefined | null, max: number): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, max) : undefined;
+}
+
+/** A `claims` / `metadata` value: bounded, flat, scalar (§5.3). */
+function claim(value: string | undefined | null): string | undefined {
+  return bounded(value, CONTRACT_LIMITS.METADATA_STRING_VALUE_MAX_LENGTH);
+}
+
+/**
+ * A user's playlist (`custom.syra.playlist`).
+ *
+ * The cleanest subject Syra has: `ownerOxyUserId` is a real Oxy identity, `name` and
+ * `description` are the owner's own words, and `visibility` says plainly whether
+ * anyone else can see it.
+ *
+ * A PRIVATE playlist returns `null`. Nobody but its owner can reach it, so a
+ * report about one either came from the owner — who can simply edit it — or from
+ * somebody who should not have seen it, and neither is a question for a jury of
+ * strangers. Handing a private list to a jury would disclose more than the report
+ * ever justified.
+ */
+function playlistProvider(): ModerationSubjectProvider {
+  return {
+    reportedType: ReportedType.PLAYLIST,
+    subjectType: 'custom.syra.playlist',
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      if (!mongoose.isValidObjectId(reportedId)) return null;
+      const playlist = await PlaylistModel.findById(reportedId)
+        .select('name description ownerOxyUserId visibility createdAt')
+        .lean<{
+          _id: mongoose.Types.ObjectId;
+          name?: string;
+          description?: string;
+          ownerOxyUserId?: string;
+          visibility?: string;
+          createdAt?: Date;
+        } | null>();
+      if (!playlist) return null;
+      if (playlist.visibility !== PlaylistVisibility.PUBLIC) return null;
+
+      const title = bounded(playlist.name, CONTRACT_LIMITS.SHORT_TEXT_MAX_LENGTH);
+      // A listing needs a title; a playlist cannot be created without a name, so
+      // an absent one is a corrupted row rather than a case to describe.
+      if (title === undefined) return null;
+      const description = bounded(
+        playlist.description,
+        CONTRACT_LIMITS.LONG_TEXT_MAX_LENGTH,
+      );
+
+      return {
+        subject: {
+          externalId: playlist._id.toHexString(),
+          type: 'custom.syra.playlist',
+          permalink: `${WEB_ORIGIN}/playlist/${playlist._id.toHexString()}`,
+          ...(playlist.ownerOxyUserId === undefined
+            ? {}
+            : { author: { oxyUserId: playlist.ownerOxyUserId } }),
+        },
+        content: {
+          type: 'listing',
+          data: {
+            title,
+            ...(description === undefined ? {} : { description }),
+          },
+          ...(playlist.createdAt === undefined
+            ? {}
+            : { createdAt: new Date(playlist.createdAt) }),
+        },
+      };
+    },
+  };
+}
+
+/**
+ * A house — a user-created community (`custom.syra.house`).
+ *
+ * Same shape as a playlist and the same rule about reach: a house nobody can
+ * discover is not something a jury should be shown. `canDiscover` on the model is
+ * the app's own answer to "is this visible", so it is asked here rather than
+ * re-derived from the visibility axes, which would be a second authority.
+ */
+function houseProvider(): ModerationSubjectProvider {
+  return {
+    reportedType: ReportedType.HOUSE,
+    subjectType: 'custom.syra.house',
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      if (!mongoose.isValidObjectId(reportedId)) return null;
+      const house = await HouseModel.findById(reportedId).lean<{
+        _id: mongoose.Types.ObjectId;
+        name?: string;
+        description?: string;
+        createdBy?: string;
+        visibility?: { discovery?: string };
+        createdAt?: Date;
+      } | null>();
+      if (!house) return null;
+
+      const title = bounded(house.name, CONTRACT_LIMITS.SHORT_TEXT_MAX_LENGTH);
+      if (title === undefined) return null;
+      const description = bounded(house.description, CONTRACT_LIMITS.LONG_TEXT_MAX_LENGTH);
+
+      return {
+        subject: {
+          externalId: house._id.toHexString(),
+          type: 'custom.syra.house',
+          permalink: `${WEB_ORIGIN}/house/${house._id.toHexString()}`,
+          ...(house.createdBy === undefined
+            ? {}
+            : { author: { oxyUserId: house.createdBy } }),
+        },
+        content: {
+          type: 'listing',
+          data: {
+            title,
+            ...(description === undefined ? {} : { description }),
+          },
+          ...(house.createdAt === undefined ? {} : { createdAt: new Date(house.createdAt) }),
+        },
+      };
+    },
+  };
+}
+
+/**
+ * A Syra artist profile (§5.3 `profile`).
+ *
+ * The one Syra noun that is a person's public identity rather than a thing they
+ * published, which is why it is `identity.profile` and why a plain listener is
+ * NOT reportable: a listener has no Syra-side profile at all, only an Oxy account
+ * that Oxy owns.
+ *
+ * `claimedByOxyUserId` is the author when it exists and is simply absent when it
+ * does not. An unclaimed artist is a catalog entity nobody has taken
+ * responsibility for — there is a profile to review but no principal to bind, and
+ * inventing one would attach a stranger to somebody else's page.
+ */
+function artistProvider(): ModerationSubjectProvider {
+  return {
+    reportedType: ReportedType.ARTIST,
+    subjectType: 'identity.profile',
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      if (!mongoose.isValidObjectId(reportedId)) return null;
+      const artist = await ArtistModel.findById(reportedId)
+        .select('name bio claimedByOxyUserId')
+        .lean<{
+          _id: mongoose.Types.ObjectId;
+          name?: string;
+          bio?: string;
+          claimedByOxyUserId?: string;
+        } | null>();
+      if (!artist) return null;
+
+      const displayName = bounded(artist.name, CONTRACT_LIMITS.SHORT_TEXT_MAX_LENGTH);
+      const bio = bounded(artist.bio, CONTRACT_LIMITS.LONG_TEXT_MAX_LENGTH);
+      const claims: Record<string, string> = {
+        // Whether anybody has taken responsibility for the page is exactly what an
+        // impersonation allegation turns on, so a jury is told plainly.
+        claimed: artist.claimedByOxyUserId ? 'true' : 'false',
+      };
+
+      return {
+        subject: {
+          externalId: artist._id.toHexString(),
+          type: 'identity.profile',
+          permalink: `${WEB_ORIGIN}/artist/${artist._id.toHexString()}`,
+          ...(artist.claimedByOxyUserId === undefined
+            ? {}
+            : { author: { oxyUserId: artist.claimedByOxyUserId } }),
+        },
+        content: {
+          type: 'profile',
+          data: {
+            ...(displayName === undefined ? {} : { displayName }),
+            ...(bio === undefined ? {} : { bio }),
+            claims,
+          },
+        },
+      };
+    },
+  };
+}
+
+/**
+ * A track (`custom.syra.track`).
+ *
+ * ## The audio is declared, never attached
+ *
+ * A track's substance is its audio, and Syra cannot hand that to a jury. The
+ * files are Syra-hosted HLS addressed by `hlsMasterKey`, encrypted, with no
+ * sha256 recorded anywhere — so there is no bare Oxy `fileId` for an `AssetRef`
+ * to carry, and shipping a URL on Syra's own host would tell that host when its
+ * content is under review while delivering live bytes rather than the pinned
+ * ones §5.6 requires.
+ *
+ * What travels is what a person WROTE: the title, and the artist's name as
+ * context. That is genuinely reportable material — a title carrying a slur is
+ * answerable on its face — and the metadata says plainly that audio exists which
+ * the jury was not given, so `insufficient_context` is available for the right
+ * reason rather than by accident.
+ *
+ * ## This is not the copyright path
+ *
+ * A track is also the object DMCA claims are about, and those go to
+ * `CopyrightReport` instead. Nothing here sets `copyrightRemoved`; the only
+ * enforcement a decision can reach is `isAvailable`, which is reversible.
+ */
+function trackProvider(): ModerationSubjectProvider {
+  return {
+    reportedType: ReportedType.TRACK,
+    subjectType: 'custom.syra.track',
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      if (!mongoose.isValidObjectId(reportedId)) return null;
+      const track = await TrackModel.findById(reportedId)
+        .select('title artistId createdAt')
+        .lean<{
+          _id: mongoose.Types.ObjectId;
+          title?: string;
+          artistId?: string;
+          createdAt?: Date;
+        } | null>();
+      if (!track) return null;
+
+      const title = bounded(track.title, CONTRACT_LIMITS.SHORT_TEXT_MAX_LENGTH);
+      if (title === undefined) return null;
+
+      const context: ModerationContextResource[] = [];
+      let ownerId: string | undefined;
+      if (track.artistId && mongoose.isValidObjectId(track.artistId)) {
+        const artist = await ArtistModel.findById(track.artistId)
+          .select('name claimedByOxyUserId')
+          .lean<{ name?: string; claimedByOxyUserId?: string } | null>();
+        ownerId = artist?.claimedByOxyUserId;
+        const artistName = bounded(artist?.name, CONTRACT_LIMITS.TEXT_RESOURCE_MAX_LENGTH);
+        if (artistName !== undefined) {
+          context.push({ role: 'context', type: 'text', data: { text: artistName } });
+        }
+      }
+
+      return {
+        subject: {
+          externalId: track._id.toHexString(),
+          type: 'custom.syra.track',
+          permalink: `${WEB_ORIGIN}/track/${track._id.toHexString()}`,
+          ...(ownerId === undefined ? {} : { author: { oxyUserId: ownerId } }),
+        },
+        content: {
+          type: 'metadata',
+          data: {
+            title,
+            /** Declared, not attached — see the note above. */
+            audioAttached: false,
+          },
+        },
+        ...(context.length > 0 ? { context } : {}),
+      };
+    },
+  };
+}
+
+/**
+ * A live or ended audio room (`custom.syra.room`).
+ *
+ * ## What is pinned, and what deliberately is not
+ *
+ * A room IS a durable document — `title`, `description`, `topic`, `tags`,
+ * `streamTitle`, `streamDescription` — and every one of those is HOST-AUTHORED.
+ * A room titled with a slur or described to advertise a scam is a real report
+ * with material §5.6 can pin and a jury can answer, and the host is answerable
+ * for it. So a room is reportable, and the host is the subject's author.
+ *
+ * **What is NOT pinned is the conversation**, and that is not a tooling gap.
+ * `participants` and `speakers` are mutable arrays that change every few seconds;
+ * snapshotting either would pin a roster that was never true of the session as a
+ * whole and would name people who merely listened. Neither travels.
+ *
+ * ## The recording exists, and is still not evidence
+ *
+ * Syra records rooms by default (`recordingEnabled` defaults to `true`, and
+ * `POST /rooms/:id/start` starts an egress) and keeps them for months. It would
+ * be easy to read `Recording.access === 'public'` as consent to send that audio
+ * to a jury. It is not: that field governs who may replay the room INSIDE Syra,
+ * and treating an in-app replay permission as consent to third-party review is
+ * exactly the inference this note exists to refuse.
+ *
+ * It is also not mechanically possible. Recordings live in object storage
+ * addressed by `objectKey` with no digest recorded, so there is no bare Oxy
+ * `fileId` an `AssetRef` could carry — only a URL on Syra's own host, which is
+ * the one thing evidence must never be.
+ *
+ * So the recording's EXISTENCE is declared and its content is withheld. A jury
+ * told nothing would assume the title was all there was; a jury told that audio
+ * exists which it was not given can answer `insufficient_context` for the right
+ * reason.
+ */
+function roomProvider(): ModerationSubjectProvider {
+  return {
+    reportedType: ReportedType.ROOM,
+    subjectType: 'custom.syra.room',
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      if (!mongoose.isValidObjectId(reportedId)) return null;
+      const room = await RoomModel.findById(reportedId)
+        .select('title description topic tags host status streamTitle streamDescription createdAt')
+        .lean<{
+          _id: mongoose.Types.ObjectId;
+          title?: string;
+          description?: string;
+          topic?: string;
+          tags?: string[];
+          host?: string;
+          status?: string;
+          streamTitle?: string;
+          streamDescription?: string;
+          createdAt?: Date;
+        } | null>();
+      if (!room) return null;
+
+      const title = bounded(room.title, CONTRACT_LIMITS.SHORT_TEXT_MAX_LENGTH);
+      if (title === undefined) return null;
+
+      /**
+       * Only the host's own words. A stream title and description are host-set
+       * too, so they belong with the rest of the material rather than in a
+       * separate resource a jury has to correlate.
+       */
+      const description = bounded(
+        [room.description, room.streamDescription]
+          .map((part) => part?.trim())
+          .filter((part): part is string => Boolean(part))
+          .join('\n\n'),
+        CONTRACT_LIMITS.LONG_TEXT_MAX_LENGTH,
+      );
+
+      const hasRecording =
+        (await RecordingModel.countDocuments({ roomId: room._id.toHexString() }).limit(1)) > 0;
+
+      const context: ModerationContextResource[] = [];
+      const topicAndTags = claim(
+        [room.topic?.trim(), ...(room.tags ?? [])].filter(Boolean).join(', '),
+      );
+
+      const content: ModerationResource = {
+        type: 'metadata',
+        data: {
+          title,
+          ...(description === undefined ? {} : { description }),
+          ...(topicAndTags === undefined ? {} : { topicAndTags }),
+          ...(claim(room.streamTitle) === undefined
+            ? {}
+            : { streamTitle: claim(room.streamTitle) ?? '' }),
+          ...(room.status === undefined ? {} : { roomStatus: room.status }),
+          /**
+           * The two withheld things, stated rather than left to be inferred.
+           * `participantsIncluded: false` is what tells a jury it is judging a
+           * room's description and not who was in it.
+           */
+          recordingExists: hasRecording,
+          recordingAttached: false,
+          participantsIncluded: false,
+        },
+      };
+
+      return {
+        subject: {
+          externalId: room._id.toHexString(),
+          type: 'custom.syra.room',
+          permalink: `${WEB_ORIGIN}/room/${room._id.toHexString()}`,
+          ...(room.host === undefined ? {} : { author: { oxyUserId: room.host } }),
+        },
+        content,
+        ...(context.length > 0 ? { context } : {}),
+      };
+    },
+  };
+}
+
+export const SYRA_SUBJECT_PROVIDERS: readonly ModerationSubjectProvider[] = Object.freeze([
+  playlistProvider(),
+  houseProvider(),
+  artistProvider(),
+  trackProvider(),
+  roomProvider(),
+]);

--- a/packages/backend/src/moderation/subjects/registry.ts
+++ b/packages/backend/src/moderation/subjects/registry.ts
@@ -1,0 +1,92 @@
+import { SYRA_SUBJECT_PROVIDERS } from './providers';
+import type { ModerationSubjectProvider } from './types';
+
+/**
+ * Every noun Syra can send for community review, and the §5.4 type each one is.
+ *
+ * Adding a subject type is one provider plus one entry. Nothing else in the
+ * integration knows what a track is — not the outbox, not the delivery worker,
+ * not the webhook receiver, not the enforcement service.
+ *
+ * ## This list decides DELIVERY, and nothing else
+ *
+ * A reported type with a provider here is sent to CrowdSource. A reported type
+ * WITHOUT one is still accepted by `POST /reports` and still stored — it simply
+ * never leaves. Making the registry an admission gate would break an
+ * application's existing report surfaces on the day it adopts CrowdSource;
+ * incremental adoption, one subject type at a time, is what makes this copyable.
+ *
+ * ## A room IS reportable — for what its host wrote, not for what was said
+ *
+ * The assumption worth correcting, because it is the one a reader arrives with: a
+ * live audio room is not too ephemeral to pin. `Room` is a durable document whose
+ * `title`, `description`, `topic`, `tags` and stream fields are all
+ * HOST-AUTHORED, and a room titled with a slur is answerable on its face. So it
+ * has a provider and the host is its author.
+ *
+ * What has no provider is the CONVERSATION. `participants` and `speakers` change
+ * every few seconds, so pinning either would name people who merely listened and
+ * would describe a roster that was never true of the session. And the recording —
+ * which does exist, by default, for months — is withheld on both a privacy
+ * argument and a mechanical one; `subjects/providers.ts` sets both out in full.
+ *
+ * ## Copyright is not here, and must never be added
+ *
+ * `CopyrightReport` plus `strikeService` already handle DMCA, and they stay
+ * separate. The universal taxonomy contains no copyright, infringement or IP code
+ * at all — forty codes across eleven families, and the nearest,
+ * `commerce.counterfeit`, is about goods. That absence is the contract declining
+ * the question: DMCA carries statutory process, counter-notice and safe-harbour
+ * consequences, and §7.5 sends material with legal weight to specialists rather
+ * than to a randomly drawn jury. A community vote must never be able to produce
+ * something that looks like a strike but carries none of the process one legally
+ * requires.
+ *
+ * ## Why a podcast has no provider
+ *
+ * Syra podcasts are MIRRORED from external RSS. The publisher is a third party
+ * who is not a Syra user, has no Oxy identity, and would never learn that a jury
+ * had judged them. `applicationId` comes off the credential, so a case would open
+ * in SYRA's tenant naming an actor Syra cannot act against beyond delisting its
+ * own mirror — and if the origin platform ever reported the same show under its
+ * own credential, §7.3's dedup key differs by tenant, so one show would get two
+ * cases and two juries.
+ *
+ * That is the same cross-application hand-off question the plan has not answered
+ * elsewhere, so the report stays local until it does. Delisting a mirror is still
+ * available to a human through the existing admin path; it simply is not a case.
+ *
+ * ## Why a listener has no provider
+ *
+ * Oxy owns identity, and a plain Syra listener has no Syra-side profile to
+ * snapshot — there is nothing §5.6 could pin. An ARTIST does have one, which is
+ * why `artist` is deliverable and `user` is not.
+ */
+
+const BY_REPORTED_TYPE: ReadonlyMap<string, ModerationSubjectProvider> = new Map(
+  SYRA_SUBJECT_PROVIDERS.map((provider) => [provider.reportedType, provider]),
+);
+
+/**
+ * The provider for a reported type, or `undefined` when it is not deliverable.
+ *
+ * The single authority on whether a report leaves this deployment. Intake asks
+ * before queueing a delivery and the snapshot builder asks again when it builds
+ * one; a type this returns `undefined` for is stored and never enqueued.
+ */
+export function subjectProviderFor(
+  reportedType: string,
+): ModerationSubjectProvider | undefined {
+  return BY_REPORTED_TYPE.get(reportedType);
+}
+
+/**
+ * The reported types wired to CrowdSource, as the registry itself sees them.
+ *
+ * Exists so a test can pin the set. The difference between a delivered type and a
+ * local-only one is invisible in a 201, so registering a provider — or forgetting
+ * to — is a change no response body would reveal.
+ */
+export function deliverableTypes(): string[] {
+  return Array.from(BY_REPORTED_TYPE.keys());
+}

--- a/packages/backend/src/moderation/subjects/types.ts
+++ b/packages/backend/src/moderation/subjects/types.ts
@@ -1,0 +1,90 @@
+/**
+ * The seam that makes this integration copyable.
+ *
+ * CrowdSource's side of the "don't design moderation around your own nouns"
+ * problem is already solved — the Case Envelope knows nothing about an agent, a
+ * post or a listing, and `@oxyhq/crowdsource` composes one from a description of
+ * the material. What is left for an application is a translation problem, and this
+ * file is the whole of it:
+ *
+ *     "given one of MY nouns and its id, describe the material"
+ *
+ * Everything downstream — resource ids, relations, digests, pseudonymous principal
+ * refs, the identity binding proof, the pinned policy version, privacy terms, the
+ * idempotency key, the envelope itself — is composed by the SDK from that
+ * description and is IDENTICAL for every application and every subject type. So
+ * adding a subject type is one file implementing {@link ModerationSubjectProvider}
+ * plus one line in the registry; nothing in the outbox, the delivery worker, the
+ * webhook receiver, the decision worker or the enforcement service changes.
+ *
+ * Two rules keep it that way, and both are load-bearing rather than stylistic:
+ *
+ * 1. **A provider returns a DESCRIPTION, never an envelope.** The types below are
+ *    the SDK's own input types, re-exported unchanged. A provider that built an
+ *    envelope would have to invent resource ids and principal refs, and §7.3's
+ *    dedup key is computed over exactly those — two reporters describing one agent
+ *    would open two cases, and "one penalty per incident" would fail in production
+ *    with nothing failing in a test.
+ * 2. **A provider is pure translation with reads.** It fetches its own object and
+ *    returns; it does not decide whether to deliver, what the allegation is, or
+ *    what happens to the report. Those belong to callers that are shared.
+ */
+
+import type { ContextInput, ReportSubjectInput, ResourceInput } from '@oxyhq/crowdsource';
+
+/**
+ * The SDK's resource description, unchanged.
+ *
+ * Re-exported as a type alias so a provider imports the vocabulary from this seam
+ * rather than from four places — but it IS the SDK's type, not a local restatement
+ * of it. A resource type added to the contract becomes available to every provider
+ * the moment the dependency is bumped.
+ */
+export type ModerationResource = ResourceInput;
+export type ModerationContextResource = ContextInput;
+
+/**
+ * One reported object, described.
+ *
+ * `content` is required because a report with no material is a question a jury
+ * cannot answer. An application that cannot produce the material for one of its
+ * nouns should not register a provider for it — see the registry.
+ */
+export interface ModerationSubjectSnapshot {
+  /** Identity, type and author of the reported object (§5.1 `subject`). */
+  readonly subject: ReportSubjectInput;
+  /** The reported material itself. A string is shorthand for plain text. */
+  readonly content: string | ModerationResource;
+  /** Media carried BY the subject. */
+  readonly attachments?: readonly ModerationResource[];
+  /**
+   * Surrounding material a jury needs to judge fairly — the agent a review is
+   * about, the instructions a listing runs on. Context, not extra exposure: §9.1
+   * keeps a reviewer's view to the minimum that makes the question answerable.
+   */
+  readonly context?: readonly ModerationContextResource[];
+}
+
+/**
+ * Translates one of Syra's nouns into universal material.
+ *
+ * `subjectType` is declared on the provider rather than returned per snapshot
+ * because it is a property of the noun (§5.4): every Syra agent is a
+ * `custom.alia.agent`, every agent review a `commerce.review`. Keeping it here
+ * means the registry can answer "what does this application report?" without
+ * loading a single object.
+ */
+export interface ModerationSubjectProvider {
+  /** Syra's own name for the noun, as it arrives on a report. */
+  readonly reportedType: string;
+  /** §5.4's namespaced subject type, or `custom.<organization>.<object_type>`. */
+  readonly subjectType: string;
+  /**
+   * Describes the object, or returns `null` when it no longer exists.
+   *
+   * `null` is not a failure. Content deleted between the report and its delivery
+   * is ordinary, and it is the caller's job to decide what that means — a provider
+   * that threw would make deletion look like an outage and be retried for days.
+   */
+  snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null>;
+}

--- a/packages/backend/src/moderation/topology.ts
+++ b/packages/backend/src/moderation/topology.ts
@@ -1,0 +1,70 @@
+import mongoose, { type Connection } from 'mongoose';
+
+/**
+ * Multi-document transactions require a replica set or a sharded cluster.
+ *
+ * Syra used no transactions at all before this feature, so nothing else in the
+ * application would ever notice a standalone `mongod`. It accepts every other
+ * write Syra makes and then fails the FIRST time a report and its outbox event try
+ * to commit together — which is the moment the outbox stops being able to protect
+ * anything.
+ *
+ * That failure is expensive to diagnose later and free to detect now, so the
+ * topology is checked when the integration is switched on rather than discovered
+ * at the first report. Mirrors CrowdSource's own `utils/mongoTopology.ts`, which
+ * cannot be imported here — its backend is a private package.
+ */
+
+interface HelloResponse {
+  /** Present on a replica set member. */
+  setName?: unknown;
+  /** `isdbgrid` on a mongos router. */
+  msg?: unknown;
+}
+
+/** True when the connected deployment can run multi-document transactions. */
+export function supportsTransactions(hello: HelloResponse): boolean {
+  const isReplicaSet = typeof hello.setName === 'string' && hello.setName.length > 0;
+  const isShardedCluster = hello.msg === 'isdbgrid';
+  return isReplicaSet || isShardedCluster;
+}
+
+export const STANDALONE_TOPOLOGY_MESSAGE =
+  'MongoDB is a standalone deployment, which cannot run multi-document transactions. ' +
+  'The moderation outbox requires a report and its delivery event to commit together, ' +
+  'so moderation work would be silently lost. Connect to a replica set or a sharded ' +
+  "cluster (check with `mongosh --eval 'rs.status().set'`).";
+
+/**
+ * Whether this deployment can run the moderation outbox at all.
+ *
+ * Returns rather than throws, and the caller decides. Syra is an AI platform whose
+ * chat surface has nothing to do with moderation, so refusing to boot the whole
+ * API over a misconfigured optional integration would trade a contained failure
+ * for an outage. The dispatcher logs at error level and stays down instead, and
+ * intake still throws per-request — two loud signals, neither of them silent.
+ */
+export async function assertTransactionalTopology(
+  connection: Connection = mongoose.connection,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const database = connection.db;
+  if (!database) {
+    return {
+      ok: false,
+      reason: 'Cannot inspect the MongoDB topology before a connection is open.',
+    };
+  }
+
+  try {
+    const hello = (await database.admin().command({ hello: 1 })) as HelloResponse;
+    if (supportsTransactions(hello)) return { ok: true };
+    return { ok: false, reason: STANDALONE_TOPOLOGY_MESSAGE };
+  } catch (error: unknown) {
+    return {
+      ok: false,
+      reason: `Could not inspect the MongoDB topology: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}

--- a/packages/backend/src/routes/crowdsourceWebhook.mount.test.ts
+++ b/packages/backend/src/routes/crowdsourceWebhook.mount.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'bun:test';
+import express, { type Express } from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { caseDecidedEventFixture, signWebhookDelivery } from '@oxyhq/crowdsource-testing';
+import { connect, clear, disconnect } from '../test/mongo';
+import { resetCrowdSourceConfig } from '../moderation/config';
+import { assertRawBody, createCrowdSourceWebhookRoutes } from './crowdsourceWebhook.routes';
+
+/**
+ * The mount order, which is part of the correctness and which no type can hold.
+ *
+ * The receiver's HMAC covers the exact bytes that arrived and it reads the request
+ * stream itself. Below a JSON parser it would be verifying a signature over a
+ * re-serialization, so it refuses outright — and this file is what makes that
+ * refusal a regression test rather than a comment.
+ */
+
+const SECRET = 'whsec_test_secret_value_for_syra';
+
+interface Harness {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function listen(app: Express): Promise<Harness> {
+  const server: Server = await new Promise((resolve) => {
+    const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        // `fetch` leaves a keep-alive socket open, and `close()` waits for every
+        // connection to end — so without `closeAllConnections()` the teardown
+        // hook hangs until the runner kills it, and the failure reads as the
+        // request rather than the harness. The close error is ignored on purpose:
+        // "Server is not running" is the ordinary outcome when a test already
+        // tore its own server down, and it is not a result worth failing on.
+        server.close(() => resolve());
+        server.closeAllConnections();
+      }),
+  };
+}
+
+/** Production: the receiver sits ABOVE the parser, as in `server.ts`. */
+function correctlyMountedApp(): Express {
+  const app = express();
+  app.use('/webhooks', createCrowdSourceWebhookRoutes());
+  app.use(express.json());
+  return app;
+}
+
+/** The regression: a parser ran first. */
+function wronglyMountedApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/webhooks', createCrowdSourceWebhookRoutes());
+  return app;
+}
+
+let harness: Harness | undefined;
+
+/**
+ * A real database, because the correctly-mounted path runs all the way through
+ * the SDK middleware into the Mongo-backed dedupe store. Without a connection
+ * mongoose buffers the insert for ten seconds and the teardown hook times out —
+ * which reads as a transport failure rather than a missing connection.
+ */
+beforeAll(connect);
+afterAll(disconnect);
+
+beforeEach(() => {
+  process.env.CROWDSOURCE_ENABLED = 'true';
+  process.env.CROWDSOURCE_SERVICE_KEY = 'app_1:cred_1:secret';
+  process.env.CROWDSOURCE_WEBHOOK_SECRET = SECRET;
+  resetCrowdSourceConfig();
+});
+
+afterEach(async () => {
+  await harness?.close();
+  await clear();
+  harness = undefined;
+  delete process.env.CROWDSOURCE_ENABLED;
+  delete process.env.CROWDSOURCE_SERVICE_KEY;
+  delete process.env.CROWDSOURCE_WEBHOOK_SECRET;
+  resetCrowdSourceConfig();
+});
+
+/**
+ * The simulator returns the exact bytes it signed. Re-serialising the event here
+ * would produce a different body than the signature covers and turn every one of
+ * these into an accidental tamper test.
+ */
+function signedDelivery() {
+  return signWebhookDelivery({ secret: SECRET, event: caseDecidedEventFixture() });
+}
+
+describe('CrowdSource webhook mount order', () => {
+  it('reaches the verifier when mounted above the parser', async () => {
+    harness = await listen(correctlyMountedApp());
+    const delivery = signedDelivery();
+    const response = await fetch(`${harness.url}/webhooks/crowdsource`, {
+      method: 'POST',
+      headers: delivery.headers,
+      body: delivery.body,
+    });
+    // No 500: the guard passed and the SDK middleware took the request.
+    expect(response.status).not.toBe(500);
+    expect(response.status).not.toBe(404);
+  });
+
+  /**
+   * Mutation evidence in permanent form. Move the mount below `express.json()`
+   * and this fails — with a refusal rather than a signature mismatch, so the
+   * diagnosis is in the failure.
+   */
+  it('REFUSES to verify anything when mounted below the parser', async () => {
+    harness = await listen(wronglyMountedApp());
+    const delivery = signedDelivery();
+    const response = await fetch(`${harness.url}/webhooks/crowdsource`, {
+      method: 'POST',
+      headers: delivery.headers,
+      body: delivery.body,
+    });
+
+    expect(response.status).toBe(500);
+    const payload: unknown = await response.json();
+    // A refusal reason and nothing about the delivery it refused.
+    expect(JSON.stringify(payload)).toContain('misconfigured');
+    expect(JSON.stringify(payload)).not.toContain('signature');
+  });
+
+  it('sees an unparsed body when mounted above the parser', async () => {
+    let observedBodyType = 'never ran';
+    const app = express();
+    const router = express.Router();
+    router.post('/crowdsource', (req, res) => {
+      observedBodyType = typeof req.body;
+      res.status(204).end();
+    });
+    app.use('/webhooks', router);
+    app.use(express.json());
+    harness = await listen(app);
+
+    await fetch(`${harness.url}/webhooks/crowdsource`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hello: 'world' }),
+    });
+
+    expect(observedBodyType).toBe('undefined');
+  });
+});
+
+describe('assertRawBody in isolation', () => {
+  function run(body: unknown): { statusCode: number | undefined; passedThrough: boolean } {
+    let statusCode: number | undefined;
+    let passedThrough = false;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json() {
+        return this;
+      },
+    };
+    assertRawBody(
+      { body } as express.Request,
+      res as unknown as express.Response,
+      () => {
+        passedThrough = true;
+      },
+    );
+    return { statusCode, passedThrough };
+  }
+
+  it('passes through only when the body is untouched', () => {
+    expect(run(undefined)).toEqual({ statusCode: undefined, passedThrough: true });
+  });
+
+  /**
+   * A Buffer means `express.raw()` ran, which is not this route's mount either —
+   * it reads the stream itself, so accepting a Buffer would make the guard depend
+   * on somebody else's parser staying configured as it is today.
+   */
+  it('refuses a parsed object, an empty object and a Buffer alike', () => {
+    for (const body of [{ a: 1 }, {}, Buffer.from('{}'), '', 'text']) {
+      const outcome = run(body);
+      expect(outcome.passedThrough).toBe(false);
+      expect(outcome.statusCode).toBe(500);
+    }
+  });
+});
+
+describe('CrowdSource webhook route without a secret', () => {
+  /**
+   * Not mounted, rather than mounted and permissive. A route that answers anything
+   * at all without a secret is a route that will one day be reasoned about as if it
+   * verified something.
+   */
+  it('404s, indistinguishably from not having the feature', async () => {
+    delete process.env.CROWDSOURCE_ENABLED;
+    delete process.env.CROWDSOURCE_WEBHOOK_SECRET;
+    resetCrowdSourceConfig();
+
+    const app = express();
+    app.use('/webhooks', createCrowdSourceWebhookRoutes());
+    harness = await listen(app);
+    const response = await fetch(`${harness.url}/webhooks/crowdsource`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/backend/src/routes/crowdsourceWebhook.routes.ts
+++ b/packages/backend/src/routes/crowdsourceWebhook.routes.ts
@@ -1,0 +1,177 @@
+import { Router, type NextFunction, type Request, type Response } from 'express';
+import { crowdsourceWebhooks } from '@oxyhq/crowdsource-express';
+import { crowdSourceConfig } from '../moderation/config';
+import {
+  recordDecisionEvent,
+  recordIgnoredEvent,
+} from '../moderation/inbound-service';
+import { mongoProcessedEventStore } from '../moderation/event-store';
+import { logger } from '../utils/logger';
+
+/**
+ * `POST /webhooks/crowdsource` — where decisions come back.
+ *
+ * ## The mount is part of the correctness
+ *
+ * This router MUST be mounted before `express.json()` in `index.ts`. The signature
+ * covers `timestamp + "." + rawBody` — the bytes that arrived — and once a JSON
+ * parser has run, those bytes are gone.
+ *
+ * Syra's parser happens to keep a Buffer copy on `req.rawBody`, which
+ * `@oxyhq/crowdsource-express` would accept, so mounting late would appear to work
+ * — and that is exactly why the guard below exists rather than a comment. The
+ * `verify` hook that populates `req.rawBody` is there for the provider HMAC and
+ * belongs to another feature entirely; the day somebody removes or narrows it,
+ * webhook verification would start signing over a re-serialisation with nothing
+ * failing. Reading the stream ourselves depends on nothing.
+ *
+ * ## What this handler does and does not do
+ *
+ * It records and returns. §10.8 asks a receiver to answer 2xx quickly and queue
+ * the processing, and the reason is not latency: applying a decision means reading
+ * catalog rows, planning enforcement and writing several collections, and a
+ * receiver that did all that inline would time out under a burst and be retried
+ * while the first attempt was still running. So the event and a durable
+ * `decision.apply` outbox row commit in ONE transaction, and the dispatcher does
+ * the work.
+ *
+ * Nothing here is authenticated by Oxy. The HMAC IS the authentication (§10.8),
+ * and an Oxy session must never satisfy this route — it is not a user endpoint.
+ */
+
+/**
+ * Refuses to run if a body parser got here first.
+ *
+ * The invariant this protects is a MOUNT ORDER, which no type can express and no
+ * unit test of this file alone would notice. Answering 500 rather than falling
+ * back is the point: a receiver that verified a signature over bytes it
+ * reconstructed would be worse than one that plainly refuses, because it would
+ * keep accepting deliveries and nobody would ever look.
+ */
+export function assertRawBody(req: Request, res: Response, next: NextFunction): void {
+  if (typeof req.body !== 'undefined') {
+    logger.error('[CrowdSource] webhook route is mounted AFTER a body parser; refusing to verify', { bodyType: typeof req.body });
+    res.status(500).json({
+      error: 'The CrowdSource webhook route is misconfigured on this deployment.',
+    });
+    return;
+  }
+  next();
+}
+
+/**
+ * One string field out of an event payload this version does not know.
+ *
+ * `WebhookEventEnvelope.data` is deliberately OPAQUE in the contract: an
+ * unrecognised event's payload is whatever a newer CrowdSource decided to send,
+ * and property access on it does not compile. That is the contract being honest
+ * rather than an obstacle, so this reads the key defensively instead of asserting
+ * a shape nobody has verified. Anything that is not a string is treated as absent,
+ * which is the only safe reading of a field this deployment has never seen.
+ */
+function stringField(source: unknown, key: string): string | undefined {
+  if (typeof source !== 'object' || source === null) return undefined;
+  const value: unknown = Reflect.get(source, key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function createCrowdSourceWebhookRoutes(): Router {
+  const router = Router();
+
+  const secret = crowdSourceConfig().webhookSecret;
+  if (!secret) {
+    /**
+     * Not mounted, rather than mounted and permissive.
+     *
+     * A route that answers anything at all without a secret is a route that will
+     * one day be reasoned about as if it verified something. An unconfigured
+     * deployment 404s here, which is indistinguishable from not having the feature
+     * — which is exactly what it is.
+     */
+    logger.info('[CrowdSource] webhook route not mounted: no CROWDSOURCE_WEBHOOK_SECRET');
+    return router;
+  }
+
+  const previousSecret = crowdSourceConfig().webhookPreviousSecret;
+
+  router.post(
+    '/crowdsource',
+    assertRawBody,
+    crowdsourceWebhooks({
+      secret,
+      ...(previousSecret === undefined ? {} : { previousSecret }),
+      // Shared across ECS tasks: the in-process default would dedupe only the
+      // instance that happened to receive both copies of a redelivery.
+      store: mongoProcessedEventStore(),
+      on: {
+        /**
+         * A decision, provisional or final. Both are queued: a provisional
+         * decision is real (§9.6) and Syra records it; what it may ACT on is
+         * decided by the enforcement mode, not by discarding the event here.
+         */
+        'case.decided': async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+        /**
+         * A later revision replacing an earlier one (§10.6). The SAME path: the
+         * decision worker compares revisions and the enforcement service reverses
+         * what the superseded revision did. A correction is not a special case
+         * with its own code — it is an ordinary decision that supersedes another,
+         * and giving it a separate path is how a restore ends up not being
+         * idempotent.
+         */
+        'decision.corrected': async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+        /**
+         * An appeal's outcome carries a decision too, and it is the current answer
+         * for the case, so it takes the same path.
+         */
+        'appeal.decided': async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+      },
+      /**
+       * Every other event type — including one this version of the contracts
+       * package has never heard of (§10.11).
+       *
+       * Recorded rather than dropped. `case.created`, `case.escalated` and
+       * `case.closed` carry no decision and nothing to enforce, but "did
+       * CrowdSource tell us about this case, and when" is the first question asked
+       * when a report appears stuck, and the answer has to exist somewhere.
+       */
+      onUnhandled: async (event) => {
+        await recordIgnoredEvent({
+          eventId: event.id,
+          type: event.type,
+          caseId: stringField(event.data, 'caseId'),
+        });
+      },
+      /**
+       * A refusal reason and nothing else — never a body, a header or a
+       * signature (§10.8's last line). It is a bounded token, so logging it
+       * cannot leak the delivery it refused.
+       */
+      onRejected: (rejection) => {
+        logger.warn('[CrowdSource] webhook delivery refused', { rejection });
+      },
+    }),
+  );
+
+  return router;
+}

--- a/packages/backend/src/routes/reports.routes.ts
+++ b/packages/backend/src/routes/reports.routes.ts
@@ -1,0 +1,179 @@
+import { Router, type Request, type Response } from 'express';
+import { getRequiredOxyUserId, type OxyAuthRequest } from '@oxyhq/core/server';
+import { createReport, DuplicateReportError } from '../moderation/intake';
+import { ReportCategory, ReportedType } from '../models/Report';
+import { logger } from '../utils/logger';
+
+/**
+ * `POST /reports` — a user tells Syra something is wrong.
+ *
+ * A 201 means the report was STORED, and — when its type has a subject provider —
+ * that a durable promise to deliver it was stored in the same transaction. It does
+ * not mean CrowdSource accepted anything, and the response deliberately does not
+ * pretend otherwise: `delivery` says `queued` or `local`, and nothing here reports
+ * a case id, because at this point there is none.
+ *
+ * Every reportable type is accepted, including the ones with no provider. A type
+ * without one is stored with the reason recorded and never leaves — see
+ * `moderation/subjects/registry.ts` for why that is a missing provider rather
+ * than a refused report.
+ */
+
+const router = Router();
+
+const MAX_CATEGORIES = 3;
+const MAX_DETAILS_LENGTH = 2_000;
+
+interface ValidationFailure {
+  status: number;
+  error: string;
+}
+
+type Validated =
+  | { ok: true; reportedType: ReportedType; reportedId: string; categories: ReportCategory[]; details?: string }
+  | { ok: false; failure: ValidationFailure };
+
+/**
+ * Validate the request body without trusting any of it.
+ *
+ * `reportedId` is checked to be a non-empty STRING here and again in
+ * `createReport`. That is not redundant: a truthiness check passes `{$ne: null}`,
+ * and an operator reaching a `findOne` filter matches an unrelated row — so the
+ * type is asserted at the boundary AND at the query, because the intake service is
+ * exported and this route is not its only possible caller.
+ */
+function validate(body: unknown): Validated {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, failure: { status: 400, error: 'A request body is required.' } };
+  }
+
+  const reportedType: unknown = Reflect.get(body, 'reportedType');
+  if (
+    typeof reportedType !== 'string' ||
+    !Object.values(ReportedType).includes(reportedType as ReportedType)
+  ) {
+    return {
+      ok: false,
+      failure: {
+        status: 400,
+        error: `'reportedType' must be one of: ${Object.values(ReportedType).join(', ')}.`,
+      },
+    };
+  }
+
+  const reportedId: unknown = Reflect.get(body, 'reportedId');
+  if (typeof reportedId !== 'string' || reportedId.trim() === '') {
+    return {
+      ok: false,
+      failure: { status: 400, error: "'reportedId' must be a non-empty string." },
+    };
+  }
+
+  const rawCategories: unknown = Reflect.get(body, 'categories');
+  if (!Array.isArray(rawCategories) || rawCategories.length === 0) {
+    return {
+      ok: false,
+      failure: { status: 400, error: "'categories' must be a non-empty array." },
+    };
+  }
+  if (rawCategories.length > MAX_CATEGORIES) {
+    return {
+      ok: false,
+      failure: {
+        status: 400,
+        error: `'categories' must name at most ${MAX_CATEGORIES} categories.`,
+      },
+    };
+  }
+  const allowed = Object.values(ReportCategory);
+  const categories: ReportCategory[] = [];
+  for (const candidate of rawCategories) {
+    if (typeof candidate !== 'string' || !allowed.includes(candidate as ReportCategory)) {
+      return {
+        ok: false,
+        failure: {
+          status: 400,
+          error: `Each category must be one of: ${allowed.join(', ')}.`,
+        },
+      };
+    }
+    if (!categories.includes(candidate as ReportCategory)) {
+      categories.push(candidate as ReportCategory);
+    }
+  }
+
+  const rawDetails: unknown = Reflect.get(body, 'details');
+  if (rawDetails !== undefined && typeof rawDetails !== 'string') {
+    return { ok: false, failure: { status: 400, error: "'details' must be a string." } };
+  }
+  const details = rawDetails?.trim();
+
+  return {
+    ok: true,
+    reportedType: reportedType as ReportedType,
+    reportedId,
+    categories,
+    ...(details ? { details: details.slice(0, MAX_DETAILS_LENGTH) } : {}),
+  };
+}
+
+router.post('/', async (req: Request, res: Response) => {
+  const reporter = getRequiredOxyUserId(req as OxyAuthRequest);
+
+  const validated = validate(req.body);
+  if (!validated.ok) {
+    return res.status(validated.failure.status).json({ error: validated.failure.error });
+  }
+
+  try {
+    const result = await createReport({
+      reporter,
+      reportedType: validated.reportedType,
+      reportedId: validated.reportedId,
+      categories: validated.categories,
+      ...(validated.details === undefined ? {} : { details: validated.details }),
+    });
+
+    return res.status(201).json({
+      report: {
+        id: result.report._id.toHexString(),
+        reportedType: result.report.reportedType,
+        reportedId: result.report.reportedId,
+        categories: result.report.categories,
+        status: result.report.status,
+        createdAt: result.report.createdAt,
+      },
+      /**
+       * What actually happened, in one word a client can branch on. `local` is not
+       * a failure and must not be presented as one — it means Syra recorded the
+       * report and has no route to community review for this kind of object.
+       */
+      delivery: result.outboxEventId === undefined ? 'local' : 'queued',
+    });
+  } catch (error: unknown) {
+    if (error instanceof DuplicateReportError) {
+      /**
+       * 409 with the original report, not a silent success. A reporter who taps
+       * twice should learn that Syra already has it, and a client that treated a
+       * duplicate as a new report would show two receipts for one action.
+       */
+      return res.status(409).json({
+        error: error.message,
+        report: {
+          id: String(error.existing._id),
+          reportedType: error.existing.reportedType,
+          reportedId: error.existing.reportedId,
+          status: error.existing.status,
+          createdAt: error.existing.createdAt,
+        },
+      });
+    }
+    if (error instanceof TypeError) {
+      return res.status(400).json({ error: error.message });
+    }
+    logger.error('Error creating report', { err: error, reportedType: validated.reportedType });
+    return res.status(500).json({ error: 'Failed to create report' });
+  }
+});
+
+export default router;

--- a/packages/backend/src/test/mongo.ts
+++ b/packages/backend/src/test/mongo.ts
@@ -14,10 +14,24 @@
  */
 
 import mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
 import { setCatalogImageMirrorImplementationForTests } from '../services/catalog/catalogImageAssets';
 
-let server: MongoMemoryServer | undefined;
+/**
+ * A single-member REPLICA SET, not a standalone.
+ *
+ * Multi-document transactions require a replica set or a sharded cluster, and the
+ * moderation outbox is built on one: a report and its delivery event commit
+ * together or not at all. On a standalone the first such write throws, so the
+ * coupling could not be tested at all — and an untested coupling is exactly the
+ * one that fails silently in production as a report answered 201 that nothing
+ * ever sends.
+ *
+ * One member behaves identically to a standalone for every other test, and it is
+ * still ONE mongod for the whole process, so the resource-contention fix this
+ * module was written for is preserved.
+ */
+let server: MongoMemoryReplSet | undefined;
 let connecting: Promise<void> | undefined;
 
 export function installCatalogImageMirrorMockForTests(): void {
@@ -60,7 +74,7 @@ export async function connect(): Promise<void> {
   if (connecting) return connecting;                // in-flight — share the promise
 
   connecting = (async () => {
-    server = await MongoMemoryServer.create();
+    server = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
     await mongoose.connect(server.getUri());
   })();
   await connecting;


### PR DESCRIPTION
Wires Syra into CrowdSource participatory moderation. **Observe mode by default** — nothing is removed until `CROWDSOURCE_ENFORCEMENT_MODE` changes, and the integration is inert without `CROWDSOURCE_ENABLED=true`.

## A room IS reportable — the ephemerality premise was wrong

The brief assumed a live audio room is too ephemeral to pin. It isn't. `Room` is a durable document whose `title`, `description`, `topic`, `tags`, `streamTitle` and `streamDescription` are all **host-authored**. A room titled with a slur or described to advertise a scam is answerable on its face, §5.6 has something to pin, and the host is the subject's author.

**What is withheld is the conversation.** `participants` and `speakers` change every few seconds, so pinning either would describe a roster that was never true of the session and would name people who only listened. A test asserts they appear nowhere in the snapshot.

**And the recording, which does exist.** Syra records rooms by default (`recordingEnabled` defaults `true`, `POST /rooms/:id/start` starts an egress, ~6-month retention), so this needed an argument rather than an assumption:

- `Recording.access` defaulting to `public` governs replay **inside Syra**. Treating an in-app replay permission as consent to third-party review is exactly the wrong inference.
- It is not mechanically possible either: recordings live in object storage addressed by `objectKey` with **no digest recorded**, so there is no bare Oxy `fileId` an `AssetRef` could carry — only a URL on Syra's own host, which evidence must never be.

The *existence* is declared (`recordingExists: true, recordingAttached: false`) so a jury can answer `insufficient_context` for the right reason. Tests assert the `objectKey` and `egressId` never leak.

## Copyright stays in `CopyrightReport`, and the contract says so

`CopyrightReport` + `strikeService` are untouched. The universal taxonomy has **forty codes across eleven families and not one** for copyright, infringement or IP — `commerce.counterfeit` is about goods. That absence is the contract declining the question: DMCA carries statutory process, counter-notice and safe-harbour consequences, and §7.5 routes legal material to specialists rather than a drawn jury.

So `ReportCategory` has no `copyright` value, enforcement never touches `copyrightRemoved` or `strikeService`, and a test asserts **both sides** — including failing if a future contracts release ever adds an infringement code, so the decision gets made deliberately rather than by import.

## Subjects

| Delivered | §5.4 type | | Accepted, never delivered |
|---|---|---|---|
| `playlist` | `custom.syra.playlist` | | `podcast` / `episode` — mirrored from external RSS; the publisher is not a Syra user, has no Oxy identity, and would never learn a jury judged them |
| `house` | `custom.syra.house` | | `user` — Oxy owns identity; an *artist* has a Syra profile, a listener does not |
| `artist` | `identity.profile` | | |
| `track` | `custom.syra.track` | | |
| `room` | `custom.syra.room` | | |

## Load-bearing details

- **The report and its outbox event commit in one REAL transaction.** The shared test harness moves from `MongoMemoryServer` to a single-member `MongoMemoryReplSet` so the coupling is exercised for real rather than mocked. One member behaves identically for every existing test and it is still one mongod per process, preserving the resource-contention fix that harness was written for. All 500 pre-existing tests still pass.
- **Webhook receiver above `express.json()`**, beside the LiveKit webhook that is there for the same reason, and it refuses outright if a parser ran first.
- **No `label_sensitive`, no `demote`.** Syra renders no warning and has no promotion flag, so `label`/`allow_with_label`/`age_gate`/`reduce_distribution` are recorded as `manual_review` rather than **upgraded** into the only effect Syra has, which is removal from the catalog. `medium` severity asks a human for the same reason — there is no middle lever.
- **CrowdSource config reads `process.env`**, not the zod `env` which is parsed once at import: the enabled flag and the two secrets only mean anything together, and that combination has to stay re-derivable.
- No `CROWDSOURCE_APP_ID`. `@oxyhq/crowdsource*` pinned at `0.3.0` with `@oxyhq/crowdsource-contracts` declared **directly** (peer dep; bun installs a missing peer silently).

## Verification

- **582 pass, 0 fail** (baseline was 500 — +82 new), `tsc --noEmit` clean, `bun install` leaves `bun.lock` matching the manifest change only.
- **Mutation evidence**, each confirmed present in source *and* type-clean before its failure was believed:
  - remove the `session.inTransaction()` guard → 2 tests fail, tsc silent;
  - remove `assertRawBody` from the route chain → the misconfigured-mount test fails.
- Two real bugs the real-database tests caught that a mocked suite could not: `$setOnInsert` colliding with Mongoose `timestamps: true` (aborted the whole intake transaction), and the playlist owner field being `ownerOxyUserId`, not `oxyUserId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)