### PR TITLE
chore(artists): delete the follow endpoint that never wrote anything

### DIFF
--- a/packages/backend/src/controllers/artists.controller.ts
+++ b/packages/backend/src/controllers/artists.controller.ts
@@ -196,54 +196,6 @@ export const getArtistTracks = async (req: Request, res: Response, next: NextFun
 };
 
 /**
- * POST /api/artists/:id/follow
- * Follow artist (requires auth)
- */
-export const followArtist = async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const id = getParam(req, 'id');
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ error: 'Unauthorized' });
-    }
-
-    // Mock - just return success
-    res.json({
-      success: true,
-      message: 'Artist followed',
-      artistId: id,
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/**
- * POST /api/artists/:id/unfollow
- * Unfollow artist (requires auth)
- */
-export const unfollowArtist = async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const id = getParam(req, 'id');
-    const userId = req.user?.id;
-
-    if (!userId) {
-      return res.status(401).json({ error: 'Unauthorized' });
-    }
-
-    // Mock - just return success
-    res.json({
-      success: true,
-      message: 'Artist unfollowed',
-      artistId: id,
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/**
  * POST /api/artists/register
  * Register as an artist (create artist profile)
  */

--- a/packages/backend/src/routes/artists.auth.routes.ts
+++ b/packages/backend/src/routes/artists.auth.routes.ts
@@ -1,7 +1,5 @@
 import { Router } from 'express';
 import {
-  followArtist,
-  unfollowArtist,
   registerAsArtist,
   getMyArtistProfile,
   updateMyArtistProfile,
@@ -41,10 +39,6 @@ router.patch('/me/contribution-settings', requireAuth, updateMyContributionSetti
 router.get('/me/image-suggestions', requireAuth, getMyImageSuggestions);
 router.post('/me/image-suggestions/accept', requireAuth, acceptMyImageSuggestion);
 router.post('/me/image-suggestions/discard', requireAuth, discardMyImageSuggestion);
-
-// Authenticated routes for following/unfollowing
-router.post('/:id/follow', requireAuth, followArtist);
-router.post('/:id/unfollow', requireAuth, unfollowArtist);
 
 // Claiming a contributed artist profile. Opens a PENDING claim and NEVER grants —
 // resolution lives on /api/artist-claims and is reviewer-only.

--- a/packages/frontend/services/musicService.ts
+++ b/packages/frontend/services/musicService.ts
@@ -51,9 +51,6 @@ const playlistsResponseSchema = z.object({
   playlists: z.array(playlistResponseSchema),
   total: z.number(),
 }).passthrough();
-const successResponseSchema = z.object({
-  success: z.boolean(),
-}).passthrough();
 
 function parseMusicResponse<T>(schema: z.ZodType<T>, data: unknown, label: string): T {
   const parsed = schema.safeParse(data);
@@ -128,16 +125,6 @@ export const musicService = {
     const response = await api.get<unknown>(`/artists/${artistId}/tracks`, params);
     const data = parseMusicResponse(tracksResponseSchema, response.data, 'artist tracks');
     return { ...data, tracks: data.tracks.map(normalizeTrackImages) };
-  },
-
-  async followArtist(artistId: string): Promise<{ success: boolean }> {
-    const response = await api.post<unknown>(`/artists/${artistId}/follow`);
-    return parseMusicResponse(successResponseSchema, response.data, 'follow artist');
-  },
-
-  async unfollowArtist(artistId: string): Promise<{ success: boolean }> {
-    const response = await api.post<unknown>(`/artists/${artistId}/unfollow`);
-    return parseMusicResponse(successResponseSchema, response.data, 'unfollow artist');
   },
 
   // Playlists


### PR DESCRIPTION
`POST /api/artists/:id/follow` and `/unfollow` returned `{success: true, message: 'Artist followed'}` and did nothing else — the handler body was a comment saying so:

```ts
// Mock - just return success
res.json({ success: true, message: 'Artist followed', artistId: id });
```

Their only client, `musicService.followArtist`/`unfollowArtist`, had **no callers** anywhere in frontend, studio or sdk, so nothing ever observed the lie.

That is worse than ordinary dead code. An endpoint that reports success is indistinguishable from one that works, so the next person to reach for `musicService.followArtist` — the obvious name, on the artists service, sitting beside every other artist read — gets a silent no-op and a UI that flips to "Following" until the page reloads.

**The real endpoint is untouched.** `POST /api/library/artists/:id/follow` (`library.controller`) writes `Library.followedArtists` and applies the taste signal; it stays the only artist-follow endpoint, and no follow data is affected. Verified the surviving route is still mounted in `library.routes.ts`.

`successResponseSchema` in `musicService.ts` goes with them — those two methods were its only users.

Found while surveying the follow surfaces for the Oxy follow-graph work (#72, currently draft pending a separate design decision). Split out deliberately so it can land on its own.

## Verification

- Typecheck clean in all four packages; lint 0 errors in frontend and studio.
- Backend 1306 tests, frontend 178 — all pass.
- `bun install` left `bun.lock` byte-unchanged, so the tree measured is the tree the lockfile describes.
- Grepped the whole tree afterwards: the only remaining `followArtist`/`unfollowArtist` are the real library controller, its route, and `libraryService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)