### PR TITLE
fix(security): close the three live amplification vectors from the codex batch

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -71,6 +71,9 @@ jobs:
 
   deploy:
     needs: test
+    # workflow_dispatch can be run against arbitrary refs; only deploys from the
+    # protected main branch may assume the AWS deploy role.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7

--- a/packages/backend/src/controllers/podcasts.claim.test.ts
+++ b/packages/backend/src/controllers/podcasts.claim.test.ts
@@ -34,10 +34,10 @@ function makeReq(podcastId: string, userId: string, linkedArtistId?: string): Au
   } as unknown as AuthRequest;
 }
 
-async function makeClaimablePodcast(): Promise<string> {
+async function makeClaimablePodcast(source: 'rss' | 'syra' = 'syra'): Promise<string> {
   const podcast = await PodcastModel.create({
     title: 'Claimable Show',
-    source: 'rss',
+    source,
     feedUrl: `https://feed.example/${Math.random().toString(36).slice(2)}.xml`,
     claimable: true,
   });
@@ -86,5 +86,41 @@ describe('claimPodcast — linkedArtistId IDOR guard', () => {
     const after = await PodcastModel.findById(podcastId).lean();
     expect(after?.claimedByOxyUserId).toBe('owner-A');
     expect(after?.linkedArtistId).toBeUndefined();
+  });
+});
+
+describe('claimPodcast — RSS shows are not claimable', () => {
+  it('refuses to hand over an RSS-mirrored show (403)', async () => {
+    // An RSS show is somebody else's podcast that we mirrored from their feed.
+    // Claiming it would transfer ownership on no evidence but arriving first.
+    const podcastId = await makeClaimablePodcast('rss');
+
+    const res = makeRes();
+    await claimPodcast(makeReq(podcastId, 'attacker-A'), res as unknown as Response);
+
+    expect(res._status).toBe(403);
+    expect(res._body).toEqual({ error: 'RSS podcast claims require ownership verification' });
+
+    const after = await PodcastModel.findById(podcastId).lean();
+    expect(after?.claimedByOxyUserId).toBeUndefined();
+    expect(after?.ownerOxyUserId).toBeUndefined();
+    expect(after?.claimable).toBe(true);
+  });
+
+  it('refuses BEFORE the claimable check, so the source is what decides', async () => {
+    // Ordering matters: were the guard placed after `claimable !== true`, an RSS
+    // show would answer 409 "not claimable" and the rule would silently depend on
+    // a flag nothing sets today rather than on the show's provenance.
+    const podcast = await PodcastModel.create({
+      title: 'Unclaimable RSS Show',
+      source: 'rss',
+      feedUrl: 'https://feed.example/not-claimable.xml',
+      claimable: false,
+    });
+
+    const res = makeRes();
+    await claimPodcast(makeReq(podcast._id.toString(), 'attacker-A'), res as unknown as Response);
+
+    expect(res._status).toBe(403);
   });
 });

--- a/packages/backend/src/controllers/podcasts.controller.ts
+++ b/packages/backend/src/controllers/podcasts.controller.ts
@@ -602,6 +602,19 @@ export async function claimPodcast(req: AuthRequest, res: Response): Promise<voi
     res.status(404).json({ error: 'Podcast not found' });
     return;
   }
+  // An RSS-mirrored show is somebody else's podcast that we imported from their
+  // feed. Claiming one hands over `ownerOxyUserId` on the strength of nothing but
+  // "I asked first", so it must stay closed until a feed-ownership proof exists
+  // (the usual shape being a token the real owner publishes in their own feed).
+  //
+  // Nothing marks an RSS podcast `claimable` today, so this is not currently
+  // reachable — which is precisely why it is worth writing down rather than
+  // relying on. The protection is an absence, and the obvious next feature
+  // ("claim your show") restores the flag without anyone re-deriving this.
+  if (podcast.source === 'rss') {
+    res.status(403).json({ error: 'RSS podcast claims require ownership verification' });
+    return;
+  }
   if (podcast.claimable !== true || podcast.claimedByOxyUserId) {
     res.status(409).json({ error: 'Podcast is not claimable' });
     return;

--- a/packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts
+++ b/packages/backend/src/services/podcasts/podcastBackgroundImport.test.ts
@@ -6,6 +6,7 @@ import {
   syncPodcastSearch,
   resetPodcastImportStateForTests,
   MAX_FEEDS_PER_SEARCH,
+  MAX_THROTTLE_KEYS,
 } from './podcastBackgroundImport';
 
 beforeAll(connect);
@@ -122,5 +123,41 @@ describe('syncPodcastSearch — shallow upsert + deep scheduling', () => {
     const result = await syncPodcastSearch('   ', { search: async () => [candidate(1)], enqueue: () => {} });
     expect(result).toEqual({ skipped: true, candidates: 0, shallowUpserted: 0, deepEnqueued: 0 });
     expect(await PodcastModel.countDocuments({})).toBe(0);
+  });
+});
+
+describe('syncPodcastSearch — the throttle map is bounded', () => {
+  // `lastSyncAt` is keyed on the caller's own search string and reached without
+  // authentication, so an unbounded map is a memory leak anyone can drive. These
+  // assert the bound BEHAVIOURALLY — an evicted key stops being throttled — so
+  // they keep working if the eviction strategy is ever rewritten.
+  const noCandidates = { search: async () => [], enqueue: async () => {}, now: () => NOW };
+
+  it('evicts the oldest key once the cap is exceeded, so it can sync again inside its TTL', async () => {
+    const first = await syncPodcastSearch('oldest query', noCandidates);
+    expect(first.skipped).toBe(false);
+
+    for (let i = 0; i < MAX_THROTTLE_KEYS; i += 1) {
+      await syncPodcastSearch(`filler query ${i}`, noCandidates);
+    }
+
+    // One millisecond later — far inside SEARCH_IMPORT_TTL_MS. Admitted only
+    // because the key itself is gone.
+    const again = await syncPodcastSearch('oldest query', { ...noCandidates, now: () => NOW + 1 });
+    expect(again.skipped).toBe(false);
+  });
+
+  it('CONTROL: without exceeding the cap the same key stays throttled', async () => {
+    // Without this, the test above passes just as well against a map that never
+    // remembers anything at all.
+    const first = await syncPodcastSearch('sticky query', noCandidates);
+    expect(first.skipped).toBe(false);
+
+    for (let i = 0; i < 10; i += 1) {
+      await syncPodcastSearch(`few fillers ${i}`, noCandidates);
+    }
+
+    const again = await syncPodcastSearch('sticky query', { ...noCandidates, now: () => NOW + 1 });
+    expect(again.skipped).toBe(true);
   });
 });

--- a/packages/backend/src/services/podcasts/podcastBackgroundImport.ts
+++ b/packages/backend/src/services/podcasts/podcastBackgroundImport.ts
@@ -36,12 +36,44 @@ const DIRECTORY_TIMEOUT_MS = 3000;
 /** Re-pull a show's full feed at most this often from search (24h). */
 const DEEP_REFRESH_STALE_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Cap on retained throttle keys.
+ *
+ * `lastSyncAt` is keyed on the normalized SEARCH QUERY, which reaches us from
+ * `GET /api/search` with no authentication — so its key space is chosen by the
+ * caller, not by our catalog. Every distinct query long enough to trigger an
+ * import used to add an entry that nothing ever removed, which makes anonymous
+ * search a slow, permanent memory leak: cheap to drive, invisible until the
+ * process is restarted, and indistinguishable from ordinary traffic.
+ *
+ * Insertion order is what makes eviction correct here. A JS `Map` iterates in
+ * insertion order, and a repeat query inside its TTL returns early WITHOUT
+ * re-setting the key, so the oldest key is always the least recently admitted —
+ * exactly the one whose TTL is closest to expiring anyway. Evicting it can
+ * therefore only ever allow an import that the TTL was about to allow regardless.
+ */
+export const MAX_THROTTLE_KEYS = 500;
+
 const lastSyncAt = new Map<string, number>();
 const queuedFeeds = new Set<string>();
 let importQueue: Promise<void> = Promise.resolve();
 
 function normalizeQuery(query: string): string {
   return query.trim().toLowerCase();
+}
+
+/**
+ * Record a sync and hold the throttle map at {@link MAX_THROTTLE_KEYS} entries,
+ * dropping the oldest-admitted keys first. A loop rather than a single delete so
+ * the bound holds even if the cap is ever lowered below the current size.
+ */
+function rememberSync(key: string, now: number): void {
+  lastSyncAt.set(key, now);
+  while (lastSyncAt.size > MAX_THROTTLE_KEYS) {
+    const oldest = lastSyncAt.keys().next().value;
+    if (oldest === undefined) break;
+    lastSyncAt.delete(oldest);
+  }
 }
 
 function bulkImportEnabled(): boolean {
@@ -214,7 +246,7 @@ export async function syncPodcastSearch(
 
   const last = lastSyncAt.get(key);
   if (last !== undefined && now - last < SEARCH_IMPORT_TTL_MS) return empty;
-  lastSyncAt.set(key, now);
+  rememberSync(key, now);
 
   let candidates: PodcastDirectoryCandidate[];
   try {

--- a/packages/backend/src/services/preview/previewInFlight.test.ts
+++ b/packages/backend/src/services/preview/previewInFlight.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `ensurePreviewClip` in-flight de-duplication.
+ *
+ * `GET /api/preview/:trackId.mp3` takes no authentication and a cache MISS costs
+ * an S3 download plus an ffmpeg transcode. Concurrent requests for the same clip
+ * all observe `objectExists` as false — the first writer has not uploaded yet —
+ * so without a shared promise each one pays that cost in full, and the multiplier
+ * is chosen by whoever is calling.
+ *
+ * These count entries into the generation path rather than asserting on the
+ * returned value, because the value is identical either way: the whole defect is
+ * how many times the expensive work runs.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import * as realS3 from '../s3Service';
+import {
+  ensurePreviewClip,
+  resetPreviewGenerationStateForTests,
+  type PreviewSourceRef,
+} from './previewService';
+
+const streamCalls: string[] = [];
+
+// Spread the real module and override only the two functions under test — a
+// wholesale replacement drops every other export and breaks unrelated importers
+// of `s3Service` with a `SyntaxError` at import time.
+//
+// Patching AFTER the static import above is fine here for the same reason it is
+// in `radio/radioStationStore.test.ts`: `previewService` calls these through the
+// module binding inside each request, not once at module load.
+mock.module('../s3Service', () => ({
+  ...realS3,
+  // The preview key is absent (that is the cache miss under test); the SOURCE
+  // object is present, so the generation reaches the download.
+  objectExists: async (key: string) => !key.includes('preview'),
+  streamFromS3: async (key: string) => {
+    streamCalls.push(key);
+    // Fail AFTER counting: the count is the measurement, and rejecting here
+    // keeps the test hermetic (no ffmpeg, no filesystem, no upload).
+    throw new Error('stream unavailable');
+  },
+}));
+
+afterEach(() => {
+  streamCalls.length = 0;
+  resetPreviewGenerationStateForTests();
+});
+
+const track: PreviewSourceRef = {
+  id: '000000000000000000000001',
+  artistId: '000000000000000000000002',
+  albumId: '000000000000000000000003',
+  title: 'Track',
+  audioSource: { url: 'https://cdn.example/source.mp3', format: 'mp3' },
+  hls: [],
+};
+
+describe('ensurePreviewClip — concurrent callers share one generation', () => {
+  it('runs the expensive path ONCE for N concurrent requests on the same clip', async () => {
+    const results = await Promise.allSettled([
+      ensurePreviewClip(track, 0),
+      ensurePreviewClip(track, 0),
+      ensurePreviewClip(track, 0),
+    ]);
+
+    expect(streamCalls.length).toBe(1);
+    // All three callers observe the same outcome — the joiners are not silently
+    // handed a null while the leader does the work.
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+  });
+
+  it('does NOT share between different start offsets — they are different clips', async () => {
+    // The map is keyed on the preview key, not the track id. Keying on the track
+    // would hand a caller asking for 0:30 the clip generated for 0:00.
+    await Promise.allSettled([ensurePreviewClip(track, 0), ensurePreviewClip(track, 30)]);
+
+    expect(streamCalls.length).toBe(2);
+  });
+
+  it('does not cache the failure — a later caller retries', async () => {
+    // The entry is dropped in `finally`, so a transient S3 error must not become
+    // a permanently dead clip for every subsequent request.
+    await Promise.allSettled([ensurePreviewClip(track, 0)]);
+    expect(streamCalls.length).toBe(1);
+
+    await Promise.allSettled([ensurePreviewClip(track, 0)]);
+    expect(streamCalls.length).toBe(2);
+  });
+});

--- a/packages/backend/src/services/preview/previewService.ts
+++ b/packages/backend/src/services/preview/previewService.ts
@@ -349,6 +349,23 @@ export async function storePreviewFromHls(
  * first, else the track's own ready HLS. Returns `null` when neither source is
  * resolvable (the endpoint then 404s).
  */
+/**
+ * Clip generations currently running, keyed by the S3 preview key.
+ *
+ * `GET /api/preview/:trackId.mp3` takes no authentication, and a cache MISS on it
+ * costs an S3 source download, an ffmpeg transcode and an upload. Without this
+ * map, N concurrent requests for the SAME clip each pay that in full: every one
+ * of them observes `objectExists` as false, because the first writer has not
+ * uploaded yet. One request is the intended cost; N is amplification an anonymous
+ * caller chooses the size of.
+ *
+ * Keyed on the preview key rather than the track id because two different
+ * `startSec` values are genuinely different clips and must not share a promise.
+ * The entry is removed in `finally`, so a rejection is not cached — the next
+ * caller retries rather than inheriting a failure it did not cause.
+ */
+const inFlightGenerations = new Map<string, Promise<string | null>>();
+
 export async function ensurePreviewClip(
   track: PreviewSourceRef,
   startSec: number,
@@ -358,6 +375,27 @@ export async function ensurePreviewClip(
     return previewKey;
   }
 
+  const running = inFlightGenerations.get(previewKey);
+  if (running) {
+    return running;
+  }
+
+  const generation = runPreviewGeneration(track, startSec).finally(() => {
+    inFlightGenerations.delete(previewKey);
+  });
+  inFlightGenerations.set(previewKey, generation);
+  return generation;
+}
+
+/** Test-only: clear in-flight generation state between cases. */
+export function resetPreviewGenerationStateForTests(): void {
+  inFlightGenerations.clear();
+}
+
+async function runPreviewGeneration(
+  track: PreviewSourceRef,
+  startSec: number,
+): Promise<string | null> {
   // Path 1: retained source audio (uploads / CC).
   if (track.audioSource) {
     const sourceRef: TrackAudioRef = {


### PR DESCRIPTION
Six `codex/*` branches sat unmerged since 2026-07-05, all conflicting with `main`. I reviewed each against current `main` instead of merging — the same approach that was taken with Mention's twenty, where **not one was mergeable as-is**.

## Verdicts

| branch | verdict |
|---|---|
| **#47** throttle-key cap | **LIVE** — landed here |
| **#44** preview in-flight dedup | **LIVE** — landed here (its other half rejected, below) |
| **#49** deploy pinned to main | **LIVE** — landed here |
| **#46** RSS claims | not reachable today; guard landed as defence-in-depth |
| #45 auth on search import | already addressed, better — closed |
| #48 copyright admin gate | already on `main` as `requireComplianceReviewer` — closed |

## The three live ones

**Unbounded throttle map.** `lastSyncAt` is keyed on the normalized search query, reached through `GET /api/search` with **no authentication**. Every distinct query long enough to trigger an import added an entry nothing removed — a leak an anonymous caller drives at will, invisible until restart. Capped at 500, evicting oldest-admitted first. Insertion order makes that correct: a repeat query inside its TTL returns early *without* re-setting the key, so the oldest key is the one whose TTL was about to expire anyway.

**Preview generation had no in-flight dedup.** `GET /api/preview/:trackId.mp3` is unauthenticated; a cache miss costs an S3 download plus an ffmpeg transcode. Concurrent callers all read `objectExists` as false — the first writer has not uploaded yet — so each paid in full, with the multiplier chosen by the caller. Keyed on the preview key, not the track id, since two `startSec` values are different clips. Dropped in `finally`, so a transient failure is not cached.

**`workflow_dispatch` could deploy any ref** with the AWS role. Guarded on `deploy` rather than `test`, so manual dispatch can still run tests on a branch. This is the exact form already on OxyHQServices `main` — **the other four repos sharing this workflow still need it**, tracked separately.

## Deliberately not taken

#44 also pinned the public endpoint to `start=0`. The SDK exposes `previewUrl(id, startSec)` with tests asserting `?start=42`, so that half would have broken a documented feature to close a vector the dedup already narrows. Landing a patch that breaks the legitimate path was one of the recurring defects in this batch.

## Verification

- Full backend suite: **1297 pass, 9 skip, 0 fail** across 104 files.
- `tsc --noEmit`: zero errors in every touched file.
- **Both guards mutation-tested.** Disabling the eviction fails exactly the eviction test; disabling the dedup lookup fails exactly the concurrency test and leaves the other two passing. The throttle test also ships a **CONTROL** that fails if the map stops remembering anything at all — without it, the eviction test would pass just as well against a map that never records.
- The RSS guard is placed **before** the claimable check, and a test pins that ordering: after it, an RSS show would answer 409 and the rule would silently depend on a flag nothing sets rather than on provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/syra/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->