### PR TITLE
test(deploy): the allowlist pin drops MONGODB_URI too

### DIFF
--- a/packages/backend/src/db/__tests__/deployWorkflow.test.ts
+++ b/packages/backend/src/db/__tests__/deployWorkflow.test.ts
@@ -248,7 +248,6 @@ describe('the deploy workflow syncs an explicit allowlist, never the whole conte
     'AWS_SECRET_ACCESS_KEY',
     'DATABASE_URL',
     'JWT_SECRET',
-    'MONGODB_URI',
     'REDIS_URL',
     'STREAM_TOKEN_SECRET',
   ];


### PR DESCRIPTION
Fixes main, red since #92 (8309d56): that PR removed `MONGODB_URI` from `deploy-aws.yml` but left it in `EXPECTED_ALLOWLIST`, so `deployWorkflow.test.ts` fails two assertions with clean `toEqual` diffs (not the known 40P01 deadlock flake). One line.

The gate worked as designed: it cross-checks the `env:` bindings against the shell word list *and* against this literal — and the literal is the leg a workflow-only change forgets. My merge of #92 is what let it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)