### PR TITLE
chore(deps): bloom 0.84.0 — four seeds retuned, and a brand can insist on a white label

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
         "@gorhom/bottom-sheet": "^5.2.6",
         "@legendapp/list": "^2.0.14",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "0.83.0",
+        "@oxyhq/bloom": "0.84.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^27.1.1",
@@ -253,7 +253,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@livekit/react-native": "^2.11.1",
-        "@oxyhq/bloom": "0.83.0",
+        "@oxyhq/bloom": "0.84.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/services": "^27.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -331,7 +331,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "lightningcss": "1.30.1",
@@ -973,7 +973,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.83.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-SDpNU4wG8uN2NUmsDxnYX6NWXLPQpZyslZHJFpIAWTagKUGg4yL+8QMkcqOOSud0lU0GnylOX5y/BOvh/MeNBw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.84.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-P3kC+VbHSZB4FQJ3fIEZcw+QubnY3qLG44bTZqXJ67uQYMpdhe6H8kx6H5PI9AoPB9jCCMeV+k0U4uE63Nmiig=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "overrides": {
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/core": "^19.1.2",
     "mongodb-connection-string-url": "7.0.2",
     "react": "19.2.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,7 @@
     "@gorhom/bottom-sheet": "^5.2.6",
     "@legendapp/list": "^2.0.14",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "0.83.0",
+    "@oxyhq/bloom": "0.84.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^27.1.1",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,7 +29,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@livekit/react-native": "^2.11.1",
-    "@oxyhq/bloom": "0.83.0",
+    "@oxyhq/bloom": "0.84.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
Bumps `@oxyhq/bloom` to 0.84.0.

Four preset seeds retuned — `yellow` (#ffd400), `orange` (#ff7a00), `pink` (#f91880), `blue` (#1d9bf0) — all carrying a **white** label in both modes.

`yellow` needed a mechanism, not just a seed. Dark's split used to be decided by seed lightness alone, and that rule cannot separate `yellow` (seed tone 86), which wants to become a deep gold with white on it, from `faircoin` (tone 90), which wants to stay a bright lime with black on it. Four tones apart, opposite answers, and nothing in either hex says which. So a preset can now **declare** `label: 'white'` and forgo the exemption.

The declaration is read from the seed hex rather than threaded as a parameter — a named preset is a fixed seed fed through the same policy, so seeding a scope with `preset.hex` has to reproduce the preset exactly. The first version passed it down from one caller and silently gave every other path a different yellow; Bloom's parity suites caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Verification** (against the published package): typecheck clean across all 5 workspaces · every package's tests exit 0.