### PR TITLE
fix(security): stop serving every account's mute and block list

### DIFF
--- a/packages/backend/src/routes/profileSettings.privacyProjection.test.ts
+++ b/packages/backend/src/routes/profileSettings.privacyProjection.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  VIEWER_VISIBLE_PRIVACY_FIELDS,
+  viewerVisiblePrivacy,
+} from './profileSettings';
+
+/**
+ * `GET /api/profile/settings/:userId` is mounted behind `requireAuth` and takes
+ * the account id from the URL, so before this projection it served ANY account's
+ * full settings document to ANY authenticated caller — including
+ * `privacy.hiddenWords` (the mute list) and `privacy.restrictedUsers` (the block
+ * list).
+ *
+ * `ensureUserSettings` returns `.lean<UserSettingsLean>()`, which CASTS without
+ * projecting, so the TypeScript type said those fields were absent while the
+ * runtime document carried them. Two guards that each looked sufficient, both
+ * inert on the same path.
+ *
+ * **The defect was a PRESENCE, not an absence**, so every fixture here carries
+ * the sensitive fields. An allowlist tested against a document that lacks them
+ * passes identically whether or not the allowlist works.
+ */
+const FULL_PRIVACY = {
+  profileVisibility: 'followers_only',
+  showContactInfo: false,
+  allowTags: true,
+  allowMentions: false,
+  showOnlineStatus: true,
+  hideLikeCounts: true,
+  hideShareCounts: false,
+  hideReplyCounts: true,
+  hideSaveCounts: false,
+  hiddenWords: ['spoiler', 'politics'],
+  restrictedUsers: ['oxy-user-blocked-1', 'oxy-user-blocked-2'],
+};
+
+describe('viewer-visible privacy projection', () => {
+  it('never returns the mute list or the block list', () => {
+    const projected = viewerVisiblePrivacy(FULL_PRIVACY);
+
+    expect(projected).not.toHaveProperty('hiddenWords');
+    expect(projected).not.toHaveProperty('restrictedUsers');
+    // Belt and braces: no VALUE from either list may appear under any key.
+    const serialised = JSON.stringify(projected);
+    for (const secret of [...FULL_PRIVACY.hiddenWords, ...FULL_PRIVACY.restrictedUsers]) {
+      expect(serialised).not.toContain(secret);
+    }
+  });
+
+  it('returns every viewer-visible field, with its real value', () => {
+    const projected = viewerVisiblePrivacy(FULL_PRIVACY);
+
+    // Values, not just presence — a projection that returned the right KEYS with
+    // wrong or defaulted values would render another account's profile wrongly.
+    expect(projected).toEqual({
+      profileVisibility: 'followers_only',
+      showContactInfo: false,
+      allowTags: true,
+      allowMentions: false,
+      showOnlineStatus: true,
+      hideLikeCounts: true,
+      hideShareCounts: false,
+      hideReplyCounts: true,
+      hideSaveCounts: false,
+    });
+  });
+
+  it('carries no key outside the allowlist, whatever the document holds', () => {
+    // The document a route hands this function is the WHOLE settings row, not a
+    // privacy subdocument — `.lean()` does not project, so anything added to the
+    // model tomorrow arrives here too.
+    const projected = viewerVisiblePrivacy({
+      ...FULL_PRIVACY,
+      someFieldAddedLater: 'must not leak',
+      notifications: { email: true },
+    });
+
+    expect(Object.keys(projected).sort()).toEqual(
+      [...VIEWER_VISIBLE_PRIVACY_FIELDS].sort(),
+    );
+  });
+
+  it('omits absent fields rather than emitting undefined', () => {
+    // A fresh account's document has defaults for some fields and nothing for
+    // others; emitting `undefined` keys would make the response shape depend on
+    // account age.
+    const projected = viewerVisiblePrivacy({ profileVisibility: 'public' });
+
+    expect(projected).toEqual({ profileVisibility: 'public' });
+    expect(Object.keys(projected)).not.toContain('showContactInfo');
+  });
+
+  it('tolerates a missing privacy subdocument', () => {
+    expect(viewerVisiblePrivacy(undefined)).toEqual({});
+    expect(viewerVisiblePrivacy(null)).toEqual({});
+  });
+
+  it('the allowlist itself excludes the two protected fields', () => {
+    // Guards the list rather than the function: someone adding `hiddenWords`
+    // here would reintroduce the leak with every behavioural test still green.
+    const allowed: readonly string[] = VIEWER_VISIBLE_PRIVACY_FIELDS;
+    expect(allowed).not.toContain('hiddenWords');
+    expect(allowed).not.toContain('restrictedUsers');
+  });
+});

--- a/packages/backend/src/routes/profileSettings.ts
+++ b/packages/backend/src/routes/profileSettings.ts
@@ -35,20 +35,75 @@ router.get('/settings/me', async (req: AuthRequest, res: Response) => {
 });
 
 /**
+ * The privacy fields a VIEWER legitimately needs to render someone else's
+ * profile: visibility and the count-hiding flags. Everything else in the
+ * document — appearance, notifications, and in particular `hiddenWords` and
+ * `restrictedUsers` — belongs to its owner alone.
+ *
+ * `hiddenWords` is the user's mute list and `restrictedUsers` is their block
+ * list. Both are registered in `PROTECTED_COLUMNS_BY_TABLE`; this route is the
+ * one that has to agree with that registration, because `ensureUserSettings`
+ * narrows the TypeScript type and never projects.
+ */
+export const VIEWER_VISIBLE_PRIVACY_FIELDS = [
+  'profileVisibility',
+  'showContactInfo',
+  'allowTags',
+  'allowMentions',
+  'showOnlineStatus',
+  'hideLikeCounts',
+  'hideShareCounts',
+  'hideReplyCounts',
+  'hideSaveCounts',
+] as const;
+
+/**
+ * Projects a settings document down to {@link VIEWER_VISIBLE_PRIVACY_FIELDS}.
+ *
+ * Exported so it can be tested against a FULL document: the defect this replaces
+ * was a presence, not an absence, so the test that matters feeds a document
+ * carrying `hiddenWords` and `restrictedUsers` and asserts they do not come out.
+ * An allowlist tested only against a document that lacks them proves nothing.
+ */
+export function viewerVisiblePrivacy(
+  privacy: Record<string, unknown> | undefined | null,
+): Record<string, unknown> {
+  const projected: Record<string, unknown> = {};
+  for (const field of VIEWER_VISIBLE_PRIVACY_FIELDS) {
+    const value = privacy?.[field];
+    if (value !== undefined) {
+      projected[field] = value;
+    }
+  }
+  return projected;
+}
+
+/**
  * GET /api/profile/settings/:userId
- * Get settings by oxy user id
+ * Get another account's viewer-visible privacy settings.
+ *
+ * This route is mounted behind `requireAuth` and takes the id from the URL, so
+ * before this projection it served ANY account's full settings document to ANY
+ * authenticated caller — mute list and block list included. Its only caller
+ * (`usePrivacySettings`, via `useProfileData`) reads the profile being VIEWED,
+ * so restricting to the caller's own id would break profile rendering; the fix
+ * is to return the viewer-visible subset instead.
+ *
+ * Callers wanting their OWN full document use `/settings/me`.
  */
 router.get('/settings/:userId', async (req: AuthRequest, res: Response) => {
   try {
     const userId = getParam(req, 'userId');
-    
+
     const validationError = validateRequired(userId, 'userId');
     if (validationError) {
       return sendErrorResponse(res, 400, 'Bad Request', validationError);
     }
 
     const doc = await ensureUserSettings(userId);
-    return sendSuccessResponse(res, 200, doc);
+    return sendSuccessResponse(res, 200, {
+      privacy: viewerVisiblePrivacy(doc?.privacy as Record<string, unknown> | undefined),
+    });
   } catch (err) {
     logger.error('[ProfileSettings] Error fetching user settings:', err);
     return sendErrorResponse(res, 500, 'Internal Server Error', 'Failed to fetch settings');

--- a/packages/backend/src/utils/userSettings.ts
+++ b/packages/backend/src/utils/userSettings.ts
@@ -12,9 +12,22 @@ export const DEFAULT_PROFILE_CUSTOMIZATION = {
  * Ensures a UserSettings document exists for a user
  * Creates with defaults if missing, updates if missing profileCustomization
  */
+/**
+ * `.lean<T>()` CASTS; it does not project. So this type names a subset while the
+ * query returns the whole document — `privacy`, `notifications` and the rest are
+ * all present at runtime whatever this says.
+ *
+ * That gap is not theoretical: `GET /api/profile/settings/:userId` returned this
+ * value wholesale and therefore served every account's mute list and block list
+ * to any authenticated caller, because the type said those fields were not there.
+ *
+ * `privacy` is listed so the route that must strip it can see it. **A route
+ * returning this document is responsible for its own projection** — narrowing
+ * here protects nothing.
+ */
 type UserSettingsLean = Pick<
   IUserSettings,
-  'oxyUserId' | 'appearance' | 'profileHeaderImage' | 'profileCustomization'
+  'oxyUserId' | 'appearance' | 'profileHeaderImage' | 'profileCustomization' | 'privacy'
 >;
 
 export async function ensureUserSettings(oxyUserId: string) {


### PR DESCRIPTION
`GET /api/profile/settings/:userId` is mounted behind `requireAuth` and takes the account id from the URL, then returned the whole settings document. **Any authenticated Syra user could read any other user's mute list (`privacy.hiddenWords`) and block list (`privacy.restrictedUsers`)**, plus the rest of their settings.

## Why two guards did not stop it

`ensureUserSettings` returns `.lean<UserSettingsLean>()`, and that type names a subset excluding `privacy` — but **`.lean<T>()` casts, it does not project**, so the runtime document carried every field while TypeScript said otherwise.

And `extractPublicProfileData`, the helper written to solve exactly this, has **zero callers** anywhere in the repo.

## Why not just restrict it to the caller

Its only caller — `usePrivacySettings` via `useProfileData` — reads the profile being *viewed*, so an ownership check would break profile rendering. The fix is a projection: the nine viewer-visible flags needed to render someone else's profile, and nothing else. Callers wanting their own full document already have `/settings/me`.

The lean type now names `privacy` rather than hiding it, with a comment saying narrowing there protects nothing and each route owns its projection.

## On the test

It feeds a **full** document carrying both lists, because the defect was a *presence*, not an absence — an allowlist tested against a document that lacks them passes whether or not it works. Mutation-verified: returning the document whole turns three of the six red.

Found while porting this vertical to PostgreSQL, where both fields are already registered in `PROTECTED_COLUMNS_BY_TABLE`. The route and the structural guard disagreed, and the route won.

🤖 Generated with [Claude Code](https://claude.com/claude-code)