### PR TITLE
ci(deploy): the Postgres and phase the cutover needs — and the runner-label theory disproven

### DIFF
--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -419,18 +419,27 @@ diff -u \
 # in exactly the way that left `dist/scripts/migrate.js` — a path this package
 # has never emitted — wired into this script with every test green.
 workflow_file="$repository_root/.github/workflows/deploy-aws.yml"
+# Read one command out of deploy-aws.yml. The values are no longer step `env:`
+# keys: since the workflow gained its `migration_phase` input they are written to
+# $GITHUB_ENV by whichever of two mutually exclusive selector steps runs, so the
+# same variable name legitimately appears more than once and the PHASE is what
+# identifies which occurrence this is. Matching on the phase rather than on
+# position keeps the "declared exactly once" check meaningful — reordering the
+# selectors or adding a third cannot silently satisfy it.
 read_workflow_command() {
   local variable_name="$1"
+  local expected_phase="$2"
   local value
 
-  value="$(sed -n -E "s/^[[:space:]]*${variable_name}:[[:space:]]*'(.*)'[[:space:]]*$/\1/p" \
+  value="$(sed -n -E \
+    "s/^[[:space:]]*echo '${variable_name}=(\[.*\"--phase=${expected_phase}\".*\])'[[:space:]]*$/\1/p" \
     "$workflow_file")"
   if [[ -z "$value" ]]; then
-    echo "deploy-aws.yml declares no $variable_name." >&2
+    echo "deploy-aws.yml declares no $variable_name for --phase=$expected_phase." >&2
     return 1
   fi
   if [[ "$(wc -l <<<"$value")" != "1" ]]; then
-    echo "deploy-aws.yml declares $variable_name more than once." >&2
+    echo "deploy-aws.yml declares $variable_name for --phase=$expected_phase more than once." >&2
     return 1
   fi
   if ! jq -e '
@@ -444,8 +453,13 @@ read_workflow_command() {
   printf '%s\n' "$value"
 }
 
-workflow_pre_command="$(read_workflow_command PRE_DEPLOY_TASK_COMMAND_JSON)"
-workflow_post_command="$(read_workflow_command POST_DEPLOY_TASK_COMMAND_JSON)"
+workflow_pre_command="$(read_workflow_command PRE_DEPLOY_TASK_COMMAND_JSON pre)"
+workflow_post_command="$(read_workflow_command POST_DEPLOY_TASK_COMMAND_JSON post)"
+# The cutover's own pre-deploy command. It runs against PRODUCTION exactly once —
+# the genesis apply, where `pre` and `post` both block — so it is the argv least
+# likely to be exercised before it matters and the one most worth holding to the
+# same entry-point and target-database checks as the phased pair.
+workflow_cutover_command="$(read_workflow_command PRE_DEPLOY_TASK_COMMAND_JSON all)"
 
 # Every migration command must name a compiled entry point that EXISTS in
 # source. The check maps the runtime path back through tsconfig's layout
@@ -491,6 +505,17 @@ assert_migration_command() {
 
 assert_migration_command PRE_DEPLOY_TASK_COMMAND_JSON "$workflow_pre_command" pre
 assert_migration_command POST_DEPLOY_TASK_COMMAND_JSON "$workflow_post_command" post
+assert_migration_command 'PRE_DEPLOY_TASK_COMMAND_JSON (cutover)' "$workflow_cutover_command" all
+
+# The cutover selector must leave the post-deploy command EMPTY, which is how
+# this script is told to skip that task. It is checked here, and not only in the
+# workflow's own test, because the meaning of an empty value is defined by THIS
+# script: the `all` run has already applied the whole journal, so a post task
+# could only find nothing pending and turn a green cutover red.
+if ! grep -qE "^[[:space:]]*echo 'POST_DEPLOY_TASK_COMMAND_JSON='$" "$workflow_file"; then
+  echo "deploy-aws.yml's cutover path does not clear POST_DEPLOY_TASK_COMMAND_JSON." >&2
+  exit 1
+fi
 
 # A failing pre-deploy migration must abort the release BEFORE update-service,
 # leaving the previously deployed image serving and nothing to roll back.

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -9,6 +9,18 @@ on:
       - '**.md'
       - 'docs/**'
   workflow_dispatch:
+    inputs:
+      migration_phase:
+        description: >-
+          How to apply migrations. `pre-post` (default) applies the additive ones
+          before the rollout and the deferred ones after. `all` applies the whole
+          journal in ONE run before the rollout — what the genesis cutover needs,
+          and wrong for anything else. See the migration steps below.
+        type: choice
+        default: pre-post
+        options:
+          - pre-post
+          - all
 
 permissions:
   id-token: write
@@ -31,7 +43,48 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-arm
+    # x86, matching `quality.yml`'s job rather than the `deploy` job below. This
+    # job now runs the SAME Postgres service container quality.yml runs, and the
+    # two are compared field-by-field by
+    # `src/db/__tests__/deployWorkflow.test.ts`; running them on the same
+    # architecture is part of keeping that comparison meaningful. Nothing here is
+    # architecture-sensitive anyway — it typechecks, migrates and runs test
+    # suites. Only `deploy` needs ARM, to build the arm64 image natively.
+    #
+    # NOT a workaround for the runner-label outage story: that theory was tested
+    # and is FALSE. See the note on `deploy`'s `runs-on` before changing either.
+    runs-on: ubuntu-latest
+
+    # `postgres:17`, not a PostGIS image — the same image `quality.yml` and
+    # `docker-compose.postgres.yml` pin, on the same version. `src/db/extensions.ts`
+    # keeps `REQUIRED_EXTENSIONS` deliberately EMPTY: Syra has no `2dsphere` index
+    # and no geospatial query to port. Keep this bare, and keep all three in
+    # agreement — a schema task that starts needing an extension adds it to
+    # `REQUIRED_EXTENSIONS` first, and only then to every image that serves a
+    # database this suite runs against.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: syra
+          POSTGRES_PASSWORD: syra
+          POSTGRES_DB: syra_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U syra -d syra_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    # The backend suite is Postgres-backed: 92 of its files reach
+    # `src/test/postgres.ts`, whose `beforeAll` throws
+    # `TEST_DATABASE_URL (or DATABASE_URL) must point at a migrated Postgres.`
+    # when this is unset. Without it every deploy fails in its first job, on a
+    # missing environment variable rather than a bad assertion.
+    env:
+      TEST_DATABASE_URL: postgres://syra:syra@127.0.0.1:5432/syra_ci
+
     steps:
       - uses: actions/checkout@v7
 
@@ -60,6 +113,20 @@ jobs:
       # Ubuntu; the runtime image uses Alpine's `chromaprint` for the same binary.
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg libchromaprint-tools
 
+      # The suite runs against a MIGRATED database — `src/test/postgres.ts` opens
+      # the schema, it does not create it. `DATABASE_URL` here, not
+      # `TEST_DATABASE_URL`: the migrator always reads the former, the same
+      # variable it reads in every other environment, while the latter is only
+      # the name the suite falls back to. `--phase=all` because CI's database is
+      # empty every run, with no live image to protect — the same call
+      # `quality.yml` makes, deliberately identical so the two cannot disagree
+      # about what the suite is tested against.
+      - name: Migrate Postgres (CI service)
+        working-directory: packages/backend
+        run: bun run db:migrate --phase=all --target-database=syra_ci
+        env:
+          DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+
       - run: cd packages/backend && bun run test
 
       - run: cd packages/frontend && bunx jest --ci
@@ -74,6 +141,23 @@ jobs:
     # workflow_dispatch can be run against arbitrary refs; only deploys from the
     # protected main branch may assume the AWS deploy role.
     if: github.ref == 'refs/heads/main'
+    # ARM, so buildx builds the linux/arm64 image NATIVELY. Do not "fix" this by
+    # moving to x86 + `docker/setup-qemu-action`: emulated arm64 builds are far
+    # slower, and the outage that change was meant to answer had a different
+    # cause entirely.
+    #
+    # THE STORY THAT SAYS OTHERWISE IS WRONG, and it is written down here so it
+    # is not re-derived. Through 2026-08-08 every run of this workflow completed
+    # as `action_required` with ZERO jobs, which was attributed to this
+    # partner-runner label. It is not the label. GitHub's run page states the
+    # actual reason: "GitHub detected that this workflow file may be malicious.
+    # It will not run until someone with write access approves it." Two
+    # measurements settle it — a dispatch of THIS workflow with both jobs on
+    # `ubuntu-latest` was blocked identically (run 31278743099, zero jobs), and
+    # Mercaria's first green deploy (run 31275312983) was created at 19:47:43Z,
+    # started at 20:05:05Z once approved, and ran its deploy job on THIS LABEL,
+    # three minutes before the commit that moved it to QEMU. The label works; the
+    # run needs a human to approve it.
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
@@ -145,6 +229,57 @@ jobs:
           echo "digest=$DIGEST" >>"$GITHUB_OUTPUT"
           echo "Built $COMMIT_TAG -> $DIGEST"
 
+      # ── Which migrations bracket this rollout ────────────────────────────────
+      #
+      # Exactly one of the next two steps runs — their conditions are
+      # complements of the same expression — and each writes the pair of one-shot
+      # commands `deploy-ecs-image.sh` consumes into $GITHUB_ENV. That is what
+      # makes `all` and `post` mutually exclusive: not a convention, but the fact
+      # that no run can execute both selectors, so no run can produce both
+      # commands. `src/db/__tests__/deployWorkflow.test.ts` reads this file and
+      # fails if the conditions stop being complements.
+      #
+      # `node`, not `bun`: the runtime stage of packages/backend/Dockerfile is
+      # node:22-alpine and never copies bun in.
+      # `dist/src/db/migrate.js`: tsconfig sets `rootDir: "./"`, so `src/` is
+      # preserved inside `dist/`.
+      # `--target-database=syra`: the migrator refuses to run without it, because
+      # a migration aimed at the wrong database does not fail — it reports
+      # success over an untouched one.
+
+      # THE CUTOVER, chosen by hand from workflow_dispatch, and never the
+      # default. THE FIRST PRODUCTION DEPLOY CANNOT USE `--phase=pre`. Measured
+      # against the journal as it stands: `pre` and `post` both BLOCK, because
+      # migration 0003 (`pre`) sits behind 0001 (`post`) and the ledger cannot
+      # express a hole. That is the genesis window — those migrations only ever
+      # ran against an empty database with no live predecessor to protect — and
+      # `--phase=all` is the correct and only sanctioned way to apply it. See
+      # src/db/migrate.ts, "THE GENESIS BOOTSTRAP WINDOW".
+      #
+      # The post-deploy command is deliberately EMPTY, which is how
+      # deploy-ecs-image.sh is told to skip that task: the `all` run above it has
+      # already applied everything, so a `post` task could only find nothing
+      # pending and add a way for a green cutover to end on a red step.
+      - name: Select migrations (cutover — the whole journal, before the rollout)
+        if: github.event.inputs.migration_phase == 'all'
+        run: |
+          {
+            echo 'PRE_DEPLOY_TASK_COMMAND_JSON=["node","packages/backend/dist/src/db/migrate.js","--phase=all","--target-database=syra"]'
+            echo 'POST_DEPLOY_TASK_COMMAND_JSON='
+          } >>"$GITHUB_ENV"
+
+      # Every ordinary release. `pre` runs while the PREVIOUS image is still
+      # serving and applies only additive migrations; `post` runs once the new
+      # image is live and applies what `pre` deferred. src/db/migrate.ts explains
+      # the marker each migration carries and why there is no default phase.
+      - name: Select migrations (default — additive before, deferred after)
+        if: github.event.inputs.migration_phase != 'all'
+        run: |
+          {
+            echo 'PRE_DEPLOY_TASK_COMMAND_JSON=["node","packages/backend/dist/src/db/migrate.js","--phase=pre","--target-database=syra"]'
+            echo 'POST_DEPLOY_TASK_COMMAND_JSON=["node","packages/backend/dist/src/db/migrate.js","--phase=post","--target-database=syra"]'
+          } >>"$GITHUB_ENV"
+
       - name: Register immutable task definition and deploy
         env:
           IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
@@ -161,9 +296,9 @@ jobs:
           # of the service. Same mechanism Mention uses for its own
           # deploy-injected secrets.
           #
-          # It is also what gives the two one-shot migration tasks below their
-          # connection string: both run as container overrides on the revision
-          # this deploy registers, so they see exactly these secrets.
+          # It is also what gives the one-shot migration tasks this step runs
+          # their connection string: each runs as a container override on the
+          # revision this deploy registers, so they see exactly these secrets.
           #
           # The parameter must EXIST before the first task launches from a
           # revision naming it, or the task dies with
@@ -174,32 +309,10 @@ jobs:
           # workflow edit to reach SSM. There is no allowlist to forget here.
           TASK_SECRET_OVERRIDES_JSON: '{"DATABASE_URL":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/syra/DATABASE_URL"}'
 
-          # The migrations, bracketing the rollout. `pre` runs while the
-          # PREVIOUS image is still serving and applies only additive
-          # migrations; `post` runs once the new image is live and applies what
-          # `pre` deferred. src/db/migrate.ts explains the marker each migration
-          # carries and why there is no default phase.
-          #
-          # `node`, not `bun`: the runtime stage of packages/backend/Dockerfile
-          # is node:22-alpine and never copies bun in.
-          # `dist/src/db/migrate.js`: tsconfig sets `rootDir: "./"`, so `src/`
-          # is preserved inside `dist/`.
-          # `--target-database=syra`: the migrator refuses to run without it,
-          # because a migration aimed at the wrong database does not fail — it
-          # reports success over an untouched one.
-          #
-          # THE FIRST PRODUCTION DEPLOY CANNOT USE `--phase=pre`. Measured
-          # against the journal as it stands: `pre` and `post` both BLOCK,
-          # because migration 0003 (`pre`) sits behind 0001 (`post`) and the
-          # ledger cannot express a hole. That is the genesis window — those
-          # migrations only ever ran against an empty database with no live
-          # predecessor to protect — and `--phase=all` is the correct and only
-          # sanctioned way to apply it. So the cutover deploy is dispatched
-          # manually with `migration_phase: all`; every deploy after it takes
-          # the default and finds nothing pending. See src/db/migrate.ts,
-          # "THE GENESIS BOOTSTRAP WINDOW".
-          PRE_DEPLOY_TASK_COMMAND_JSON: '["node","packages/backend/dist/src/db/migrate.js","--phase=pre","--target-database=syra"]'
-          POST_DEPLOY_TASK_COMMAND_JSON: '["node","packages/backend/dist/src/db/migrate.js","--phase=post","--target-database=syra"]'
+          # PRE_DEPLOY_TASK_COMMAND_JSON / POST_DEPLOY_TASK_COMMAND_JSON are NOT
+          # set here: whichever selector step above ran put them in $GITHUB_ENV,
+          # so the pair this step sees is the one the chosen `migration_phase`
+          # produced. The script reads an empty POST value as "no post task".
         run: |
           STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP" --query 'services[0].status' --output text 2>/dev/null || echo NONE)
           if [ "$STATUS" != "ACTIVE" ]; then

--- a/packages/backend/src/db/__tests__/deployWorkflow.test.ts
+++ b/packages/backend/src/db/__tests__/deployWorkflow.test.ts
@@ -1,0 +1,204 @@
+/**
+ * `deploy-aws.yml` is the only thing that migrates production, and nothing
+ * executes it before it runs against production.
+ *
+ * That is the whole reason this file exists. The workflow encodes three facts
+ * that live in code elsewhere — which `--phase` spellings the migrator accepts,
+ * which database the suite is tested against, and which of the two migration
+ * paths a run takes — and each of them fails SILENTLY when the workflow drifts:
+ * a bad phase is refused by the migrator at deploy time, a missing Postgres
+ * service turns every deploy red in its first job, and a broken exclusivity
+ * condition applies the journal twice. None of those is a test failure anywhere
+ * else in this repo, because no test runs a workflow.
+ *
+ * ## The exclusivity is a property of the CONDITIONS, not of a convention
+ *
+ * `deploy-ecs-image.sh` takes its two one-shot commands from
+ * `PRE_DEPLOY_TASK_COMMAND_JSON` / `POST_DEPLOY_TASK_COMMAND_JSON`, so the
+ * workflow chooses between the cutover and the ordinary release by writing one
+ * pair or the other into `$GITHUB_ENV` from two selector steps. Those steps
+ * carry `if:` conditions that are COMPLEMENTS of the same expression, which is
+ * what makes `--phase=all` and `--phase=post` unable to co-occur: not that
+ * someone will remember, but that no run can execute both selectors.
+ *
+ * Two assertions are needed to hold that, and neither is redundant. The first
+ * checks the conditions really are complements. The second checks the selectors
+ * are the ONLY place those variables are set — because a hardcoded
+ * `POST_DEPLOY_TASK_COMMAND_JSON` on the deploy step would be immune to every
+ * `if:` in the file and would ride along with the cutover, which is the exact
+ * shape this workflow had before the input existed.
+ *
+ * ## Why the cutover needs to be reachable at all
+ *
+ * `drizzle/` interleaves the two phases from 0001 onwards (0003 `pre` sits
+ * behind 0001/0002 `post`), so against the EMPTY production ledger `pre` and
+ * `post` both block — `planMigrationRun` refuses, by design, rather than leave a
+ * hole. `all` is the only run that can perform the genesis apply. See
+ * `src/db/migrate.ts`, "THE GENESIS BOOTSTRAP WINDOW". So `all` has to be
+ * reachable (or the cutover cannot happen) and it has to be OPT-IN (or every
+ * ordinary release applies deferred migrations while the previous image serves).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { MIGRATION_RUNS } from '@oxyhq/db/migrate';
+
+/** Only the shape these assertions read — not a schema for GitHub Actions. */
+interface WorkflowFile {
+  on: {
+    workflow_dispatch?: {
+      inputs?: Record<string, { default?: string; options?: string[] }>;
+    };
+  };
+  jobs: Record<
+    string,
+    {
+      'runs-on': string;
+      env?: Record<string, string>;
+      services?: Record<string, unknown>;
+      steps: { name?: string; if?: string; run?: string; uses?: string; with?: Record<string, string> }[];
+    }
+  >;
+}
+
+/** From `packages/backend/src/db/__tests__`, the repo root is five levels up. */
+const REPO_ROOT = path.join(__dirname, '..', '..', '..', '..', '..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github', 'workflows', 'deploy-aws.yml');
+const QUALITY_PATH = path.join(REPO_ROOT, '.github', 'workflows', 'quality.yml');
+
+const workflowSource = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+const workflow = Bun.YAML.parse(workflowSource) as WorkflowFile;
+const quality = Bun.YAML.parse(fs.readFileSync(QUALITY_PATH, 'utf8')) as WorkflowFile;
+
+const selectorSteps = workflow.jobs.deploy.steps.filter((step) =>
+  step.name?.startsWith('Select migrations ('),
+);
+
+const selectorFor = (prefix: string): { if?: string; run?: string } => {
+  const step = selectorSteps.find((candidate) => candidate.name?.startsWith(prefix));
+  expect(step, `no selector step named ${prefix}`).toBeDefined();
+  return step ?? {};
+};
+
+describe('the deploy workflow and the migrator agree', () => {
+  it('offers the cutover override, defaulted to the phased pair', () => {
+    const input = workflow.on.workflow_dispatch?.inputs?.migration_phase;
+    expect(input, 'the migration_phase dispatch input is gone').toBeDefined();
+    expect(input?.default).toBe('pre-post');
+    expect(input?.options).toEqual(['pre-post', 'all']);
+  });
+
+  it('passes only phase values the migrator accepts', () => {
+    // Vacuity floor on both sides: an empty MIGRATION_RUNS would make the
+    // membership check unfalsifiable, and a regex that matched nothing would
+    // make it vacuous. The workflow spells `--phase=` four times — three
+    // migration runs plus the CI migrate step.
+    // Widened to `string[]` on purpose: the whole point is to compare values the
+    // migrator has NOT been told about, which a `MigrationRun[]` cannot express.
+    const accepted: readonly string[] = MIGRATION_RUNS;
+    expect(accepted.length).toBeGreaterThan(0);
+    const phases = [...workflowSource.matchAll(/--phase=([a-z-]+)/g)].map((match) => match[1]);
+    expect(phases.length).toBeGreaterThanOrEqual(4);
+    for (const phase of phases) {
+      expect(accepted).toContain(phase);
+    }
+  });
+
+  it('runs the built migrator by the path the runtime image actually contains', () => {
+    // `dist/src/db/migrate.js` under `node`: the runtime stage of the Dockerfile
+    // is node:22-alpine and never copies bun in, and tsconfig's `rootDir: "./"`
+    // preserves `src/` inside `dist/`. And `--target-database=`, which the
+    // migrator refuses to run without — a migration aimed at the wrong database
+    // reports success over an untouched one rather than failing.
+    for (const selector of selectorSteps) {
+      expect(selector.run).toContain('"node","packages/backend/dist/src/db/migrate.js"');
+      expect(selector.run).toContain('--target-database=syra"');
+    }
+  });
+
+  it('runs the cutover and the phased pair as MUTUALLY EXCLUSIVE paths', () => {
+    expect(selectorSteps).toHaveLength(2);
+    expect(selectorFor('Select migrations (cutover').if).toBe(
+      "github.event.inputs.migration_phase == 'all'",
+    );
+    expect(selectorFor('Select migrations (default').if).toBe(
+      "github.event.inputs.migration_phase != 'all'",
+    );
+  });
+
+  it('applies the whole journal on the cutover, and no post task after it', () => {
+    // The empty POST value is what tells deploy-ecs-image.sh to skip that task.
+    // A `post` run after `all` could only find nothing pending — a way for a
+    // green cutover to end on a red step.
+    const cutover = selectorFor('Select migrations (cutover').run ?? '';
+    expect(cutover).toContain('"--phase=all"');
+    expect(cutover).not.toContain('"--phase=post"');
+    expect(cutover).toMatch(/^\s*echo 'POST_DEPLOY_TASK_COMMAND_JSON='$/m);
+
+    const phased = selectorFor('Select migrations (default').run ?? '';
+    expect(phased).toContain('"--phase=pre"');
+    expect(phased).toContain('"--phase=post"');
+    expect(phased).not.toContain('"--phase=all"');
+  });
+
+  it('sets the one-shot commands ONLY from the selectors, never on the deploy step', () => {
+    // A value hardcoded on the deploy step's `env:` is immune to every `if:` in
+    // this file, so it would ride along with the cutover regardless.
+    const deployStep = workflow.jobs.deploy.steps.find((step) =>
+      step.name?.startsWith('Register immutable task definition'),
+    );
+    expect(deployStep, 'the deploy step is gone').toBeDefined();
+    for (const variable of ['PRE_DEPLOY_TASK_COMMAND_JSON', 'POST_DEPLOY_TASK_COMMAND_JSON']) {
+      // Once per selector, written to $GITHUB_ENV — and nowhere else.
+      const assignments = [...workflowSource.matchAll(new RegExp(`^\\s*echo '${variable}=`, 'gm'))];
+      expect(assignments).toHaveLength(2);
+      // The YAML-key spelling (`NAME: value`) is the one that binds an env var
+      // to a step unconditionally; the selectors use the shell spelling instead.
+      expect(workflowSource).not.toMatch(new RegExp(`^\\s*${variable}:`, 'm'));
+    }
+  });
+});
+
+describe('the deploy workflow can actually run its own gate', () => {
+  it('gives the Postgres-backed suite the same database quality.yml gives it', () => {
+    // 92 backend test files reach `src/test/postgres.ts`, whose `beforeAll`
+    // throws without this. Compared against quality.yml rather than restated:
+    // two hand-maintained copies of a service definition drift, and the drift
+    // shows up as a suite that passes in one workflow and fails in the other.
+    expect(workflow.jobs.test.services?.postgres).toEqual(quality.jobs.quality.services?.postgres);
+    expect(workflow.jobs.test.env?.TEST_DATABASE_URL).toBe(
+      quality.jobs.quality.env?.TEST_DATABASE_URL,
+    );
+    expect(workflow.jobs.test.env?.TEST_DATABASE_URL).toContain('postgres://');
+  });
+
+  it('migrates that database BEFORE running the suite against it', () => {
+    // `src/test/postgres.ts` opens the schema, it does not create it.
+    const steps = workflow.jobs.test.steps;
+    const migrateAt = steps.findIndex((step) => step.run?.includes('db:migrate'));
+    const suiteAt = steps.findIndex((step) => step.run?.includes('cd packages/backend && bun run test'));
+    expect(migrateAt).toBeGreaterThanOrEqual(0);
+    expect(suiteAt).toBeGreaterThanOrEqual(0);
+    expect(migrateAt).toBeLessThan(suiteAt);
+  });
+
+  it('runs the suite on the same architecture quality.yml runs it on', () => {
+    // The two jobs are compared field-by-field above, which is only worth
+    // anything if they run the same way. This is NOT a claim that the ARM label
+    // is broken — it is not; see the note on `deploy`'s `runs-on`.
+    expect(workflow.jobs.test['runs-on']).toBe(quality.jobs.quality['runs-on']);
+  });
+
+  it('builds the arm64 image on an arm64 host, without an emulator', () => {
+    // Emulated arm64 is much slower, and the outage that motivated moving this
+    // job to x86 + QEMU had a different cause (a workflow-approval block, which
+    // no runner label affects). If a future change genuinely needs emulation it
+    // has to remove this assertion deliberately rather than drift into it.
+    expect(workflow.jobs.deploy['runs-on']).toContain('arm');
+    const qemu = workflow.jobs.deploy.steps.find((step) =>
+      step.uses?.startsWith('docker/setup-qemu-action@'),
+    );
+    expect(qemu, 'a native arm64 host does not need the QEMU emulator').toBeUndefined();
+  });
+});


### PR DESCRIPTION
The Postgres cutover cannot be dispatched from `deploy-aws.yml` as it stands. Two blockers are real and fixed here. A third — the one everyone believes — turned out to be false, and disproving it is the most important thing in this PR.

## 1. The test job runs the Postgres-backed suite with no Postgres

92 backend test files reach `src/test/postgres.ts`, whose `beforeAll` throws `TEST_DATABASE_URL (or DATABASE_URL) must point at a migrated Postgres.` The job had no service container, no `TEST_DATABASE_URL` and no migrate step, so every deploy would die in its first job on a missing environment variable rather than a bad assertion.

The wiring is `quality.yml`'s, not a second interpretation of it: the same `postgres:17` (Syra's `REQUIRED_EXTENSIONS` is deliberately empty — no PostGIS, no `2dsphere`, nothing to install), the same URL, and the same `db:migrate --phase=all --target-database=syra_ci` before the suite, because `src/test/postgres.ts` opens the schema rather than creating it.

## 2. `migration_phase` did not exist, though the workflow's own comment already told operators to dispatch with it

`drizzle/` interleaves the phases — 15 `pre`, 10 `post`, with 0003 (`pre`) behind 0001 (`post`) — so against the empty production ledger both phased runs BLOCK by design and only `all` can perform the genesis apply.

Verified against a real `postgres:17` container rather than taken from the comment:

| run | result |
|---|---|
| `--phase=pre` | refuses: `0003_young_silver_fox is a pre-deploy migration queued behind the post-deploy migration 0001_yielding_black_queen` |
| `--phase=post` | refuses, naming all fifteen still-pending `pre` migrations |
| `--phase=all` | applies 25 migrations, 73 tables |

The input defaults to `pre-post`, so an ordinary release is untouched.

## 3. ⚠️ The runner label is NOT why deploys stopped running — and no code change fixes it

Every run of this workflow completing as `action_required` with zero jobs has been attributed to the `ubuntu-24.04-arm` partner-runner label. **That is wrong.** GitHub's run page states the actual reason:

> GitHub detected that this workflow file may be malicious. It will not run until someone with write access approves it.

Two measurements settle it:

- A dispatch of this workflow with **both jobs on `ubuntu-latest`** was blocked identically — [run 31278743099](https://github.com/OxyHQ/Syra/actions/runs/31278743099), `action_required`, zero jobs.
- Mercaria's first green deploy ([run 31275312983](https://github.com/OxyHQ/Mercaria/actions/runs/31275312983)) was **created at 19:47:43Z and started at 20:05:05Z** — the gap of a run waiting to be approved — and it ran its deploy job **on that same ARM label**, three minutes *before* the commit that moved it to QEMU. Mercaria recovered because someone approved the runs, not because of the runner change.

So this PR does **not** move the deploy job off ARM: it keeps building arm64 natively (QEMU emulation would only make it slower), and the disproof is written into the workflow so it is not re-derived. Only the `test` job moves to x86, to match the `quality.yml` job whose Postgres service it now mirrors.

**This means merging this PR is not sufficient to unblock the cutover.** Someone with write access has to approve the flagged workflow run in the GitHub UI. The likely trigger for the flag is the pre-existing `SECRETS_JSON: ${{ toJSON(secrets) }}` secrets-sync step, which reads as secret exfiltration to automated detection; that step is unchanged here.

## How the exclusivity is pinned

Syra runs its one-shot tasks through `deploy-ecs-image.sh`, which takes them as two environment variables rather than as separate steps. So the choice is made by two selector steps carrying complementary `if:` conditions that write one pair or the other into `$GITHUB_ENV`. `all` and `post` cannot co-occur because no run can execute both selectors. The load-bearing ordering inside the script — the pre-task failing before `update-service` is ever called — is untouched.

`packages/backend/src/db/__tests__/deployWorkflow.test.ts` pins it, and needs two assertions rather than one: that the conditions really are complements, AND that the selectors are the only place those variables are set — a value hardcoded on the deploy step's `env:` is immune to every `if:` in the file and would ride along with the cutover, which is the shape this workflow had before. It also compares the Postgres service against `quality.yml`'s parsed value instead of restating it, so the two copies cannot drift into a suite that passes in one workflow and fails in the other.

## The second commit: an existing gate caught this, and had to follow the values

`test-deploy-ecs-image.sh` does not restate the production migration commands — it READS them out of `deploy-aws.yml` and drives the real script with them (which is what once caught `dist/scripts/migrate.js`, a path this package has never emitted, wired in with every test green). Moving those values into `$GITHUB_ENV` writes made its `^VARIABLE:` pattern match nothing, and it failed loudly ([run 31278123899](https://github.com/OxyHQ/Syra/actions/runs/31278123899)). That is the gate working; it now reads them by PHASE rather than position, so the same name legitimately appearing twice does not weaken its "declared exactly once" check.

Two things are newly covered rather than merely relocated: the cutover's own `--phase=all` argv is held to the same entry-point and `--target-database` checks as the phased pair, and the cutover's empty post command is asserted here too, since the meaning of an empty value is defined by that script.

## Gates

- **21 mutations**, each producing a red naming the right invariant — 16 against the workflow test (same-condition selectors, a hardcoded post command, a post task on the cutover path, an invalid `--phase` spelling, a flipped input default, a drifted Postgres image, a drifted URL, the suite reordered ahead of the migrate step, the test job moved off quality.yml's runner, the deploy job moved to x86, the QEMU step reintroduced) and 5 against the script gate (cutover retagged to `pre`, cleared post command replaced, cutover argv pointed at a missing source, `--target-database` stripped, `pre` selector removed).
- Full backend suite against a real migrated `postgres:17`: **1803 pass, 9 skip, 0 fail** across 135 files.
- `bash .github/scripts/test-deploy-ecs-image.sh`: passes.
- `actionlint` 1.7.7: clean, and clean on the base revision too (no regression).
- `bun run typecheck` (packages/backend): exit 0.

Note that `deploy-aws.yml` has no `pull_request` trigger, so this PR's own CI does not exercise the workflow it changes — the local runs above and the pinning tests are the pre-merge evidence.

## After merge

A maintainer approves the flagged run, then the cutover is `workflow_dispatch` on `main` with `migration_phase: all`. Every deploy after it takes the default and finds nothing pending.
