### PR TITLE
fix(profile): ask the CDN for a variant it actually serves

### DIFF
--- a/packages/frontend/app/p/[id].tsx
+++ b/packages/frontend/app/p/[id].tsx
@@ -25,7 +25,7 @@ import { MediaCard } from '@/components/MediaCard';
 import { ResponsiveGrid } from '@/components/ResponsiveGrid';
 import { ArtistDetailSkeleton } from '@/components/skeletons';
 import { EmptyState } from '@/components/common/EmptyState';
-import { pickCatalogImageUrl, resolvePodcastArtwork, type CatalogImageTarget } from '@/utils/pickImage';
+import { oxyImageVariantForTarget, pickCatalogImageUrl, resolvePodcastArtwork, type CatalogImageTarget } from '@/utils/pickImage';
 import { oxyServices } from '@/lib/oxyServices';
 import { useLibrary, useToggleFollowArtist } from '@/hooks/useLibrary';
 import { useRelatedArtists } from '@/hooks/useRecommendations';
@@ -124,8 +124,7 @@ const EntityProfileScreen: React.FC = () => {
       if (fromCatalog) return fromCatalog;
     }
     if (entity.avatar) {
-      const variant = target === 'hero' || target === 'detailArtwork' ? 'full' : 'thumb';
-      return oxyServices.getFileDownloadUrl(entity.avatar, variant);
+      return oxyServices.getFileDownloadUrl(entity.avatar, oxyImageVariantForTarget(target));
     }
     return undefined;
   };

--- a/packages/frontend/utils/pickImage.test.ts
+++ b/packages/frontend/utils/pickImage.test.ts
@@ -1,4 +1,10 @@
-import { pickCatalogImageUrl, pickImageUrl } from './pickImage';
+import {
+  CATALOG_IMAGE_TARGET_WIDTH,
+  oxyImageVariantForTarget,
+  pickCatalogImageUrl,
+  pickImageUrl,
+  type CatalogImageTarget,
+} from './pickImage';
 import type { CatalogImageSizes, TrackImage } from '@syra/shared-types';
 
 const IMAGES: TrackImage[] = [
@@ -129,5 +135,66 @@ describe('pickImageUrl — robustness', () => {
 
   it('does not return an external fallback URL', () => {
     expect(pickImageUrl(undefined, 'https://cdn.example.com/cover.jpg', 300)).toBeUndefined();
+  });
+});
+
+/**
+ * The variant names oxy-api's `VariantService.imageVariants` actually serves for
+ * an image. Spelled out independently of the implementation so that a name the
+ * CDN does not know cannot be introduced on both sides at once — every other
+ * string, `full` included, is a 404 with no fallback.
+ */
+const REAL_OXY_IMAGE_VARIANTS = ['w96', 'w128', 'thumb', 'w320', 'w640', 'w1280', 'w2048'];
+
+/** Names that look plausible, have never existed, and 404 the CDN. */
+const NON_EXISTENT_OXY_VARIANTS = ['full', 'large', 'original'];
+
+describe('oxyImageVariantForTarget', () => {
+  const targets = Object.keys(CATALOG_IMAGE_TARGET_WIDTH) as CatalogImageTarget[];
+
+  it('covers every catalog target (vacuity floor)', () => {
+    // Guards the two loops below: were the target table to come back empty,
+    // their assertions would pass without ever running.
+    expect(targets).toHaveLength(6);
+    expect(targets).toEqual(
+      expect.arrayContaining(['icon', 'thumbnail', 'smallArtwork', 'card', 'detailArtwork', 'hero']),
+    );
+  });
+
+  it('maps every target to a variant the Oxy CDN actually serves', () => {
+    for (const target of targets) {
+      expect(REAL_OXY_IMAGE_VARIANTS).toContain(oxyImageVariantForTarget(target));
+    }
+  });
+
+  it('never emits a variant that 404s', () => {
+    for (const target of targets) {
+      expect(NON_EXISTENT_OXY_VARIANTS).not.toContain(oxyImageVariantForTarget(target));
+    }
+  });
+
+  it('picks the narrowest rung at least as wide as the target', () => {
+    expect(oxyImageVariantForTarget('icon')).toBe('w96'); // 64 → 96
+    expect(oxyImageVariantForTarget('thumbnail')).toBe('w96'); // 80 → 96
+    expect(oxyImageVariantForTarget('smallArtwork')).toBe('thumb'); // 180 → 256
+    expect(oxyImageVariantForTarget('card')).toBe('w320'); // 300 → 320
+    expect(oxyImageVariantForTarget('detailArtwork')).toBe('w640'); // 520 → 640
+    expect(oxyImageVariantForTarget('hero')).toBe('w1280'); // 1000 → 1280
+  });
+
+  it('returns a rung at least as wide as the target wherever the ladder allows', () => {
+    const widthOf: Record<string, number> = {
+      w96: 96,
+      w128: 128,
+      thumb: 256,
+      w320: 320,
+      w640: 640,
+      w1280: 1280,
+      w2048: 2048,
+    };
+    for (const target of targets) {
+      const width = widthOf[oxyImageVariantForTarget(target)];
+      expect(width).toBeGreaterThanOrEqual(CATALOG_IMAGE_TARGET_WIDTH[target]);
+    }
   });
 });

--- a/packages/frontend/utils/pickImage.ts
+++ b/packages/frontend/utils/pickImage.ts
@@ -30,6 +30,43 @@ export const CATALOG_IMAGE_TARGET_WIDTH = {
 
 export type CatalogImageTarget = keyof typeof CATALOG_IMAGE_TARGET_WIDTH;
 
+/**
+ * Oxy's public image variant ladder, narrowest first, mirroring oxy-api's
+ * `VariantService.imageVariants`.
+ *
+ * This list is the entire vocabulary the Oxy CDN accepts for an image, and it
+ * answers an unknown name with a hard 404 and no fallback — `full`, `large` and
+ * `original` are not variants and never were. Video files carry a disjoint set
+ * (`poster`, `hls_master`), so a name from this ladder must only ever be asked
+ * of a file known to be an image.
+ */
+const OXY_IMAGE_VARIANT_LADDER = [
+  { variant: 'w96', width: 96 },
+  { variant: 'w128', width: 128 },
+  { variant: 'thumb', width: 256 },
+  { variant: 'w320', width: 320 },
+  { variant: 'w640', width: 640 },
+  { variant: 'w1280', width: 1280 },
+  { variant: 'w2048', width: 2048 },
+] as const;
+
+/** The widest rung — what a target wider than the whole ladder settles for. */
+const WIDEST_OXY_IMAGE_VARIANT = OXY_IMAGE_VARIANT_LADDER[OXY_IMAGE_VARIANT_LADDER.length - 1];
+
+/**
+ * The Oxy media variant to request for an image rendered at a catalog target
+ * size: the narrowest rung at least as wide as the target, else the widest rung.
+ *
+ * This is the same "big enough, no bigger" rule {@link pickImageUrl} applies to
+ * Syra-hosted catalog images, so an Oxy avatar and a Syra cover standing in for
+ * each other at the same target are fetched at comparable sizes.
+ */
+export function oxyImageVariantForTarget(target: CatalogImageTarget): string {
+  const preferredWidth = CATALOG_IMAGE_TARGET_WIDTH[target];
+  const rung = OXY_IMAGE_VARIANT_LADDER.find((entry) => entry.width >= preferredWidth);
+  return (rung ?? WIDEST_OXY_IMAGE_VARIANT).variant;
+}
+
 function normalizeCandidate(urlValue: string | undefined, widthValue: number | undefined): ImageCandidate | null {
   if (!urlValue) return null;
   const url = resolveCatalogImageUrl(urlValue);


### PR DESCRIPTION
## The bug

`app/p/[id].tsx` resolved an Oxy avatar with `getFileDownloadUrl(id, 'full')`. **There is no `full` variant** — not for images, not for videos. Oxy's taxonomy is mime-specific and 404s hard with no fallback:

| | image | video |
|---|---|---|
| `w96 w128 thumb w320 w640 w1280 w2048` | 302 | 404 |
| `poster`, `hls_master` | 404 | 302 |
| `full`, `large`, `original` | **404** | **404** |

Only the `hero` target hit `'full'`, so the broken render was the parallax cover, and only for an entity with no catalog image falling back to its Oxy avatar.

## Why nobody noticed

Nothing failed loudly. The `<Image>` has no `onError`, and the placeholder branch keys on `heroImage` being `undefined` — a 404 URL is a perfectly defined string, so the placeholder never fired. The hero rendered transparent under the `LinearGradient` overlay, which reads as an intentional dark header.

## The fix

`oxyImageVariantForTarget` in `utils/pickImage.ts` — the module that already owns `CatalogImageTarget`/`CATALOG_IMAGE_TARGET_WIDTH`, so the two size tables sit adjacent and cannot drift. It encodes Oxy's real ladder and picks the narrowest rung at least as wide as the target, the same rule `pickImageUrl` already applies to Syra-hosted covers. The call site becomes one line.

**No per-kind mapping**, deliberately: `entity.avatar` is typed as an Oxy avatar file id — always an image — and no video reaches `getFileDownloadUrl` anywhere in Syra. A video branch would have been dead code.

All 10 `getFileDownloadUrl` call sites were enumerated, not sampled; `full` was the only bad one. Two false leads were ruled out rather than "fixed": `sdk/src/client.ts`'s `ArtworkSize` (external podcast RSS) and `catalogImageAssets.ts` (Syra's own ladder) are different taxonomies.

## Verification

HTTP probes of the variants the shipped function actually emits, following redirects so a 302 to a dead object cannot pass as success:

```
icon           w96      200 image/webp   2484B
smallArtwork   thumb    200 image/webp  13194B
card           w320     200 image/webp  18270B
detailArtwork  w640     200 image/webp  36102B
hero           w1280    200 image/webp  36102B

CONTROL — what this screen used before:
hero (OLD)     full     404 application/json  {"error":"NOT_FOUND"}
```

Mutation test — reintroducing `target === 'hero' ? 'full' : …` fails 4 of the new tests; restored, 23/23 pass. The tests carry a vacuity floor (all 6 targets enumerated) and spell the variant list independently of the implementation, so the same name cannot be wrong on both sides at once.

Gates on the current base: frontend typecheck exit 0, 178 tests pass.

## Note: an earlier revision of this branch carried a second commit, now dropped

It added the missing `artist_image_required` string, because `tsc` was failing on `main` with `TS2741: Property 'artist_image_required' is missing`. While this branch was open, `c5eda7d` removed that reason code from `shared-types` entirely — solving the same problem from the other end. The string became an unknown property (`TS2353`) rather than a missing one, so the commit is gone and this branch is the variant fix alone.

Worth recording how that was nearly missed: after rebasing, a local `bun run typecheck` in `packages/frontend` exited **0**, because it compiled against a stale `@syra/shared-types` `dist`. CI built fresh and exited 2. Rebuilding shared-types first is what made the local run agree with CI.

## Needs a human look

The pixels. The URLs return real image bytes, but nobody has opened `/p/<id>` on an entity that takes the avatar fallback — an Oxy-linked artist or person with no catalog image. Worth one look before or right after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
