### PR TITLE
Syra's app.syra.* chain lexicons, and the gate that decides what leaves

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -16,6 +16,7 @@ export * from './entityProfile';
 export * from './library';
 export * from './radio';
 export * from './player';
+export * from './mtn/lexicons';
 export * from './search';
 export * from './integrations';
 export * from './connect';

--- a/packages/shared-types/src/mtn/lexicons.test.ts
+++ b/packages/shared-types/src/mtn/lexicons.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Syra's chain lexicons.
+ *
+ * The case that carries the weight is `unlisted`. Everything else here is schema
+ * shape; that one is a disclosure boundary, and it is the one a reasonable
+ * person writes as `!== 'private'` without noticing they just published every
+ * unlisted playlist in the product.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { PlaylistVisibility } from '../playlist';
+import {
+  SYRA_FEED_COLLECTIONS,
+  SYRA_PLAYLIST_COLLECTION,
+  SYRA_PLAYLIST_INLINE_TRACK_CAP,
+  SYRA_TOMBSTONE_COLLECTION,
+  isChainPublishablePlaylist,
+  syraPlaylistRecordSchema,
+  syraRecordSubject,
+  syraTombstoneRecordSchema,
+} from './lexicons';
+
+describe('isChainPublishablePlaylist', () => {
+  it('publishes a public playlist', () => {
+    expect(isChainPublishablePlaylist(PlaylistVisibility.PUBLIC)).toBe(true);
+  });
+
+  it('refuses a private one', () => {
+    expect(isChainPublishablePlaylist(PlaylistVisibility.PRIVATE)).toBe(false);
+  });
+
+  it('refuses an UNLISTED one', () => {
+    // The fixture that tells `=== 'public'` from `!== 'private'`. An unlisted
+    // playlist is reachable by link and absent from every listing; putting it on
+    // a chain other apps read would un-list it, which is the one thing its owner
+    // asked for. Without this case both implementations pass.
+    expect(isChainPublishablePlaylist(PlaylistVisibility.UNLISTED)).toBe(false);
+  });
+
+  it('covers every visibility the product defines', () => {
+    // A vacuity floor: if a fourth visibility is added, this fails until someone
+    // decides which side of the boundary it belongs on.
+    expect(Object.values(PlaylistVisibility).sort()).toEqual(['private', 'public', 'unlisted']);
+  });
+});
+
+describe('collections', () => {
+  it('names both collections under the app.syra. namespace', () => {
+    // The prefix is what oxy-api's namespace grant matches on, so a collection
+    // outside it would be refused at write time with a 403 nobody expects.
+    for (const nsid of SYRA_FEED_COLLECTIONS) {
+      expect(nsid.startsWith('app.syra.')).toBe(true);
+    }
+    expect(SYRA_FEED_COLLECTIONS).toEqual([SYRA_PLAYLIST_COLLECTION, SYRA_TOMBSTONE_COLLECTION]);
+  });
+});
+
+describe('syraPlaylistRecordSchema', () => {
+  const valid = {
+    playlistId: 'pl_1',
+    name: 'Domingo',
+    trackCount: 2,
+    tracks: [{ trackId: 't1', title: 'One' }],
+    createdAt: '2026-08-06T00:00:00.000Z',
+  };
+
+  it('accepts a minimal record', () => {
+    expect(syraPlaylistRecordSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts a trackCount larger than the inline tracks', () => {
+    // Deliberate: the record carries what a reader needs to render, not the
+    // playlist's whole state.
+    expect(syraPlaylistRecordSchema.safeParse({ ...valid, trackCount: 900 }).success).toBe(true);
+  });
+
+  it('refuses more inline tracks than the cap', () => {
+    const tracks = Array.from({ length: SYRA_PLAYLIST_INLINE_TRACK_CAP + 1 }, (_, i) => ({
+      trackId: `t${i}`,
+      title: `Track ${i}`,
+    }));
+    expect(syraPlaylistRecordSchema.safeParse({ ...valid, tracks }).success).toBe(false);
+  });
+
+  it('refuses an empty name and a negative count', () => {
+    expect(syraPlaylistRecordSchema.safeParse({ ...valid, name: '' }).success).toBe(false);
+    expect(syraPlaylistRecordSchema.safeParse({ ...valid, trackCount: -1 }).success).toBe(false);
+  });
+});
+
+describe('tombstones', () => {
+  it('names the record it supersedes by collection and key', () => {
+    expect(syraRecordSubject(SYRA_PLAYLIST_COLLECTION, 'pl_1')).toBe('app.syra.feed.playlist/pl_1');
+  });
+
+  it('accepts a well-formed tombstone', () => {
+    expect(
+      syraTombstoneRecordSchema.safeParse({
+        subject: syraRecordSubject(SYRA_PLAYLIST_COLLECTION, 'pl_1'),
+        createdAt: '2026-08-06T00:00:00.000Z',
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/shared-types/src/mtn/lexicons.ts
+++ b/packages/shared-types/src/mtn/lexicons.ts
@@ -1,0 +1,155 @@
+/**
+ * Syra's chain lexicons — `app.syra.*` record payloads.
+ *
+ * A person has ONE chain, held by Oxy, and every app appends its own records to
+ * it. The Oxy Protocol owns the WIRE grammar (a signed envelope whose `record`
+ * is opaque); a lexicon is the typed projection of that payload, addressed by an
+ * AtProto-style `(collection, rkey)` key. Syra defines its own here without
+ * touching the envelope — the same recipe Mention's `app.mention.feed.*` follows.
+ *
+ * ## Scope, and why it starts this small
+ *
+ * One content kind: a PUBLIC playlist. Not listens.
+ *
+ * That is a disclosure decision, not a scheduling one. `ListeningEvent` carries
+ * no visibility field and Syra has no listening-privacy setting at all, so
+ * putting listens on a shared chain would CREATE a disclosure rather than mirror
+ * one a person already made — and a chain is append-only, so it would be a
+ * disclosure nobody could take back. A playlist already carries an explicit
+ * `visibility` the user chose, which is exactly what makes it publishable.
+ *
+ * When Syra grows a real "share my listening" setting, a listen lexicon can
+ * follow the same rule: publish only what the person already chose to publish.
+ */
+
+import * as z from 'zod';
+import { PlaylistVisibility, type PlaylistVisibility as PlaylistVisibilityType } from '../playlist';
+
+/* -------------------------------------------------------------------------- */
+/*  Collection NSIDs                                                          */
+/* -------------------------------------------------------------------------- */
+
+/** A playlist the person published. */
+export const SYRA_PLAYLIST_COLLECTION = 'app.syra.feed.playlist' as const;
+
+/**
+ * A deletion marker superseding a previously published record.
+ *
+ * Not optional, and not a later nicety. A playlist can go from `public` back to
+ * `private` or `unlisted`, and a chain is append-only — so without a way to
+ * supersede, the first publish would be permanent and flipping a playlist
+ * private would change nothing anyone else can see. The tombstone is what makes
+ * the visibility control keep working after the first publish.
+ */
+export const SYRA_TOMBSTONE_COLLECTION = 'app.syra.feed.tombstone' as const;
+
+/** Every Syra chain collection. */
+export const SYRA_FEED_COLLECTIONS = [SYRA_PLAYLIST_COLLECTION, SYRA_TOMBSTONE_COLLECTION] as const;
+
+export type SyraFeedCollection = (typeof SYRA_FEED_COLLECTIONS)[number];
+
+/* -------------------------------------------------------------------------- */
+/*  The publish gate                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Whether a playlist's visibility permits publishing it to the shared chain.
+ *
+ * `public` ONLY. `unlisted` is deliberately excluded and is the whole reason
+ * this is a named function rather than an inline comparison: an unlisted
+ * playlist is reachable by whoever holds its link and absent from every listing,
+ * so putting it on a chain other apps read and project would un-list it — the
+ * one thing its owner asked for. A `!== 'private'` test reads as equivalent and
+ * is not.
+ *
+ * `private` is refused for the obvious reason, which is also the least likely to
+ * be got wrong.
+ */
+export function isChainPublishablePlaylist(visibility: PlaylistVisibilityType): boolean {
+  return visibility === PlaylistVisibility.PUBLIC;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  app.syra.feed.playlist                                                    */
+/* -------------------------------------------------------------------------- */
+
+/** A track as named on a published playlist record. */
+export interface SyraPlaylistTrackRef {
+  /** Syra's own track id — resolvable through Syra, opaque to every other app. */
+  trackId: string;
+  title: string;
+  /** Primary artist's display name, denormalized so a reader renders without a second lookup. */
+  artist?: string;
+  /** ISRC when known — the one identifier that means the same thing outside Syra. */
+  isrc?: string;
+}
+
+export const syraPlaylistTrackRefSchema: z.ZodType<SyraPlaylistTrackRef> = z.object({
+  trackId: z.string().min(1),
+  title: z.string().min(1),
+  artist: z.string().optional(),
+  isrc: z.string().optional(),
+});
+
+/**
+ * The payload of an `app.syra.feed.playlist` record.
+ *
+ * `rkey` is the playlist's own Syra id, so re-publishing supersedes rather than
+ * duplicates — which is how an edit works, and how a rename reaches readers.
+ *
+ * Tracks are capped and denormalized on purpose. A chain record is replicated to
+ * every node following the subject and committed to by the transparency log, so
+ * it carries what a reader needs to RENDER the playlist, not the playlist's
+ * whole state. Anything beyond the cap is fetched from Syra by `playlistId`.
+ */
+export interface SyraPlaylistRecord {
+  playlistId: string;
+  name: string;
+  description?: string;
+  /** Cover art content address, when the playlist has one. */
+  coverSha256?: string;
+  /** Total tracks, which may exceed `tracks.length`. */
+  trackCount: number;
+  tracks: SyraPlaylistTrackRef[];
+  /** ISO 8601. Self-asserted, so a reader clamps it rather than trusting it. */
+  createdAt: string;
+}
+
+/** Most tracks carried inline on one record. Beyond this, readers fetch from Syra. */
+export const SYRA_PLAYLIST_INLINE_TRACK_CAP = 50;
+
+export const syraPlaylistRecordSchema: z.ZodType<SyraPlaylistRecord> = z.object({
+  playlistId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  coverSha256: z.string().optional(),
+  trackCount: z.number().int().nonnegative(),
+  tracks: z.array(syraPlaylistTrackRefSchema).max(SYRA_PLAYLIST_INLINE_TRACK_CAP),
+  createdAt: z.string().min(1),
+});
+
+/* -------------------------------------------------------------------------- */
+/*  app.syra.feed.tombstone                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The payload of an `app.syra.feed.tombstone` record: the record it supersedes.
+ *
+ * `subject` is the superseded record's `(collection, rkey)` pair rendered as
+ * `<collection>/<rkey>`, so a tombstone names what it removes without depending
+ * on a content address the publisher may not have kept.
+ */
+export interface SyraTombstoneRecord {
+  subject: string;
+  createdAt: string;
+}
+
+export const syraTombstoneRecordSchema: z.ZodType<SyraTombstoneRecord> = z.object({
+  subject: z.string().min(1),
+  createdAt: z.string().min(1),
+});
+
+/** The `subject` a tombstone carries for a given record key. */
+export function syraRecordSubject(collection: SyraFeedCollection, rkey: string): string {
+  return `${collection}/${rkey}`;
+}


### PR DESCRIPTION
Primer paso de Syra hacia la cadena compartida (fase 4 del plan de fediverso/MTN). El sustrato ya está en oxy-api: escritura por app con doble puerta, lectura multi-autor con estrechamiento, y cliente en el SDK.

## Playlists, no escuchas — y es una decisión de divulgación, no de calendario

`ListeningEvent` **no tiene campo de visibilidad** y Syra no tiene ningún ajuste de privacidad de escucha. Poner escuchas en una cadena compartida no reflejaría una decisión que la persona ya tomó: **la crearía**. Y una cadena es append-only, así que sería una divulgación que nadie puede retirar.

Una playlist ya lleva una `visibility` que su dueño eligió. Eso es justo lo que la hace publicable, y es el mismo patrón que `isPublicPublishedPost` en Mention: publicar solo lo que ya era público.

## `unlisted` es por lo que la puerta es una función con nombre

`isChainPublishablePlaylist` es `=== 'public'`, **no** `!== 'private'`.

Una playlist *unlisted* es alcanzable por quien tenga el enlace y está ausente de todo listado. Publicarla en una cadena que otras apps leen y proyectan la **des-ocultaría** — exactamente lo que su dueño pidió que no pasara. Las dos formas se leen igual y no lo son, así que el test lleva la fixture que las distingue: **mutation-tested**, y la forma laxa falla ese caso y solo ese.

Hay además un piso de vacuidad que afirma que el enum sigue teniendo tres valores, para que una cuarta visibilidad falle hasta que alguien decida de qué lado cae.

## El tombstone no es un adorno para después

Una playlist puede volver de pública a privada, y la cadena es append-only. Sin forma de superseder, el primer publish sería permanente y volverla privada no cambiaría nada para nadie. El tombstone es lo que mantiene el control de visibilidad funcionando **después** del primer publish.

## Lo que NO trae, y por qué no puede

Emisor. Syra pina `@oxyhq/core ^19.1.2`, lo publicado es 20.0.0 y el cliente de cadenas es más nuevo que ambos — así que el emisor no compilaría hoy. Las reglas sí son comprobables sin él, que es la mitad que merece aterrizar primero.

Cuando llegue el emisor hará falta además, y no está en mano de este PR: que staff conceda a Syra el scope `chains:write` y le ponga `chainNamespaces = ['app.syra.']`, y declarar `app.syra.feed.playlist` como pública en la política de colecciones de oxy-api.

## Verificación

11/11, `typecheck` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)