### PR TITLE
docs: AGENTS.md points at the org standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Syra
 
+> Org-wide engineering standards (TypeScript, React, naming, error handling, security, testing, git, bun) live at <https://github.com/OxyHQ/engineering/blob/main/AGENTS.md> and are not repeated here. This file holds ONLY Syra-specific content.
+
 ## Monorepo Structure
 
 | Package | Path | Role |


### PR DESCRIPTION
Adds the pointer to the org standards. That is the whole change, and the audit is the point of the PR.

## What the audit found

Nothing to remove. Syra's `AGENTS.md` was already delta-only:

- the monorepo table (verified: `@syra/frontend`, `@syra/backend`, `@syra/studio`, `@syra.fm/sdk`, `@syra/shared-types` are the five tracked workspaces; `packages/creators/` on disk is an untracked build artefact with no manifest, correctly absent)
- the deploy facts (`PORT` defaults to `4120` at `packages/backend/src/config/env.ts:9`; `us-west-2` and the ECR registry confirmed in `deploy-aws.yml`; `https://syra.fm` / `api.syra.fm` confirmed in `packages/frontend/config.ts` and the backend env schema)
- the catalog rules, `playableTrackFilter()` and its playback twin
- the `$lookup` local-side conversion rule
- the `select: false`-is-not-access-control finding
- the zod-DTO-without-a-Mongoose-path finding

No generic TypeScript, React, git, security or testing advice was present. **No version number is pinned in prose anywhere in the file**, so there was nothing to correct on that front either. Every backticked path resolves against `git ls-files`.

## The pointer

<https://github.com/OxyHQ/engineering/blob/main/AGENTS.md> now owns the generic rules org-wide, and this file states that it does not repeat them, so the next person adding a section knows which half belongs where.

`CLAUDE.md` and `GEMINI.md` already contain only the `@AGENTS.md` import line. No change needed.

Branch cut from `origin/main` in a scratch worktree; `git add` scoped to `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)