### PR TITLE
fix(deploy): pin syra rollouts to an image digest, not `:latest`

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${CLUSTER:?CLUSTER is required}"
+: "${APP:?APP is required}"
+: "${IMAGE_URI:?IMAGE_URI is required}"
+if [[ ! "$IMAGE_URI" =~ ^.+@sha256:[0-9a-fA-F]{64}$ ]]; then
+  echo "::error::IMAGE_URI must pin an immutable OCI digest (repository@sha256:<64 hex characters>)."
+  exit 1
+fi
+
+CONTAINER_NAME="${CONTAINER_NAME:-$APP}"
+MAX_WAIT_SECS="${MAX_WAIT_SECS:-1200}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+RUN_MIGRATIONS="${RUN_MIGRATIONS:-false}"
+INTERNAL_METRICS_PARAMETER="${INTERNAL_METRICS_PARAMETER:-}"
+TASK_SECRET_OVERRIDES_JSON="${TASK_SECRET_OVERRIDES_JSON:-}"
+AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
+AWS_PARTITION="${AWS_PARTITION:-aws}"
+POST_DEPLOY_SMOKE_SCRIPT="${POST_DEPLOY_SMOKE_SCRIPT:-}"
+POST_DEPLOY_TASK_COMMAND_JSON="${POST_DEPLOY_TASK_COMMAND_JSON:-}"
+DEPLOY_HEAD_GUARD_SCRIPT="${DEPLOY_HEAD_GUARD_SCRIPT:-.github/scripts/require-current-main.sh}"
+
+if ! [[ "$MAX_WAIT_SECS" =~ ^[0-9]+$ ]] || (( MAX_WAIT_SECS < 1 )); then
+  echo "::error::MAX_WAIT_SECS must be a positive integer."
+  exit 1
+fi
+if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ ]] || (( POLL_INTERVAL < 1 )); then
+  echo "::error::POLL_INTERVAL must be a positive integer."
+  exit 1
+fi
+if [[ "$RUN_MIGRATIONS" != "true" && "$RUN_MIGRATIONS" != "false" ]]; then
+  echo "::error::RUN_MIGRATIONS must be either 'true' or 'false'."
+  exit 1
+fi
+if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" && ! -f "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
+  echo "::error::POST_DEPLOY_SMOKE_SCRIPT does not exist: $POST_DEPLOY_SMOKE_SCRIPT"
+  exit 1
+fi
+if [[ -n "${DEPLOY_SHA:-}" && ! -f "$DEPLOY_HEAD_GUARD_SCRIPT" ]]; then
+  echo "::error::DEPLOY_HEAD_GUARD_SCRIPT does not exist: $DEPLOY_HEAD_GUARD_SCRIPT"
+  exit 1
+fi
+if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]] &&
+   ! jq -e '
+     type == "array" and
+     length > 0 and
+     all(.[]; type == "string" and length > 0)
+   ' <<<"$POST_DEPLOY_TASK_COMMAND_JSON" >/dev/null; then
+  echo "::error::POST_DEPLOY_TASK_COMMAND_JSON must be a non-empty JSON string array."
+  exit 1
+fi
+if [[ -z "$TASK_SECRET_OVERRIDES_JSON" ]]; then
+  TASK_SECRET_OVERRIDES_JSON='{}'
+fi
+if ! jq -e '
+  type == "object" and
+  length <= 20 and
+  all(
+    to_entries[];
+    (.key | type == "string" and test("^[A-Z][A-Z0-9_]{0,127}$")) and
+    (
+      .value
+      | type == "string" and
+        test("^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/[A-Za-z0-9_./-]+$")
+    )
+  )
+' <<<"$TASK_SECRET_OVERRIDES_JSON" >/dev/null; then
+  echo "::error::TASK_SECRET_OVERRIDES_JSON must map environment variable names to complete SSM parameter ARNs."
+  exit 1
+fi
+
+service_json="$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP")"
+if [[ "$(jq '.failures | length' <<<"$service_json")" != "0" ||
+      "$(jq '.services | length' <<<"$service_json")" != "1" ]]; then
+  echo "::error::ECS did not return exactly one service named $APP."
+  jq '.failures' <<<"$service_json"
+  exit 1
+fi
+service_status="$(jq -r '.services[0].status // "NONE"' <<<"$service_json")"
+if [[ "$service_status" != "ACTIVE" ]]; then
+  echo "::error::ECS service $APP is not ACTIVE (status: $service_status)."
+  exit 1
+fi
+
+current_task_definition="$(jq -r '.services[0].taskDefinition // empty' <<<"$service_json")"
+if [[ -z "$current_task_definition" ]]; then
+  echo "::error::ECS service $APP has no task definition."
+  exit 1
+fi
+
+service_desired_count="$(jq -r '.services[0].desiredCount // empty' <<<"$service_json")"
+if ! [[ "$service_desired_count" =~ ^[0-9]+$ ]] ||
+   (( service_desired_count < 1 )); then
+  echo "::error::ECS service $APP must have a positive desiredCount before deployment (current: ${service_desired_count:-missing}). Scale the service up explicitly before retrying."
+  exit 1
+fi
+
+task_definition_file="$(mktemp)"
+rendered_task_definition_file="$(mktemp)"
+active_one_shot_task_arn=""
+active_one_shot_task_stopped=true
+active_one_shot_label=""
+
+cleanup() {
+  if [[ "$active_one_shot_task_stopped" != "true" &&
+        -n "$active_one_shot_task_arn" ]]; then
+    echo "::warning::Unfinished $active_one_shot_label task $active_one_shot_task_arn may still be running; the deploy role cannot call ecs:StopTask."
+  fi
+  rm -f "$task_definition_file" "$rendered_task_definition_file"
+}
+trap cleanup EXIT
+
+wait_for_task_stop() {
+  local task_arn="$1"
+  local label="$2"
+  local max_wait_secs="$3"
+  local elapsed=0
+  local task_json last_status
+
+  while (( elapsed < max_wait_secs )); do
+    task_json="$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$task_arn")"
+    if [[ "$(jq '.failures | length' <<<"$task_json")" != "0" ]]; then
+      echo "::error::ECS could not describe $label task $task_arn."
+      jq '.failures' <<<"$task_json"
+      return 1
+    fi
+    last_status="$(jq -r '.tasks[0].lastStatus // "MISSING"' <<<"$task_json")"
+    echo "($elapsed s) $label task status=$last_status"
+    if [[ "$last_status" == "STOPPED" ]]; then
+      return 0
+    fi
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+  done
+
+  echo "::error::$label task did not stop within ${max_wait_secs}s. The deploy role cannot call ecs:StopTask; task $task_arn may still be running."
+  return 1
+}
+
+wait_for_service_rollout() {
+  local task_definition="$1"
+  local label="$2"
+  local elapsed=0
+  local deployment_json="$service_json"
+  local deployment_state rollout_state running desired service_desired
+
+  while (( elapsed < MAX_WAIT_SECS )); do
+    if ! deployment_json="$(aws ecs describe-services \
+      --cluster "$CLUSTER" \
+      --services "$APP")"; then
+      echo "::warning::Unable to inspect the $label rollout; retrying."
+      sleep "$POLL_INTERVAL"
+      elapsed=$((elapsed + POLL_INTERVAL))
+      continue
+    fi
+    if [[ "$(jq '.failures | length' <<<"$deployment_json")" != "0" ]]; then
+      echo "::warning::ECS returned a failure while inspecting the $label rollout; retrying."
+      sleep "$POLL_INTERVAL"
+      elapsed=$((elapsed + POLL_INTERVAL))
+      continue
+    fi
+    if ! deployment_state="$(jq -r --arg task "$task_definition" '
+      .services[0] as $service
+      |
+      [
+        $service.deployments[]
+        | select(.taskDefinition == $task and .status == "PRIMARY")
+        | [.rolloutState, .runningCount, .desiredCount, $service.desiredCount]
+        | @tsv
+      ][0] // empty
+    ' <<<"$deployment_json")"; then
+      echo "::warning::ECS returned malformed rollout data for $label; retrying."
+      sleep "$POLL_INTERVAL"
+      elapsed=$((elapsed + POLL_INTERVAL))
+      continue
+    fi
+
+    if [[ -z "$deployment_state" ]]; then
+      echo "($elapsed s) waiting for the $label PRIMARY deployment"
+    else
+      IFS=$'\t' read -r rollout_state running desired service_desired <<<"$deployment_state"
+      echo "($elapsed s) $label rolloutState=$rollout_state running=$running desired=$desired serviceDesired=$service_desired"
+      if ! [[ "$running" =~ ^[0-9]+$ &&
+              "$desired" =~ ^[0-9]+$ &&
+              "$service_desired" =~ ^[0-9]+$ ]]; then
+        echo "::warning::ECS returned non-numeric task counts for the $label rollout; retrying."
+      elif (( service_desired < 1 )); then
+        echo "::error::ECS service $APP reached desiredCount=0 during the $label rollout."
+        return 1
+      elif [[ "$rollout_state" == "COMPLETED" ]]; then
+        if (( desired < 1 )); then
+          echo "::error::ECS $label rollout for $APP completed at desiredCount=0; refusing to accept a zero-task steady state."
+          return 1
+        fi
+        if [[ "$running" == "$desired" ]]; then
+          return 0
+        fi
+      elif (( desired < 1 )); then
+        echo "::warning::ECS has not assigned desired tasks to the $label PRIMARY deployment yet; waiting."
+      fi
+      if [[ "$rollout_state" == "FAILED" ]]; then
+        echo "::error::ECS $label rollout for $APP failed."
+        echo "::group::Recent ECS service events"
+        jq -r '
+          .services[0].events[:10][]?
+          | "\(.createdAt // "unknown") \(.message // "unknown")"
+        ' <<<"$deployment_json"
+        echo "::endgroup::"
+        return 1
+      fi
+    fi
+
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+  done
+
+  echo "::error::ECS $label rollout for $APP did not complete within ${MAX_WAIT_SECS}s."
+  echo "::group::Recent ECS service events"
+  jq -r '
+    .services[0].events[:10][]?
+    | "\(.createdAt // "unknown") \(.message // "unknown")"
+  ' <<<"$deployment_json"
+  echo "::endgroup::"
+  return 1
+}
+
+print_one_shot_logs() {
+  local task_arn="$1"
+  local label="$2"
+  local task_id log_group log_stream_prefix log_stream log_json
+
+  task_id="${task_arn##*/}"
+  log_group="$(jq -r --arg name "$CONTAINER_NAME" '
+    .containerDefinitions[]
+    | select(.name == $name)
+    | .logConfiguration.options["awslogs-group"] // empty
+  ' "$rendered_task_definition_file")"
+  log_stream_prefix="$(jq -r --arg name "$CONTAINER_NAME" '
+    .containerDefinitions[]
+    | select(.name == $name)
+    | .logConfiguration.options["awslogs-stream-prefix"] // empty
+  ' "$rendered_task_definition_file")"
+
+  if [[ -z "$task_id" || -z "$log_group" || -z "$log_stream_prefix" ]]; then
+    echo "::warning::Unable to derive the CloudWatch log stream for failed $label task $task_arn."
+    return 0
+  fi
+
+  log_stream="$log_stream_prefix/$CONTAINER_NAME/$task_id"
+  if ! log_json="$(aws logs get-log-events \
+    --log-group-name "$log_group" \
+    --log-stream-name "$log_stream" \
+    --limit 200 \
+    --start-from-head)"; then
+    echo "::warning::Unable to read CloudWatch logs for failed $label task $task_arn."
+    return 0
+  fi
+
+  echo "::group::$label CloudWatch logs"
+  jq -r '.events[]?.message' <<<"$log_json"
+  echo "::endgroup::"
+}
+
+run_one_shot_command() {
+  local label="$1"
+  local command_json="$2"
+  local overrides run_json task_json exit_code stopped_reason container_reason
+
+  overrides="$(jq -cn \
+    --arg name "$CONTAINER_NAME" \
+    --argjson command "$command_json" \
+    '{
+      containerOverrides: [{
+        name: $name,
+        command: $command
+      }]
+    }')"
+
+  if ! run_json="$(aws "${one_shot_run_task_args[@]}" --overrides "$overrides")"; then
+    echo "::error::ECS failed to start the $label task."
+    return 1
+  fi
+  if [[ "$(jq '.failures | length' <<<"$run_json")" != "0" ]]; then
+    echo "::error::ECS refused to start the $label task."
+    jq '.failures' <<<"$run_json"
+    return 1
+  fi
+
+  active_one_shot_task_arn="$(jq -r '.tasks[0].taskArn // empty' <<<"$run_json")"
+  if [[ -z "$active_one_shot_task_arn" ]]; then
+    echo "::error::ECS returned no task ARN for $label."
+    return 1
+  fi
+  active_one_shot_label="$label"
+  active_one_shot_task_stopped=false
+
+  echo "Running $label with $new_task_definition"
+  if ! wait_for_task_stop "$active_one_shot_task_arn" "$label" "$MAX_WAIT_SECS"; then
+    return 1
+  fi
+  active_one_shot_task_stopped=true
+
+  task_json="$(aws ecs describe-tasks \
+    --cluster "$CLUSTER" \
+    --tasks "$active_one_shot_task_arn")"
+  exit_code="$(jq -r --arg name "$CONTAINER_NAME" '
+    .tasks[0].containers[] | select(.name == $name) | .exitCode // -1
+  ' <<<"$task_json")"
+  if [[ "$exit_code" != "0" ]]; then
+    print_one_shot_logs "$active_one_shot_task_arn" "$label"
+    stopped_reason="$(jq -r '.tasks[0].stoppedReason // "unknown"' <<<"$task_json")"
+    container_reason="$(jq -r --arg name "$CONTAINER_NAME" '
+      .tasks[0].containers[] | select(.name == $name) | .reason // "unknown"
+    ' <<<"$task_json")"
+    echo "::error::$label task failed (exit=$exit_code, stopped=$stopped_reason, container=$container_reason)."
+    return 1
+  fi
+  echo "$label completed successfully"
+}
+
+rollback_service() {
+  echo "::warning::Rolling $APP back to $current_task_definition."
+  if ! aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$APP" \
+    --task-definition "$current_task_definition" \
+    --desired-count "$service_desired_count" \
+    --deployment-configuration '{
+      "deploymentCircuitBreaker": {"enable": true, "rollback": true},
+      "minimumHealthyPercent": 100,
+      "maximumPercent": 200
+    }' \
+    >/dev/null; then
+    echo "::error::ECS rejected the rollback to $current_task_definition."
+    return 1
+  fi
+  wait_for_service_rollout "$current_task_definition" "rollback"
+}
+
+internal_metrics_secret_arn=""
+if [[ -n "$INTERNAL_METRICS_PARAMETER" ]]; then
+  if [[ "$INTERNAL_METRICS_PARAMETER" == arn:* ]]; then
+    internal_metrics_secret_arn="$INTERNAL_METRICS_PARAMETER"
+  else
+    if [[ ! "$AWS_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+      echo "::error::AWS_ACCOUNT_ID must be a 12-digit account id when INTERNAL_METRICS_PARAMETER is a parameter name."
+      exit 1
+    fi
+    # The hyphen is LAST on purpose. This is a POSIX bracket expression, where a
+    # backslash is an ordinary character rather than an escape, so the `\-/` that
+    # reads as an escaped hyphen in PCRE is really a reversed `\`-to-`/` range and
+    # the class then matches no hyphen at all. Every `/oxy/<app>/...` parameter
+    # path whose app name contains one was silently rejected.
+    if [[ ! "$AWS_PARTITION" =~ ^aws(-[a-z]+)?$ ||
+          ! "$INTERNAL_METRICS_PARAMETER" =~ ^/[A-Za-z0-9_./-]+$ ]]; then
+      echo "::error::AWS partition or INTERNAL_METRICS_PARAMETER name is invalid."
+      exit 1
+    fi
+    internal_metrics_secret_arn="arn:${AWS_PARTITION}:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/${INTERNAL_METRICS_PARAMETER#/}"
+  fi
+  if [[ ! "$internal_metrics_secret_arn" =~ ^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/.+$ ]]; then
+    echo "::error::Unable to construct a valid SSM parameter ARN for the task definition."
+    exit 1
+  fi
+fi
+
+task_secret_overrides="$(jq -c '
+  [
+    to_entries[]
+    | {name: .key, valueFrom: .value}
+  ]
+' <<<"$TASK_SECRET_OVERRIDES_JSON")"
+
+aws ecs describe-task-definition \
+  --task-definition "$current_task_definition" \
+  --query taskDefinition \
+  >"$task_definition_file"
+
+container_matches="$(jq --arg name "$CONTAINER_NAME" '[.containerDefinitions[] | select(.name == $name)] | length' "$task_definition_file")"
+if [[ "$container_matches" != "1" ]]; then
+  available_containers="$(jq -r '[.containerDefinitions[].name] | join(", ")' "$task_definition_file")"
+  echo "::error::Expected exactly one container named $CONTAINER_NAME; found $container_matches. Available: $available_containers"
+  exit 1
+fi
+
+jq \
+  --arg name "$CONTAINER_NAME" \
+  --arg image "$IMAGE_URI" \
+  --arg internalMetricsSecretArn "$internal_metrics_secret_arn" \
+  --argjson taskSecretOverrides "$task_secret_overrides" \
+  '
+    del(
+      .taskDefinitionArn,
+      .revision,
+      .status,
+      .requiresAttributes,
+      .compatibilities,
+      .registeredAt,
+      .registeredBy
+    )
+    | ($taskSecretOverrides | map(.name)) as $taskSecretNames
+    | .containerDefinitions |= map(
+        if .name == $name then
+          .image = $image
+          | if $internalMetricsSecretArn != "" then
+              .secrets = (
+                (.secrets // [])
+                | map(select(.name != "INTERNAL_METRICS_TOKEN"))
+                + [{
+                    name: "INTERNAL_METRICS_TOKEN",
+                    valueFrom: $internalMetricsSecretArn
+                  }]
+              )
+              | .environment = (
+                  (.environment // [])
+                  | map(select(.name != "INTERNAL_METRICS_ENABLED"))
+                  + [{name: "INTERNAL_METRICS_ENABLED", value: "true"}]
+                )
+            else .
+            end
+          | .secrets = (
+              ((.secrets // [])
+                | map(
+                    select(
+                      .name as $existingName
+                      | ($taskSecretNames | index($existingName)) == null
+                    )
+                  ))
+              + $taskSecretOverrides
+            )
+        else . end
+      )
+  ' \
+  "$task_definition_file" >"$rendered_task_definition_file"
+
+new_task_definition="$(aws ecs register-task-definition \
+  --cli-input-json "file://$rendered_task_definition_file" \
+  --query 'taskDefinition.taskDefinitionArn' \
+  --output text)"
+
+one_shot_run_task_args=()
+if [[ "$RUN_MIGRATIONS" == "true" || -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+  network_configuration="$(jq -c '.services[0].networkConfiguration' <<<"$service_json")"
+  if [[ -z "$network_configuration" || "$network_configuration" == "null" ]]; then
+    echo "::error::ECS service $APP has no network configuration for the migration task."
+    exit 1
+  fi
+
+  one_shot_run_task_args=(
+    ecs run-task
+    --cluster "$CLUSTER"
+    --task-definition "$new_task_definition"
+    --count 1
+    --network-configuration "$network_configuration"
+  )
+
+  capacity_provider_strategy="$(jq -c '.services[0].capacityProviderStrategy // []' <<<"$service_json")"
+  if [[ "$capacity_provider_strategy" != "[]" ]]; then
+    one_shot_run_task_args+=(--capacity-provider-strategy "$capacity_provider_strategy")
+  else
+    launch_type="$(jq -r '.services[0].launchType // "FARGATE"' <<<"$service_json")"
+    one_shot_run_task_args+=(--launch-type "$launch_type")
+    platform_version="$(jq -r '.services[0].platformVersion // empty' <<<"$service_json")"
+    if [[ -n "$platform_version" ]]; then
+      one_shot_run_task_args+=(--platform-version "$platform_version")
+    fi
+  fi
+fi
+
+if [[ "$RUN_MIGRATIONS" == "true" ]]; then
+  if ! run_one_shot_command \
+    "Migration" \
+    '["bun","packages/backend/dist/scripts/migrate.js"]'; then
+    exit 1
+  fi
+fi
+
+if [[ -n "${DEPLOY_SHA:-}" ]]; then
+  echo "Re-verifying origin/main immediately before the ECS service update."
+  bash "$DEPLOY_HEAD_GUARD_SCRIPT"
+fi
+
+if ! aws ecs update-service \
+  --cluster "$CLUSTER" \
+  --service "$APP" \
+  --task-definition "$new_task_definition" \
+  --desired-count "$service_desired_count" \
+  --deployment-configuration '{
+    "deploymentCircuitBreaker": {"enable": true, "rollback": true},
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200
+  }' \
+  >/dev/null; then
+  echo "::error::ECS rejected the service update; restoring the previous task definition defensively."
+  if ! rollback_service; then
+    echo "::error::The defensive rollback also failed; manual intervention is required."
+  fi
+  exit 1
+fi
+
+echo "Deploying immutable image $IMAGE_URI with task definition $new_task_definition"
+
+if ! wait_for_service_rollout "$new_task_definition" "deployment"; then
+  if ! rollback_service; then
+    echo "::error::Deployment and explicit rollback both failed; manual intervention is required."
+  fi
+  exit 1
+fi
+echo "ECS rollout reached a healthy steady state at $new_task_definition"
+
+if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
+  echo "Running post-deploy smoke checks with $POST_DEPLOY_SMOKE_SCRIPT"
+  if ! bash "$POST_DEPLOY_SMOKE_SCRIPT"; then
+    echo "::error::Post-deploy smoke checks failed."
+    if rollback_service; then
+      echo "::warning::Rollback completed after smoke failure."
+    else
+      echo "::error::Rollback also failed; manual intervention is required."
+    fi
+    exit 1
+  fi
+fi
+
+if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+  if ! run_one_shot_command \
+    "Post-deploy reconciliation" \
+    "$POST_DEPLOY_TASK_COMMAND_JSON"; then
+    echo "::error::Post-deploy reconciliation failed."
+    if ! rollback_service; then
+      echo "::error::Reconciliation and rollback both failed; manual intervention is required."
+    fi
+    exit 1
+  fi
+fi
+
+echo "Deployed $APP at $new_task_definition"

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_directory="$(mktemp -d)"
+temporary_root="$(realpath "${TMPDIR:-/tmp}")"
+test_directory="$(realpath "$test_directory")"
+
+cleanup_test_directory() {
+  if [[ "$test_directory" == "$temporary_root/"* &&
+        -d "$test_directory" ]]; then
+    rm -rf -- "$test_directory"
+  else
+    echo "Refusing to remove unexpected test directory: $test_directory" >&2
+  fi
+}
+trap cleanup_test_directory EXIT
+
+export DEPLOY_TEST_LOG=""
+export DEPLOY_TEST_EXPECT_METRICS_ARN=false
+# The SSM parameter path a case feeds to INTERNAL_METRICS_PARAMETER, and from
+# which the mocked register-task-definition derives the ARN it demands. A case
+# overrides it to cover a path shape the default does not.
+export DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+export DEPLOY_TEST_TASK_EXIT_CODE=0
+export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN=false
+export DEPLOY_TEST_SERVICE_DESIRED_COUNT=1
+export DEPLOY_TEST_ROLLOUT_SCENARIO=healthy
+
+aws() {
+  local service_json='{
+    "failures": [],
+    "services": [{
+      "status": "ACTIVE",
+      "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
+      "desiredCount": 1,
+      "networkConfiguration": {
+        "awsvpcConfiguration": {
+          "subnets": ["subnet-test"],
+          "securityGroups": ["sg-test"]
+        }
+      },
+      "launchType": "FARGATE",
+      "deployments": [
+        {
+          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:2",
+          "status": "PRIMARY",
+          "rolloutState": "COMPLETED",
+          "runningCount": 1,
+          "desiredCount": 1
+        },
+        {
+          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
+          "status": "PRIMARY",
+          "rolloutState": "COMPLETED",
+          "runningCount": 1,
+          "desiredCount": 1
+        }
+      ]
+    }]
+  }'
+  service_json="$(jq \
+    --argjson desired "$DEPLOY_TEST_SERVICE_DESIRED_COUNT" \
+    '.services[0].desiredCount = $desired' \
+    <<<"$service_json")"
+
+  case "$1 $2" in
+    "ecs describe-services")
+      local describe_count_file="${DEPLOY_TEST_LOG}.describe-count"
+      local describe_count=0
+      if [[ -f "$describe_count_file" ]]; then
+        describe_count="$(<"$describe_count_file")"
+      fi
+      describe_count=$((describe_count + 1))
+      printf '%s\n' "$describe_count" >"$describe_count_file"
+      if [[ "$DEPLOY_TEST_ROLLOUT_SCENARIO" == "transient-zero-deployment" &&
+            "$describe_count" == "2" ]]; then
+        service_json="$(jq '
+          .services[0].deployments |= map(
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              then
+                .rolloutState = "IN_PROGRESS"
+                | .desiredCount = 0
+                | .runningCount = 0
+              else .
+              end
+            )
+        ' <<<"$service_json")"
+      elif [[ "$DEPLOY_TEST_ROLLOUT_SCENARIO" == "zero-service-during-deploy" &&
+              "$describe_count" == "2" ]]; then
+        service_json="$(jq '
+          .services[0].desiredCount = 0
+          | .services[0].deployments |= map(
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              then .desiredCount = 0 | .runningCount = 0
+              else .
+              end
+            )
+        ' <<<"$service_json")"
+      elif [[ "$DEPLOY_TEST_ROLLOUT_SCENARIO" == "completed-zero-deployment" &&
+              "$describe_count" == "2" ]]; then
+        service_json="$(jq '
+          .services[0].deployments |= map(
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
+              then .desiredCount = 0 | .runningCount = 0
+              else .
+              end
+            )
+        ' <<<"$service_json")"
+      fi
+      printf '%s\n' "$service_json"
+      ;;
+    "ecs describe-task-definition")
+      printf '%s\n' '{
+        "family": "mention-test",
+        "networkMode": "awsvpc",
+        "requiresCompatibilities": ["FARGATE"],
+        "cpu": "256",
+        "memory": "512",
+        "containerDefinitions": [{
+          "name": "mention-test",
+          "image": "example.invalid/mention-test:old",
+          "essential": true,
+          "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+              "awslogs-group": "/ecs/mention-test",
+              "awslogs-stream-prefix": "ecs"
+            }
+          }
+        }]
+      }'
+      ;;
+    "ecs register-task-definition")
+      if [[ "$DEPLOY_TEST_EXPECT_METRICS_ARN" == "true" ]]; then
+        local previous_argument=""
+        local input_json=""
+        local argument
+        for argument in "$@"; do
+          if [[ "$previous_argument" == "--cli-input-json" ]]; then
+            input_json="${argument#file://}"
+            break
+          fi
+          previous_argument="$argument"
+        done
+        # The verdict is written to the log rather than left to `set -e`. A
+        # command that fails in the MIDDLE of this function does not abort the
+        # run -- measured, and it holds whether the function is exported or
+        # local -- because the caller consumes it as `v="$(aws ...)"` and only
+        # the function's LAST command reaches that assignment's exit status. An
+        # assertion whose only effect is its own exit status therefore cannot
+        # fail, which is what this one did: pointing it at an ARN no case uses
+        # left the suite green. Logging a distinct token instead puts the
+        # mismatch in the expected.log diff, where it names itself.
+        if jq -e \
+          --arg expected \
+          "arn:aws:ssm:test:123456789012:parameter${DEPLOY_TEST_METRICS_PARAMETER}" \
+          '
+          .containerDefinitions[]
+          | select(.name == "mention-test")
+          | .secrets[]
+          | select(
+              .name == "INTERNAL_METRICS_TOKEN" and
+              .valueFrom == $expected
+            )
+        ' "$input_json" >/dev/null; then
+          printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'metrics:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
+      fi
+      if [[ "$DEPLOY_TEST_EXPECT_TASK_SECRET_ARN" == "true" ]]; then
+        local previous_argument=""
+        local input_json=""
+        local argument
+        for argument in "$@"; do
+          if [[ "$previous_argument" == "--cli-input-json" ]]; then
+            input_json="${argument#file://}"
+            break
+          fi
+          previous_argument="$argument"
+        done
+        # Same reason as the metrics assertion above: log the verdict, do not
+        # rely on this function's exit status.
+        if jq -e '
+          .containerDefinitions[]
+          | select(.name == "mention-test")
+          | .secrets[]
+          | select(
+              .name == "MENTION_MCP_JWT_SECRET" and
+              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"
+            )
+        ' "$input_json" >/dev/null; then
+          printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'task-secret:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
+      fi
+      printf '%s\n' "arn:aws:ecs:test:task-definition/mention-test:2"
+      ;;
+    "ecs update-service")
+      local previous_argument=""
+      local task_definition=""
+      local desired_count=""
+      local argument
+      for argument in "$@"; do
+        if [[ "$previous_argument" == "--task-definition" ]]; then
+          task_definition="$argument"
+        elif [[ "$previous_argument" == "--desired-count" ]]; then
+          desired_count="$argument"
+        fi
+        previous_argument="$argument"
+      done
+      if [[ -z "$desired_count" ]]; then
+        echo "Mocked update-service requires an explicit --desired-count." >&2
+        return 1
+      fi
+      printf 'service:%s:desired=%s\n' \
+        "$task_definition" \
+        "$desired_count" \
+        >>"$DEPLOY_TEST_LOG"
+      printf '{}\n'
+      ;;
+    "ecs run-task")
+      printf 'reconcile\n' >>"$DEPLOY_TEST_LOG"
+      printf '%s\n' '{
+        "failures": [],
+        "tasks": [{"taskArn": "arn:aws:ecs:test:task/mention-reconcile"}]
+      }'
+      ;;
+    "ecs describe-tasks")
+      printf '{
+        "failures": [],
+        "tasks": [{
+          "lastStatus": "STOPPED",
+          "stoppedReason": "Essential container exited",
+          "containers": [{
+            "name": "mention-test",
+            "exitCode": %s
+          }]
+        }]
+      }\n' "$DEPLOY_TEST_TASK_EXIT_CODE"
+      ;;
+    "logs get-log-events")
+      printf 'tasklogs\n' >>"$DEPLOY_TEST_LOG"
+      printf '%s\n' '{
+        "events": [{
+          "message": "[migration] fixture failure"
+        }]
+      }'
+      ;;
+    *)
+      printf 'Unexpected mocked AWS call: %s\n' "$*" >&2
+      return 1
+      ;;
+  esac
+}
+export -f aws
+
+run_release() {
+  local case_name="$1"
+  local expect_success="$2"
+  local run_migrations="${3:-false}"
+  local inject_internal_metrics="${4:-false}"
+  local task_exit_code="${5:-0}"
+  local inject_task_secret="${6:-false}"
+  local service_desired_count="${7:-1}"
+  local rollout_scenario="${8:-healthy}"
+  local case_directory="$test_directory/$case_name"
+  local output_file="$case_directory/output.log"
+  local smoke_script="$case_directory/smoke.sh"
+
+  mkdir -p "$case_directory"
+  DEPLOY_TEST_LOG="$case_directory/aws.log"
+  DEPLOY_TEST_EXPECT_METRICS_ARN="$inject_internal_metrics"
+  DEPLOY_TEST_TASK_EXIT_CODE="$task_exit_code"
+  DEPLOY_TEST_EXPECT_TASK_SECRET_ARN="$inject_task_secret"
+  DEPLOY_TEST_SERVICE_DESIRED_COUNT="$service_desired_count"
+  DEPLOY_TEST_ROLLOUT_SCENARIO="$rollout_scenario"
+  export DEPLOY_TEST_LOG DEPLOY_TEST_EXPECT_METRICS_ARN
+  export DEPLOY_TEST_TASK_EXIT_CODE
+  export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN
+  export DEPLOY_TEST_SERVICE_DESIRED_COUNT
+  export DEPLOY_TEST_ROLLOUT_SCENARIO
+
+  # The generated smoke fixture expands this variable when it runs.
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "smoke\n" >>"$DEPLOY_TEST_LOG"' \
+    >"$smoke_script"
+
+  local -a release_environment=(
+    AWS_REGION=test
+    AWS_ACCOUNT_ID=123456789012
+    CLUSTER=mention-test
+    APP=mention-test
+    CONTAINER_NAME=mention-test
+    IMAGE_URI="example.invalid/mention-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    MAX_WAIT_SECS=5
+    POLL_INTERVAL=1
+    RUN_MIGRATIONS="$run_migrations"
+    POST_DEPLOY_SMOKE_SCRIPT="$smoke_script"
+    POST_DEPLOY_TASK_COMMAND_JSON='["reconcile"]'
+  )
+  if [[ "$inject_internal_metrics" == "true" ]]; then
+    release_environment+=(
+      INTERNAL_METRICS_PARAMETER="$DEPLOY_TEST_METRICS_PARAMETER"
+    )
+  fi
+  if [[ "$inject_task_secret" == "true" ]]; then
+    release_environment+=(
+      TASK_SECRET_OVERRIDES_JSON='{"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"}'
+    )
+  fi
+
+  if env "${release_environment[@]}" \
+    bash "$repository_root/.github/scripts/deploy-ecs-image.sh" \
+    >"$output_file" 2>&1; then
+    if [[ "$expect_success" != "true" ]]; then
+      echo "Expected $case_name to fail." >&2
+      return 1
+    fi
+  elif [[ "$expect_success" == "true" ]]; then
+    echo "Expected $case_name to succeed." >&2
+    sed -n '1,240p' "$output_file" >&2
+    return 1
+  fi
+}
+
+run_release success true false true
+printf '%s\n' \
+  metrics:arn \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/success/expected.log"
+diff -u \
+  "$test_directory/success/expected.log" \
+  "$test_directory/success/aws.log"
+
+# A hyphen in the parameter path is its own case because it is its own bug: the
+# bracket expression validating this name once matched every character EXCEPT a
+# hyphen, so /oxy/mention/... deployed and /oxy/oxy-api/... did not. Mention's
+# own path has no hyphen, which is why nothing here caught it. Keep both.
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention-mcp/INTERNAL_METRICS_TOKEN
+run_release hyphenated-metrics-parameter true false true
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+printf '%s\n' \
+  metrics:arn \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/hyphenated-metrics-parameter/expected.log"
+diff -u \
+  "$test_directory/hyphenated-metrics-parameter/expected.log" \
+  "$test_directory/hyphenated-metrics-parameter/aws.log"
+
+run_release explicit-task-secret true false false 0 true
+printf '%s\n' \
+  task-secret:arn \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/explicit-task-secret/expected.log"
+diff -u \
+  "$test_directory/explicit-task-secret/expected.log" \
+  "$test_directory/explicit-task-secret/aws.log"
+
+run_release reconciliation-failure false false false 1
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  tasklogs \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  >"$test_directory/reconciliation-failure/expected.log"
+diff -u \
+  "$test_directory/reconciliation-failure/expected.log" \
+  "$test_directory/reconciliation-failure/aws.log"
+
+run_release migration-failure false true false 1
+printf '%s\n' \
+  reconcile \
+  tasklogs \
+  >"$test_directory/migration-failure/expected.log"
+diff -u \
+  "$test_directory/migration-failure/expected.log" \
+  "$test_directory/migration-failure/aws.log"
+grep -F \
+  "[migration] fixture failure" \
+  "$test_directory/migration-failure/output.log" \
+  >/dev/null
+if grep -q '^service:' "$test_directory/migration-failure/aws.log"; then
+  echo "Failed migration reached update-service." >&2
+  exit 1
+fi
+
+run_release zero-desired-count false false false 0 false 0
+grep -F \
+  "must have a positive desiredCount before deployment (current: 0)" \
+  "$test_directory/zero-desired-count/output.log" \
+  >/dev/null
+if [[ -s "$test_directory/zero-desired-count/aws.log" ]]; then
+  echo "Zero-capacity service reached a mutating AWS call." >&2
+  exit 1
+fi
+
+run_release transient-zero-deployment true false false 0 false 1 transient-zero-deployment
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/transient-zero-deployment/expected.log"
+diff -u \
+  "$test_directory/transient-zero-deployment/expected.log" \
+  "$test_directory/transient-zero-deployment/aws.log"
+grep -F \
+  "has not assigned desired tasks" \
+  "$test_directory/transient-zero-deployment/output.log" \
+  >/dev/null
+
+run_release zero-service-during-deploy false false false 0 false 1 zero-service-during-deploy
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  >"$test_directory/zero-service-during-deploy/expected.log"
+diff -u \
+  "$test_directory/zero-service-during-deploy/expected.log" \
+  "$test_directory/zero-service-during-deploy/aws.log"
+grep -F \
+  "service mention-test reached desiredCount=0 during the deployment rollout" \
+  "$test_directory/zero-service-during-deploy/output.log" \
+  >/dev/null
+
+run_release completed-zero-deployment false false false 0 false 1 completed-zero-deployment
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
+  >"$test_directory/completed-zero-deployment/expected.log"
+diff -u \
+  "$test_directory/completed-zero-deployment/expected.log" \
+  "$test_directory/completed-zero-deployment/aws.log"
+grep -F \
+  "completed at desiredCount=0; refusing to accept a zero-task steady state" \
+  "$test_directory/completed-zero-deployment/output.log" \
+  >/dev/null
+
+echo "Deployment script transaction tests passed."

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -14,6 +14,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # Serialize production rollouts. Two overlapping runs each register a task
+  # definition revision and then call update-service; interleaved, the older
+  # image wins and the newer run still reports success. Never cancel in
+  # progress: an interrupted run leaves an unmonitored rollout in ECS.
+  group: deploy-syra-backend
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   ECR_REGISTRY: 237343248947.dkr.ecr.us-west-2.amazonaws.com
@@ -100,25 +108,47 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push (linux/arm64)
+        id: build
+        env:
+          COMMIT_TAG: ${{ github.sha }}
         run: |
           IMG=$ECR_REGISTRY/oxy/$APP
+          # --metadata-file is the only addition to this build: the digest comes
+          # out of the build itself. Resolving it afterwards with
+          # `aws ecr describe-images` is not an option here: oxy-github-deploy
+          # has no ecr:DescribeImages, confirmed with
+          # `aws iam simulate-principal-policy` (implicitDeny), so that call
+          # fails at deploy time behind a green build.
           docker buildx build \
             --platform linux/arm64 \
             --cache-from type=gha,scope=$APP-backend \
             --cache-to type=gha,scope=$APP-backend,mode=max \
             -f "$DOCKERFILE" \
-            -t "$IMG:${{ github.sha }}" \
+            -t "$IMG:$COMMIT_TAG" \
             -t "$IMG:latest" \
+            --metadata-file "$RUNNER_TEMP/build-metadata.json" \
             --push \
             .
 
-      - name: Deploy to ECS (rolling; skipped until the service exists)
+          # :latest is still moved, but nothing that deploys reads it. It exists
+          # so a from-scratch `terraform apply` -- whose app-service module
+          # declares `<repo>:latest` as the task definition's bootstrap image --
+          # creates the service on a current build rather than an ancient one.
+          DIGEST=$(jq -r '.["containerimage.digest"] // empty' "$RUNNER_TEMP/build-metadata.json")
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::buildx produced no usable image digest (got: ${DIGEST:-<empty>})"
+            exit 1
+          fi
+          echo "digest=$DIGEST" >>"$GITHUB_OUTPUT"
+          echo "Built $COMMIT_TAG -> $DIGEST"
+
+      - name: Register immutable task definition and deploy
+        env:
+          IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
         run: |
           STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP" --query 'services[0].status' --output text 2>/dev/null || echo NONE)
-          if [ "$STATUS" = "ACTIVE" ]; then
-            aws ecs update-service --cluster "$CLUSTER" --service "$APP" --force-new-deployment >/dev/null
-            aws ecs wait services-stable --cluster "$CLUSTER" --services "$APP"
-            echo "deployed $APP"
-          else
-            echo "ECS service $APP not created yet — image is in ECR, skipping deploy"
+          if [ "$STATUS" != "ACTIVE" ]; then
+            echo "ECS service $APP not created yet - image is in ECR, skipping deploy"
+            exit 0
           fi
+          bash .github/scripts/deploy-ecs-image.sh

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Gates the rollout logic deploy-aws.yml runs against production. The script
+  # and this harness are byte-identical copies of Mention's, so they share its
+  # test rather than growing a second, drifting one. Separate job: it needs no
+  # bun install and no workspace build, so it should not queue behind them.
+  deploy-script-test:
+    name: Deploy Script Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify deployment transaction safeguards
+        run: |
+          bash -n .github/scripts/*.sh
+          bash .github/scripts/test-deploy-ecs-image.sh
+
   quality:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## The bug

`oxy-syra:7` names `237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/syra:latest`, and the deploy step was `update-service --force-new-deployment`. That re-pulls whatever the mutable tag means at task-placement time. Two consequences:

- **An out-of-band retag silently changes what production runs**, with every deploy still green. Not hypothetical — `oxy/oxy-api:latest` was re-tagged by hand onto an older image after CI had pushed the correct one, which is how OxyHQServices#760 started.
- **There is no distinct revision to roll back to.** Every deploy points at one indistinguishable tag.

## The fix

The shape from #760: resolve the digest the build produced, re-register the service's task definition pinning `oxy/syra@sha256:…`, update the service to that revision. Rollback on a failed rollout, and a guard that rejects any non-digest `IMAGE_URI`, come with it.

**The build is otherwise untouched.** This repo already used `docker buildx build --push` with a gha cache, so the only addition is `--metadata-file`; the platform, cache scopes and tags are unchanged.

## Where this deliberately differs from #760

**The digest comes from `--metadata-file`, not `aws ecr describe-images`.** #760 resolves it with `aws ecr describe-images`, and **the deploy role cannot call that** — see Verification. That build would go green and then fail at the deploy step, which is the exact failure mode being removed here. Worth fixing in #760 before it merges.

`:latest` is still pushed, because `terraform-uswest2` declares `<repo>:latest` as the bootstrap image for a from-scratch `apply`; nothing that deploys reads it any more.

A `concurrency` group serializes rollouts. The `Deploy Script Tests` job goes in `quality.yml` — the workflow that is deliberately not path-filtered — as its own job, since it needs neither `bun install` nor the workspace build and should not queue behind them.
## Verification

Measured, not reasoned:

- **`ecr:DescribeImages` is denied.** `aws iam simulate-principal-policy --policy-source-arn .../oxy-github-deploy --action-names ecr:DescribeImages --resource-arns <this repo's ECR arn>` → `implicitDeny`. `ecr:BatchGetImage` and `ecr:PutImage` → `allowed`. This is why the digest comes from the build rather than from ECR after the fact.
- **The deploy role already grants everything the new shape needs.** Same simulation: `ecs:RegisterTaskDefinition`, `ecs:UpdateService`, `ecs:DescribeServices`, `ecs:DescribeTaskDefinition` → `allowed`; `iam:PassRole` on `oxy-ecs-task` → `allowed`. One shared role, and its trust policy already lists this repo at `refs/heads/main`.
- **The digest expression is right.** Ran a real `docker buildx build --push --metadata-file` (buildx 0.34.1) against a local registry: `containerimage.digest` is present, `jq -r '.["containerimage.digest"]'` returns it, the guard regex accepts it — and it is the *registry manifest* digest, confirmed by `GET /v2/<repo>/manifests/<digest>` → `HTTP 200` and by the per-commit tag's `Docker-Content-Digest` header matching byte-for-byte. That is the value ECS resolves.
- **No deployment-configuration change.** `describe-services` shows this service already runs `deploymentCircuitBreaker {enable: true, rollback: true}`, `minimumHealthyPercent: 100`, `maximumPercent: 200` — exactly what the script sets — and `desiredCount >= 1`, which the script requires.
- **The script and its harness are byte-identical to Mention's**, git blob hashes `0dd66acd` / `9430a460` in all five repos, so drift is detectable with `git rev-parse HEAD:<path>` rather than by reading.

**Not verified by running a deploy.** That needs a merge, and a green run is precisely what proved nothing in the case that started this. After this lands, the check that matters is that `aws ecs describe-services` reports a task definition whose image is `…@sha256:<digest of the deployed commit>`, and that the revision number increments once per deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)