### PR TITLE
ci(deploy): sync an explicit secret allowlist — toJSON(secrets) held every run

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -168,14 +168,69 @@ jobs:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}
 
+      # An EXPLICIT allowlist — never `toJSON(secrets)`.
+      #
+      # This step used to enumerate every secret the repo can see and pipe the
+      # lot through `jq` into `aws ssm put-parameter`. That shape is
+      # indistinguishable from a secret-exfiltration payload, and it is what
+      # GitHub's malicious-workflow detection was matching — the block recorded
+      # on `deploy`'s `runs-on` below, where every run was created as
+      # `action_required` with ZERO jobs until a human pressed "Approve and run".
+      # Measured across the org on 2026-08-08: the three repos whose deploy
+      # workflow contained `toJSON(secrets)` (Syra, Mercaria, Homiio) were all
+      # held, and the two without it (Mention, OxyHQServices) deployed unheld.
+      # The gate re-fires whenever the workflow file changes, which is what made
+      # it look like a runner-label problem in the first place.
+      #
+      # So the allowlist is not tidiness: it is the property that keeps
+      # automated deploys running at all. `src/db/__tests__/deployWorkflow.test.ts`
+      # fails if `toJSON(secrets)` comes back.
+      #
+      # The SYNC_ prefix is load-bearing for a second, unrelated reason, and this
+      # repo is where it actually bites: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      # are real secrets here, and the OIDC step above exports those same two
+      # names into the job environment. Binding them under their raw names would
+      # shadow the assumed role and fail this step with
+      # UnrecognizedClientException. The old loop never bound a secret to an env
+      # var at all — values moved through `jq` into the loop variables — which is
+      # how it sidestepped that; an allowlist has to avoid it deliberately. Same
+      # reason oxy-api's sync step carries the prefix.
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
         env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
+          SYNC_ACOUSTID_API_KEY: ${{ secrets.ACOUSTID_API_KEY }}
+          SYNC_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SYNC_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SYNC_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SYNC_JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          SYNC_MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          SYNC_REDIS_URL: ${{ secrets.REDIS_URL }}
+          SYNC_STREAM_TOKEN_SECRET: ${{ secrets.STREAM_TOKEN_SECRET }}
         run: |
-          SHARED="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET"
-          echo "$SECRETS_JSON" | jq -r 'to_entries[] | select((.key|ascii_upcase) as $k | ($k=="GITHUB_TOKEN" or ($k|startswith("ACTIONS_")))|not) | [.key,.value]|@tsv' | \
-          while IFS=$'\t' read -r k v; do
-            [ -z "$k" ] && continue
+          # Derived from the LIVE task definition (oxy-syra:8, the revision
+          # service `syra` runs), not from a plan: these are the parameters the
+          # container actually reads as `secrets`.
+          SHARED_SECRETS="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL"
+          # DATABASE_URL is NOT in that task definition yet, and must be here
+          # anyway: the deploy step below names
+          # /oxy/syra/DATABASE_URL in TASK_SECRET_OVERRIDES_JSON, so every
+          # revision this workflow registers reads it — and a task launched from
+          # a revision naming a parameter that does not exist dies with
+          # `ResourceInitializationError: unable to pull secrets or registry
+          # auth`. This step is what puts it there, on the same run, before that
+          # step. Dropping it from this list breaks the Mongo->Postgres cutover.
+          APP_SECRETS="ACOUSTID_API_KEY DATABASE_URL JWT_SECRET MONGODB_URI STREAM_TOKEN_SECRET"
+
+          # LIVEKIT_API_KEY and LIVEKIT_API_SECRET are deliberately absent,
+          # though oxy-syra:8 reads both from /oxy/_shared/. Syra CONSUMES those
+          # two; it does not own them — OxyHQServices holds them as secrets and
+          # is what writes them. This repo holds neither, so leaving them out
+          # stops nothing that was being synced, and a value added here later
+          # would otherwise overwrite the shared credential oxy-api reads.
+          for k in $SHARED_SECRETS $APP_SECRETS; do
+            v=$(printenv "SYNC_$k" || true)
+            # A secret left empty, or set to a single dash, is a mistake — not an
+            # instruction to overwrite production with garbage. Skipping the sync
+            # preserves whatever SSM already holds.
             if [ -z "$v" ] || [ "$v" = "-" ]; then
               echo "::warning::skip empty/placeholder secret $k; SSM unchanged"
               continue
@@ -184,7 +239,7 @@ jobs:
               echo "::warning::skip REDIS_URL because it does not point at the us-west-2 Valkey endpoint; SSM unchanged"
               continue
             fi
-            case " $SHARED " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
+            case " $SHARED_SECRETS " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
             aws ssm put-parameter --name "$path" --value "$v" --type SecureString --overwrite >/dev/null && echo "synced -> $path"
           done
 
@@ -304,9 +359,14 @@ jobs:
           # revision naming it, or the task dies with
           # `ResourceInitializationError: unable to pull secrets or registry
           # auth`. The sync step above writes it from the GitHub repo secret on
-          # this same run, before this step — Syra's sync loop enumerates
-          # nothing, it walks `toJSON(secrets)`, so a new repo secret needs no
-          # workflow edit to reach SSM. There is no allowlist to forget here.
+          # this same run, before this step — but ONLY because DATABASE_URL is on
+          # that step's allowlist. It is an allowlist you CAN forget: adding a
+          # repo secret no longer reaches SSM by itself, and adding one here
+          # without adding it there registers a revision naming a parameter that
+          # does not exist, which fails at task launch rather than at deploy.
+          # The sync step used to walk `toJSON(secrets)` instead, which needed no
+          # workflow edit — and which is exactly what got every run of this
+          # workflow held for approval. See the note on that step.
           TASK_SECRET_OVERRIDES_JSON: '{"DATABASE_URL":"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/syra/DATABASE_URL"}'
 
           # PRE_DEPLOY_TASK_COMMAND_JSON / POST_DEPLOY_TASK_COMMAND_JSON are NOT

--- a/packages/backend/src/db/__tests__/deployWorkflow.test.ts
+++ b/packages/backend/src/db/__tests__/deployWorkflow.test.ts
@@ -57,7 +57,14 @@ interface WorkflowFile {
       'runs-on': string;
       env?: Record<string, string>;
       services?: Record<string, unknown>;
-      steps: { name?: string; if?: string; run?: string; uses?: string; with?: Record<string, string> }[];
+      steps: {
+        name?: string;
+        if?: string;
+        run?: string;
+        uses?: string;
+        with?: Record<string, string>;
+        env?: Record<string, string>;
+      }[];
     }
   >;
 }
@@ -200,5 +207,155 @@ describe('the deploy workflow can actually run its own gate', () => {
       step.uses?.startsWith('docker/setup-qemu-action@'),
     );
     expect(qemu, 'a native arm64 host does not need the QEMU emulator').toBeUndefined();
+  });
+});
+
+/**
+ * The SSM sync step names the secrets it copies, and that is what keeps deploys
+ * automated.
+ *
+ * A step that walks `${{ toJSON(secrets) }}` and pipes the lot into
+ * `aws ssm put-parameter` is structurally a secret-exfiltration payload, and
+ * GitHub's malicious-workflow detection treats it as one. That is the
+ * approval block recorded on `deploy`'s `runs-on` above: every run created as
+ * `action_required` with ZERO jobs until a human pressed "Approve and run".
+ * Measured across the org on 2026-08-08 — three repos with the pattern all held,
+ * two without it deployed unheld. Nothing in a normal CI run reports this,
+ * because the runs never start; it presents as an outage, not a workflow defect,
+ * and it already sent one investigation after the runner label instead.
+ *
+ * The assertions are deliberately paired. Checking only for the absence of
+ * `toJSON(secrets)` would pass on a step that synced nothing at all, and checking
+ * only that the names are present would pass on a step that ALSO enumerated
+ * everything. And the two spellings of the allowlist — the `env:` bindings and
+ * the shell word lists — are cross-checked against each other rather than each
+ * against a literal, because the drift that actually happens is adding one and
+ * forgetting the other: a name in `env:` but not in the loop is never synced,
+ * and a name in the loop but not in `env:` reads as empty and is skipped with a
+ * warning nobody sees until the deploy that needed it.
+ */
+describe('the deploy workflow syncs an explicit allowlist, never the whole context', () => {
+  /**
+   * Every parameter the LIVE task definition (oxy-syra:8) reads as a `secret`,
+   * plus DATABASE_URL — which that revision does NOT carry, and which the deploy
+   * step injects into every revision it registers. Minus LIVEKIT_API_KEY /
+   * LIVEKIT_API_SECRET: those live under /oxy/_shared/, this repo holds neither,
+   * and OxyHQServices is what writes them.
+   */
+  const EXPECTED_ALLOWLIST = [
+    'ACOUSTID_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'DATABASE_URL',
+    'JWT_SECRET',
+    'MONGODB_URI',
+    'REDIS_URL',
+    'STREAM_TOKEN_SECRET',
+  ];
+
+  const syncStep = workflow.jobs.deploy.steps.find((step) =>
+    step.name?.startsWith('Sync GitHub secrets'),
+  );
+
+  const boundNames = (): string[] =>
+    Object.keys(syncStep?.env ?? {})
+      .map((key) => key.replace(/^SYNC_/, ''))
+      .sort();
+
+  /** The words of a `NAME="a b c"` assignment in the step's shell body. */
+  const shellList = (variable: string): string[] => {
+    const match = new RegExp(`^\\s*${variable}="([^"]*)"`, 'm').exec(syncStep?.run ?? '');
+    expect(match, `the step no longer assigns ${variable}`).not.toBeNull();
+    return (match?.[1] ?? '').split(/\s+/).filter(Boolean);
+  };
+
+  it('has a sync step at all', () => {
+    // Vacuity floor for every assertion below: they all read this step, and an
+    // `undefined` step would make the `?.` chains silently trivially true.
+    expect(syncStep, 'the secret sync step is gone').toBeDefined();
+    expect(syncStep?.env, 'the sync step binds no secrets').toBeDefined();
+    expect(EXPECTED_ALLOWLIST.length).toBeGreaterThan(4);
+  });
+
+  it('never enumerates the whole secrets context', () => {
+    // Matched as an EXPRESSION, not as text: the step's own comment explains the
+    // block by name, so a bare substring check would fail on the explanation
+    // rather than on the payload.
+    expect(workflowSource).not.toMatch(/\$\{\{[^}]*toJSON\s*\(\s*secrets\s*\)/);
+  });
+
+  it('binds each allowlisted secret under a SYNC_ prefix, and nothing else', () => {
+    // The prefix is not cosmetic, and this repo is where it bites:
+    // AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are real secrets here, and
+    // `aws-actions/configure-aws-credentials` exports those same two names into
+    // the job environment. Bound raw, they shadow the assumed OIDC role and fail
+    // the step with UnrecognizedClientException.
+    const env = syncStep?.env ?? {};
+    for (const [key, value] of Object.entries(env)) {
+      expect(key).toMatch(/^SYNC_/);
+      expect(value).toBe(`\${{ secrets.${key.replace(/^SYNC_/, '')} }}`);
+    }
+    expect(boundNames()).toEqual([...EXPECTED_ALLOWLIST].sort());
+  });
+
+  it('iterates exactly the secrets it binds', () => {
+    const iterated = [...shellList('SHARED_SECRETS'), ...shellList('APP_SECRETS')].sort();
+    expect(iterated).toEqual(boundNames());
+    expect(iterated).toEqual([...EXPECTED_ALLOWLIST].sort());
+  });
+
+  it('syncs every /oxy/syra/ parameter the deploy step injects into a revision', () => {
+    // The load-bearing one, and the reason it is derived rather than pinned:
+    // TASK_SECRET_OVERRIDES_JSON names parameters that every registered revision
+    // reads, and a revision naming a parameter that does not exist does not fail
+    // the deploy — it fails at TASK LAUNCH, with
+    // `ResourceInitializationError: unable to pull secrets or registry auth`.
+    // This step is the only thing that creates them, so the two lists cannot be
+    // allowed to drift apart. Adding an override without adding it here is
+    // exactly the mistake this catches.
+    const deployStep = workflow.jobs.deploy.steps.find((step) =>
+      step.name?.startsWith('Register immutable task definition'),
+    );
+    expect(deployStep, 'the deploy step is gone').toBeDefined();
+    const overrides = JSON.parse(deployStep?.env?.TASK_SECRET_OVERRIDES_JSON ?? '{}') as Record<
+      string,
+      string
+    >;
+    const injected = Object.keys(overrides);
+    expect(injected.length, 'no overrides parsed — the assertion would be vacuous').toBeGreaterThan(
+      0,
+    );
+    for (const name of injected) {
+      expect(overrides[name]).toContain(`parameter/oxy/syra/${name}`);
+      expect(boundNames(), `${name} is injected but never synced to SSM`).toContain(name);
+      expect(shellList('APP_SECRETS')).toContain(name);
+    }
+  });
+
+  it('keeps the shared secrets on the shared path and the app secrets on the app path', () => {
+    // One field decides which SSM namespace a value lands in. A shared secret
+    // written to /oxy/syra/ is invisible to the task definition, which reads it
+    // from /oxy/_shared/ — so the sync reports success and changes nothing the
+    // container sees.
+    expect(shellList('SHARED_SECRETS')).toEqual([
+      'AWS_ACCESS_KEY_ID',
+      'AWS_SECRET_ACCESS_KEY',
+      'REDIS_URL',
+    ]);
+    for (const shared of shellList('SHARED_SECRETS')) {
+      expect(shellList('APP_SECRETS')).not.toContain(shared);
+    }
+    expect(syncStep?.run).toContain('path="/oxy/_shared/$k"');
+    expect(syncStep?.run).toContain('path="/oxy/$APP/$k"');
+  });
+
+  it('still refuses placeholders and a non-us-west-2 REDIS_URL', () => {
+    // Both guards predate the allowlist and protect production from a secret
+    // that was never really set: skipping leaves the previous SSM value alone,
+    // where syncing would overwrite it with an empty string or a dash.
+    expect(syncStep?.run).toContain('[ "$v" = "-" ]');
+    // The escaped spelling, because the guard is a `grep` regex — asserting the
+    // bare hostname passes on a workflow whose dots are unescaped wildcards.
+    expect(syncStep?.run).toContain(String.raw`'\.usw2\.cache\.amazonaws\.com'`);
   });
 });


### PR DESCRIPTION
## Why

The secret-sync step enumerated **every** secret the repo can see and piped the lot through `jq` into `aws ssm put-parameter`. That is structurally identical to a secret-exfiltration payload, and GitHub's malicious-workflow detection matches it.

This is the approval block already recorded in the note on `deploy`'s `runs-on`: every run created as `action_required` with **zero jobs** until a human pressed "Approve and run". That note correctly ruled out the ARM runner label — **this is what was actually causing it.**

Evidence, measured 2026-08-08:

| Repo | `toJSON(secrets)` in `deploy-aws.yml` | Deploy runs |
|---|---|---|
| Syra | yes | held since its Postgres merge |
| Mercaria | yes | held all day |
| Homiio | yes | `action_required` on 2026-07-30 |
| Mention | no | green, unheld (20:12Z) |
| OxyHQServices | no | green, unheld (20:59Z) |

3/3 with the pattern held, 0/2 without. The gate re-fires whenever the workflow file changes, which is part of what made it look like a runner-label problem.

## The allowlist, and where each name came from

Ground truth is the **live** task definition — `oxy-syra:8`, not `:7`; service `syra` has moved on, though the two carry identical secrets. Cross-checked against what `packages/backend` reads from `process.env`.

| Secret | SSM path | Provenance |
|---|---|---|
| `AWS_ACCESS_KEY_ID` | `/oxy/_shared/` | task def `oxy-syra:8`; repo secret exists |
| `AWS_SECRET_ACCESS_KEY` | `/oxy/_shared/` | task def `oxy-syra:8`; repo secret exists |
| `REDIS_URL` | `/oxy/_shared/` | task def `oxy-syra:8`; repo secret exists |
| `ACOUSTID_API_KEY` | `/oxy/syra/` | task def `oxy-syra:8`; repo secret exists |
| `JWT_SECRET` | `/oxy/syra/` | task def `oxy-syra:8`; repo secret exists |
| `MONGODB_URI` | `/oxy/syra/` | task def `oxy-syra:8`; repo secret exists |
| `STREAM_TOKEN_SECRET` | `/oxy/syra/` | task def `oxy-syra:8`; repo secret exists |
| `DATABASE_URL` | `/oxy/syra/` | **not** in `oxy-syra:8` — see below; repo secret exists |

That is every one of this repo's eight secrets, so **nothing that was actually being synced stops being synced.**

### `DATABASE_URL` is the one that must not be dropped

It is not in `oxy-syra:8`, and it still has to be on the allowlist. The deploy step names `/oxy/syra/DATABASE_URL` in `TASK_SECRET_OVERRIDES_JSON`, so every revision this workflow registers reads it — and a revision naming a parameter that does not exist does not fail the deploy, it fails at **task launch** with `ResourceInitializationError: unable to pull secrets or registry auth`. This step is the only thing that creates it. Dropping it would break the Mongo→Postgres cutover.

Rather than pin that by hand, the test **derives** it: every `/oxy/syra/` parameter named in `TASK_SECRET_OVERRIDES_JSON` must appear on the allowlist. Adding an override without adding it here now fails CI.

### Deliberately excluded

**`LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET`** — in `oxy-syra:8`, read from `/oxy/_shared/`. Syra *consumes* them; it does not own them. Neither is a repo or org secret here, so the old loop never synced them either — OxyHQServices holds and writes them. Leaving them out also closes a hazard the mass sync had by accident: a value added here later would silently overwrite the shared credential oxy-api reads.

**Org secrets that stop being copied into `/oxy/syra/`:** `ADD_TO_PROJECT_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `NPM_TOKEN`. This repo is public, so org secrets reach it and the old loop wrote all four into the app's SSM namespace. None is in the task definition; nothing reads them from SSM. Their existing parameters are left untouched (this step simply stops writing them) — deleting them is out of scope for this PR.

## The second occurrence

`toJSON(secrets)` appeared twice. The other was the comment on `TASK_SECRET_OVERRIDES_JSON` claiming *"Syra's sync loop enumerates nothing… There is no allowlist to forget here."* That is now false, and dangerously so — it tells the next reader that a new repo secret reaches SSM by itself. Rewritten to say there **is** an allowlist, and what forgetting it costs.

## Preserved behaviours

`/oxy/_shared/*` vs `/oxy/<app>/*` path split, the empty/`-` placeholder guard, and the `REDIS_URL` us-west-2 endpoint check are all unchanged.

## The `SYNC_` prefix is load-bearing, and this repo is where it bites

`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are **real secrets here**, and `aws-actions/configure-aws-credentials` exports those same two names into the job environment. Bound raw, they shadow the assumed OIDC role and fail the step with `UnrecognizedClientException`. The old `jq` loop moved values through shell loop variables and never bound a secret to an env var at all, so it sidestepped this by accident — a naive allowlist conversion here would have broken the deploy outright. Same shape as oxy-api's sync step.

## Gates

- `packages/backend/src/db/__tests__/deployWorkflow.test.ts` extended — **17 passed, 87 assertions**
- `cd packages/backend && bun run test` — **1816 passed, 9 skipped, 0 failed** across 136 files (real `postgres:17`, migrated `--phase=all`)
- `cd packages/backend && bun run typecheck` — clean
- YAML parses; the step's shell body passes `bash -n`

### Mutation-tested, not just green

Each assertion was verified to fail when the thing it guards is broken, then both files restored from pristine copies (not `git checkout`, which would have reverted the uncommitted work under test) and re-verified byte-identical:

| Mutation | Caught by |
|---|---|
| reintroduce `${{ toJSON(secrets) }}` | `never enumerates the whole secrets context` (+2 more) |
| bind `AWS_ACCESS_KEY_ID` raw (the OIDC-shadowing bug) | `binds each allowlisted secret under a SYNC_ prefix` |
| move the AWS keys to the app path | `keeps the shared secrets on the shared path…` |
| drop `DATABASE_URL` from env + shell + expected list | `syncs every /oxy/syra/ parameter the deploy step injects` — **and only that test**, confirming the cross-check does the work rather than the pinned list |

The `toJSON(secrets)` check matches an **expression**, not the text, because the step's own comment names the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)