### PR TITLE
chore(deps): core 19.1.2, and drop the helmet declaration it makes redundant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,6 @@
         "express-validator": "^7.0.1",
         "fast-xml-parser": "^5.10.0",
         "firebase-admin": "^14.1.0",
-        "helmet": "^8.0.0",
         "i18n": "^0.15.1",
         "ioredis": "^6.0.0",
         "jsonwebtoken": "^9.0.2",
@@ -80,7 +79,7 @@
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
         "@oxyhq/bloom": "0.73.0",
-        "@oxyhq/core": "^19.1.1",
+        "@oxyhq/core": "^19.1.2",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^27.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -255,7 +254,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
         "@oxyhq/bloom": "0.73.0",
-        "@oxyhq/core": "^19.1.1",
+        "@oxyhq/core": "^19.1.2",
         "@oxyhq/services": "^27.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@shopify/flash-list": "2.0.2",
@@ -333,7 +332,7 @@
   },
   "overrides": {
     "@oxyhq/bloom": "^0.73.0",
-    "@oxyhq/core": "^19.1.1",
+    "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "lightningcss": "1.30.1",
     "lightningcss-linux-x64-gnu": "1.30.1",
@@ -978,7 +977,7 @@
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 
-    "@oxyhq/core": ["@oxyhq/core@19.1.1", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.24.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0", "helmet": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express", "helmet"] }, "sha512-Lsou8kE6a7rkE2ttRYpAgnR4ftuQGXEOpGPBGn1Aflve6b4gs6PQd/hR1I+SOiFc6SyOVGoWQ2DvhC37GmXinw=="],
+    "@oxyhq/core": ["@oxyhq/core@19.1.2", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.24.0", "@oxyhq/protocol": "^0.1.6", "@scure/bip39": "^1.6.0", "@types/elliptic": "^6.4.18", "buffer": "^6.0.3", "elliptic": "^6.6.1", "helmet": "^8.0.0", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^8.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-NxpXs2q+ZeqNN4K6nSwD8IMr9y7JYhZ7zavNgFwGp7IGIbjAzyy+xg4udXjHe+XdY7zieZfuTuZeHEk6edj+Og=="],
 
     "@oxyhq/crowdsource": ["@oxyhq/crowdsource@0.3.0", "", { "dependencies": { "zod": "^4.4.3" }, "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-YwLDyeIsXrU9qC8H51DW8KQI571HhdLXS3DjaPlJZ3n9W/Eeb/Xu+bqIHqLdFjViu/3Cvjw+dSYLPz2Zh/VAGg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {},
   "overrides": {
     "@oxyhq/bloom": "^0.73.0",
-    "@oxyhq/core": "^19.1.1",
+    "@oxyhq/core": "^19.1.2",
     "mongodb-connection-string-url": "7.0.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,7 +42,6 @@
     "express-validator": "^7.0.1",
     "fast-xml-parser": "^5.10.0",
     "firebase-admin": "^14.1.0",
-    "helmet": "^8.0.0",
     "i18n": "^0.15.1",
     "ioredis": "^6.0.0",
     "jsonwebtoken": "^9.0.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,7 +37,7 @@
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
     "@oxyhq/bloom": "0.73.0",
-    "@oxyhq/core": "^19.1.1",
+    "@oxyhq/core": "^19.1.2",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^27.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -30,7 +30,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
     "@oxyhq/bloom": "0.73.0",
-    "@oxyhq/core": "^19.1.1",
+    "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@shopify/flash-list": "2.0.2",


### PR DESCRIPTION
Takes `@oxyhq/core@19.1.2` and removes the now-redundant `helmet` declaration from `packages/backend`.

## Why the declaration existed, and why it was a trap

`@oxyhq/core/server` **value-imports helmet at module load** — `dist/*/server/securityHeaders.js` line 1-ish, `import helmet from 'helmet'` — but through 19.1.1 core declared helmet only as an **optional peer**. bun does not install an optional peer, so the module resolved only if the consumer happened to declare helmet itself.

Syra did, in `packages/backend`, which is why this repo booted while others did not. That made the declaration **load-bearing for a package Syra never imports**: `helmet` appears **zero** times in Syra's own source, so it read as an unused dependency to any reader or tool, and a routine dependency-pruning pass removing it would have broken the backend at startup — with `tsc` staying green the whole way.

19.1.2 makes helmet a real `dependency` of core and drops the peer entry, so it arrives transitively. The local declaration is now genuinely redundant rather than quietly propping up a broken manifest, and removing it **retires the trap** instead of leaving a comment to survive it.

## Verified, because the whole point is startup behaviour typechecking cannot see

- **The check is not vacuous.** `@oxyhq/core/server` re-exports `createOxySecurityHeaders`, `buildOxyCspDirectives`, `formatOxyCspPolicy` and `OXY_CSP_BASELINE` from the very module that imports helmet — so an unresolvable helmet throws on `require`. Confirmed the barrel reaches that module before trusting the result.
- **The backend boots** with helmet undeclared: `Server running, port: <random high port>`, and no `Cannot find module` / `MODULE_NOT_FOUND` anywhere in the log. The only error line is the `SIGTERM` from the timeout I used to stop it.
- **helmet stays in `bun.lock`** at `8.3.0`, now resolved through core's `dependencies` rather than through the backend workspace. The lockfile delta is exactly that: backend's entry removed, core 19.1.1 → 19.1.2 with helmet moving from `peerDependencies` to `dependencies`.

Bound a random high port for the boot check rather than the local default `4120`, so it could not be mistaken for the real dev backend by anything else on the machine; verified nothing was left listening.

## Gates

Typecheck clean in all four packages, lint 0 errors (frontend and studio), backend 1306 tests, frontend 186.

## Note for other repos

Any repo that declares `helmet` without importing it is in the state Syra was in. Until it takes core 19.1.2, that declaration is load-bearing and must not be pruned; after 19.1.2 it can be dropped like this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
