### PR TITLE
chore(deps): bloom 0.83.0 — the colour system derives its fills

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "0.79.1",
+        "@oxyhq/bloom": "0.83.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^27.1.1",
@@ -253,7 +253,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "0.79.1",
+        "@oxyhq/bloom": "0.83.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/services": "^27.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -331,7 +331,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.79.1",
+    "@oxyhq/bloom": "^0.83.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "lightningcss": "1.30.1",
@@ -973,7 +973,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.79.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-yQs1WvZTCHc15J7K5/aUrs6vPlV6S0H438+aUZjDUk9GQfxhz5AMv39A6xu50q11E4AY88julklqSdcKDG9jfw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.83.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-SDpNU4wG8uN2NUmsDxnYX6NWXLPQpZyslZHJFpIAWTagKUGg4yL+8QMkcqOOSud0lU0GnylOX5y/BOvh/MeNBw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "overrides": {
-    "@oxyhq/bloom": "^0.79.1",
+    "@oxyhq/bloom": "^0.83.0",
     "@oxyhq/core": "^19.1.2",
     "mongodb-connection-string-url": "7.0.2",
     "react": "19.2.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "0.79.1",
+    "@oxyhq/bloom": "0.83.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^27.1.1",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "0.79.1",
+    "@oxyhq/bloom": "0.83.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
Bumps `@oxyhq/bloom` 0.79.1 → 0.83.0 across the root catalog, `packages/frontend` and `packages/studio`.

## What changed upstream

- The brand fill's tone is **searched per hue** for the most vivid one that still carries a white label, instead of a flat 45 (light) / 49 (dark) for every hue.
- Light **no longer forces a seed to maximum chroma**, so a muted brand stays muted rather than resolving to its saturated neighbour.
- Most preset seeds retuned. **`amber` is removed** — it and `pumpkin` sit six degrees apart in hue and flatten to the same gold at the tones a white label needs. `mono` (black and white), `pumpkin`, `gray`, `brown`, `peach` and `rose` are new.
- `PREMIUM_COLOR_NAMES` **changes meaning**: `['mono']` now, with the reserved brand colours under the new `HANDLE_COLOR_NAMES`. Nothing here reads either.

`@oxyhq/core` and `@oxyhq/services` are already at their published latest here, so only Bloom moves.

## Verification

Against the published package:

- `typecheck` — clean across all five workspaces
- `test` — every package exits 0 (backend 1297 pass, 9 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)