### PR TITLE
test: assert the webhook's side effects, and that the HMAC is actually compared

### DIFF
--- a/packages/backend/src/routes/crowdsourceWebhook.mount.test.ts
+++ b/packages/backend/src/routes/crowdsourceWebhook.mount.test.ts
@@ -4,7 +4,10 @@ import type { AddressInfo } from 'net';
 import type { Server } from 'http';
 import { caseDecidedEventFixture, signWebhookDelivery } from '@oxyhq/crowdsource-testing';
 import { connect, clear, disconnect } from '../test/mongo';
+import { ModerationEventModel } from '../models/ModerationEvent';
+import { ModerationOutboxModel } from '../models/ModerationOutbox';
 import { resetCrowdSourceConfig } from '../moderation/config';
+import { logger } from '../utils/logger';
 import { assertRawBody, createCrowdSourceWebhookRoutes } from './crowdsourceWebhook.routes';
 
 /**
@@ -98,7 +101,17 @@ function signedDelivery() {
 }
 
 describe('CrowdSource webhook mount order', () => {
-  it('reaches the verifier when mounted above the parser', async () => {
+  /**
+   * The acceptance sibling — asserted on SIDE EFFECTS, not on a status code.
+   *
+   * A refusal test alone only proves the request was malformed somehow. This is
+   * its pair, and it has to prove the same delivery is genuinely handled, which a
+   * status code cannot do: this receiver answers `200 { handled: false }` to an
+   * envelope the schema rejects, so an endpoint that ran no handler at all would
+   * satisfy every status assertion. The decision reaching the database is the
+   * only thing that distinguishes "accepted" from "acknowledged and dropped".
+   */
+  it('accepts a signed delivery and records the decision', async () => {
     harness = await listen(correctlyMountedApp());
     const delivery = signedDelivery();
     const response = await fetch(`${harness.url}/webhooks/crowdsource`, {
@@ -106,9 +119,70 @@ describe('CrowdSource webhook mount order', () => {
       headers: delivery.headers,
       body: delivery.body,
     });
-    // No 500: the guard passed and the SDK middleware took the request.
-    expect(response.status).not.toBe(500);
-    expect(response.status).not.toBe(404);
+
+    expect(response.status).toBeGreaterThanOrEqual(200);
+    expect(response.status).toBeLessThan(300);
+    expect(await response.json()).toMatchObject({ handled: true });
+
+    // §10.8: the event is recorded and the work is queued, in one transaction.
+    expect(await ModerationEventModel.countDocuments({ state: 'queued' })).toBe(1);
+    expect(await ModerationOutboxModel.countDocuments({ kind: 'decision.apply' })).toBe(1);
+  });
+
+  /**
+   * That the HMAC is actually compared, which nothing else here proves.
+   *
+   * Every other test in this file would pass with the signature check deleted —
+   * they turn on the mount, not on the cryptography. A tampered body against a
+   * valid signature is refused, and the assertion names the rejection REASON
+   * rather than the status: a 401 for a missing header would satisfy a
+   * status-only test while proving the signature was never compared at all.
+   */
+  it('refuses a tampered body, for the signature reason specifically', async () => {
+    /**
+     * Observed through the route's own `onRejected`, which logs the reason —
+     * rather than by adding a test-only parameter to the factory. The production
+     * path is the thing under test; a seam built for the test would be a
+     * different path that happens to agree.
+     */
+    const rejections: string[] = [];
+    const originalWarn = logger.warn;
+    logger.warn = ((message: string, meta?: unknown) => {
+      const rejection =
+        meta && typeof meta === 'object' && 'rejection' in meta
+          ? (meta as { rejection: unknown }).rejection
+          : undefined;
+      if (typeof rejection === 'string') rejections.push(rejection);
+      return originalWarn(message, meta);
+    }) as typeof logger.warn;
+
+    harness = await listen(correctlyMountedApp());
+
+    const event = caseDecidedEventFixture();
+    const delivery = signWebhookDelivery({
+      secret: SECRET,
+      event,
+      // Signed over the real event, delivered as something else.
+      tamperedBody: JSON.stringify({ ...event, data: { caseId: 'case_forged' } }),
+    });
+
+    const response = await fetch(`${harness.url}/webhooks/crowdsource`, {
+      method: 'POST',
+      headers: delivery.headers,
+      body: delivery.body,
+    });
+
+    logger.warn = originalWarn;
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    // `signature_mismatch` specifically, taken from the SDK's own emitted token
+    // rather than guessed: it is what proves the signature was COMPARED. A
+    // missing-header rejection would also be a 4xx and would also be "refused",
+    // while proving the comparison never happened.
+    expect(rejections).toEqual(['signature_mismatch']);
+    // Nothing recorded: a forged delivery must not reach the database at all.
+    expect(await ModerationEventModel.countDocuments({})).toBe(0);
+    expect(await ModerationOutboxModel.countDocuments({})).toBe(0);
   });
 
   /**


### PR DESCRIPTION
Follow-up to #64, applying two test-design rules `mercaria` found and `allo` relayed. No production code changes.

## 1. The acceptance sibling proved nothing

It asserted the response was **not 500 and not 404**. But this receiver answers `200 { handled: false }` to an envelope the schema rejects — so **an endpoint that ran no handler at all would have satisfied both assertions**. A refusal test alone only proves a request was malformed somehow; its acceptance pair has to prove the same delivery is genuinely handled, and a status code cannot do that here.

I measured before changing anything: the endpoint *is* handling deliveries today (`handled: true`, one `ModerationEvent`, one `decision.apply` outbox row). So this is a test-strength fix, not a live bug — but the test could not have told the difference, which is the point.

Now asserts the side effects. **Mutation-checked:** make the `case.decided` handler return early — the endpoint still verifies the signature and still answers 2xx, and the strengthened test fails where the status-only version passed.

## 2. Nothing proved the signature was ever compared

Every other test in the file turns on the **mount**, not the cryptography — all of them would pass with the signature check deleted.

Adds a tampered-body delivery (signed over the real event, delivered as something else) and asserts the **specific rejection token**, `signature_mismatch`. That specificity is the whole value: a missing-header rejection would also be a 4xx and would also count as "refused" while proving the comparison never happened. Also asserts nothing reaches the database.

The token was **read from what the SDK emits, not guessed** — my first attempt expected `invalid_signature` and the test correctly failed. Worth noting as a small vindication of asserting the exact reason: guessing it wrong is loud, guessing it vaguely is silent.

Observed through the route's own `onRejected` → logger rather than by adding a test-only parameter to the factory. A seam built for the test would be a different path that happens to agree with the one that ships.

## Verification

585 pass (was 584), `tsc --noEmit` clean, no production files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)