### PR TITLE
docs(test): six comments promise gates that were deleted

### DIFF
--- a/packages/backend/src/controllers/artists.imageSuggestions.test.ts
+++ b/packages/backend/src/controllers/artists.imageSuggestions.test.ts
@@ -66,9 +66,12 @@ import {
  * to open one. The guard was the whole dependency.
  *
  * Task 15 switched that gate to `isPostgresConnected()`, and the Mongo hooks
- * went with it. `db/__tests__/connectivityGates.test.ts` is what keeps this
- * true: it walks this controller's whole import graph and fails if anything it
- * reaches opens a model again.
+ * went with it. `db/__tests__/connectivityGates.test.ts` used to keep this true
+ * by walking this controller's whole import graph and failing if anything it
+ * reached opened a model; it was retired in 8cd87a8 together with its subject.
+ * Nothing polices it now because nothing can violate it — `mongoose` is not a
+ * dependency and `src/models/` does not exist, so reintroducing a model is a
+ * package install and a new directory, not a silent import.
  */
 beforeAll(async () => {
   await connectDb();

--- a/packages/backend/src/controllers/entityProfile.artistSections.test.ts
+++ b/packages/backend/src/controllers/entityProfile.artistSections.test.ts
@@ -37,9 +37,12 @@ import { getEntityProfile } from './entityProfile.controller';
  * to open one. The guard was the whole dependency.
  *
  * Task 15 switched that gate to `isPostgresConnected()`, and the Mongo hooks
- * went with it. `db/__tests__/connectivityGates.test.ts` is what keeps this
- * true: it walks this controller's whole import graph and fails if anything it
- * reaches opens a model again.
+ * went with it. `db/__tests__/connectivityGates.test.ts` used to keep this true
+ * by walking this controller's whole import graph and failing if anything it
+ * reached opened a model; it was retired in 8cd87a8 together with its subject.
+ * Nothing polices it now because nothing can violate it — `mongoose` is not a
+ * dependency and `src/models/` does not exist, so reintroducing a model is a
+ * package install and a new directory, not a silent import.
  */
 beforeAll(async () => {
   await connectDb();

--- a/packages/backend/src/controllers/entityProfile.controller.test.ts
+++ b/packages/backend/src/controllers/entityProfile.controller.test.ts
@@ -19,9 +19,12 @@ import type { EntityProfile } from '@syra/shared-types';
  * to open one. The guard was the whole dependency.
  *
  * Task 15 switched that gate to `isPostgresConnected()`, and the Mongo hooks
- * went with it. `db/__tests__/connectivityGates.test.ts` is what keeps this
- * true: it walks this controller's whole import graph and fails if anything it
- * reaches opens a model again.
+ * went with it. `db/__tests__/connectivityGates.test.ts` used to keep this true
+ * by walking this controller's whole import graph and failing if anything it
+ * reached opened a model; it was retired in 8cd87a8 together with its subject.
+ * Nothing polices it now because nothing can violate it — `mongoose` is not a
+ * dependency and `src/models/` does not exist, so reintroducing a model is a
+ * package install and a new directory, not a silent import.
  */
 beforeAll(async () => {
   await connectDb();

--- a/packages/backend/src/controllers/serverOnlyFields.leak.test.ts
+++ b/packages/backend/src/controllers/serverOnlyFields.leak.test.ts
@@ -68,9 +68,12 @@ import { getArtistById, getMyContributions, getMyImageSuggestions } from './arti
  * to open one. The guard was the whole dependency.
  *
  * Task 15 switched that gate to `isPostgresConnected()`, and the Mongo hooks
- * went with it. `db/__tests__/connectivityGates.test.ts` is what keeps this
- * true: it walks this controller's whole import graph and fails if anything it
- * reaches opens a model again.
+ * went with it. `db/__tests__/connectivityGates.test.ts` used to keep this true
+ * by walking this controller's whole import graph and failing if anything it
+ * reached opened a model; it was retired in 8cd87a8 together with its subject.
+ * Nothing polices it now because nothing can violate it — `mongoose` is not a
+ * dependency and `src/models/` does not exist, so reintroducing a model is a
+ * package install and a new directory, not a silent import.
  */
 beforeAll(async () => {
   await connectDb();

--- a/packages/backend/src/db/__tests__/deployWorkflow.test.ts
+++ b/packages/backend/src/db/__tests__/deployWorkflow.test.ts
@@ -236,11 +236,22 @@ describe('the deploy workflow can actually run its own gate', () => {
  */
 describe('the deploy workflow syncs an explicit allowlist, never the whole context', () => {
   /**
-   * Every parameter the LIVE task definition (oxy-syra:8) reads as a `secret`,
-   * plus DATABASE_URL — which that revision does NOT carry, and which the deploy
-   * step injects into every revision it registers. Minus LIVEKIT_API_KEY /
-   * LIVEKIT_API_SECRET: those live under /oxy/_shared/, this repo holds neither,
-   * and OxyHQServices is what writes them.
+   * Every parameter the live task definition reads as a `secret`. Minus
+   * LIVEKIT_API_KEY / LIVEKIT_API_SECRET: those live under /oxy/_shared/, this
+   * repo holds neither, and OxyHQServices is what writes them.
+   *
+   * `MONGODB_URI` left in #92, with the Mongo it named. `DATABASE_URL` took its
+   * place as the database secret — it was already listed here before it reached
+   * a task definition, because the deploy step injects it into every revision it
+   * registers.
+   *
+   * This list is the THIRD leg of the cross-check, and worth knowing about as
+   * such: the two spellings in the workflow (the `env:` bindings and the shell
+   * word lists) are compared against each OTHER, which catches the drift that
+   * usually happens — adding one and forgetting the other. It does not catch
+   * removing a secret from both and forgetting this literal, which is exactly
+   * what #92 did: the workflow was correct, this list was stale, and `main` went
+   * red on these two assertions.
    */
   const EXPECTED_ALLOWLIST = [
     'ACOUSTID_API_KEY',
@@ -248,7 +259,6 @@ describe('the deploy workflow syncs an explicit allowlist, never the whole conte
     'AWS_SECRET_ACCESS_KEY',
     'DATABASE_URL',
     'JWT_SECRET',
-    'MONGODB_URI',
     'REDIS_URL',
     'STREAM_TOKEN_SECRET',
   ];

--- a/packages/backend/src/db/expiry.ts
+++ b/packages/backend/src/db/expiry.ts
@@ -18,35 +18,56 @@
  * never in this code to be missed: there is no deleted call site, no orphaned
  * function, nothing a reviewer diffing the port would see go absent.
  *
- * So porting a collection is not done when its schema and migration exist. If
- * its Mongoose model declares `expireAfterSeconds`, it is done only once a
- * matching entry exists here.
+ * So porting a collection was not done when its schema and migration existed:
+ * if its Mongoose model declared `expireAfterSeconds`, it was done only once a
+ * matching entry existed here. All four such models have been ported, and the
+ * rule generalises past its origin — a table that needs rows to stop existing
+ * needs an entry here, whatever made it need one.
  *
- * THAT IS GATED, and no longer by a hand grep. `__tests__/gates.test.ts`
- * ("accounts for every Mongoose TTL index") WALKS `src/models/*.ts` for
- * `<Model>Schema.index({ field: 1 }, { … expireAfterSeconds … })` and compares
- * what it finds against a model→port map, then compares the covered half of
- * that map against the targets below. A vertical that ports a TTL-bearing
- * model without adding an entry here fails there, naming the model. Only the
- * model→column correspondence is hand-maintained — a human has to say which
- * Postgres column a Mongo field became — while the SET of declarations comes
- * from the files, which is the half that used to be a grep in somebody's
- * report.
+ * ## WHAT IS AND IS NOT GATED — read this before adding a table
  *
- * The map holds FOUR entries and only TWO are still declared in `src/models/`,
- * because a ported model's file is deleted: Task 15 removed
- * `ListeningEvent.ts` and `NotificationSuppression.ts`. The gate derives which
- * side an entry belongs on from whether its model file still EXISTS rather
- * than from a hand-kept flag, so the migration succeeding cannot be mistaken
- * for a TTL deleted by accident — and a declaration surviving a model the map
- * calls deleted fails too. `ModerationOutbox`/`ModerationEvent` are the two
- * still declared, mapped to a deferred sentinel that is deliberately NOT
- * counted as covered.
+ * A gate in `__tests__/gates.test.ts` ("accounts for every Mongoose TTL index")
+ * used to WALK `src/models/*.ts` for
+ * `<Model>Schema.index({ field: 1 }, { … expireAfterSeconds … })` and fail a
+ * vertical that ported a TTL-bearing model without adding an entry here — so the
+ * SET of declarations came from the files rather than from a grep in somebody's
+ * report. It was deleted in 8cd87a8 on its own instruction ("the next time this
+ * number moves is when Task 8 deletes those models, and at that point the right
+ * change is to DELETE this gate with them rather than lower the floor to zero").
+ * It cannot read a declaration that exists in no file.
  *
- * The gate reads one spelling of a TTL declaration — the only one this repo
- * uses, not the only one Mongoose accepts. See its own comment for the four
- * shapes it would miss and why a miss is SILENT; adding a target in an
- * unusual shape means checking that comment first.
+ * What still holds the registry, all of it against Postgres rather than against
+ * Mongoose, so none of it went with the models:
+ *
+ *  - `__tests__/gates.test.ts`, "registers every Mongo TTL index that was
+ *    ported, with its own retention" — the exact, ORDERED list of
+ *    `table.column:retentionSeconds`, not a count. A target pointed at the wrong
+ *    column or carrying the wrong retention is caught; both are mistakes that
+ *    leave rows either immortal or deleted early, and neither moves a length.
+ *  - `findUnsupportedExpiryColumns` (`@oxyhq/db/assert`), driven against a REAL
+ *    migrated database, so a target added without a supporting index fails
+ *    rather than silently costing a full scan every tick.
+ *  - `db/user/__tests__/user.explain.test.ts` — an EXPLAIN probe per target on
+ *    the sweep's own statement (an index can exist and still not be usable),
+ *    plus a length parity check against its own index map.
+ *  - `gates.test.ts`'s "keeps user_uploads.expires_at OUT of the blind expiry
+ *    sweep", the negative direction.
+ *
+ * **What nothing gates: that a NEW table which ought to be swept gets an entry.**
+ * The deleted walk never covered that either — it only ever caught a Mongoose
+ * model being ported without one — so nothing regressed when it went. But no
+ * check derives the required SET from anything now; the list below is what the
+ * assertions compare against, so a table that needs expiry and is simply never
+ * added here is invisible to all of them, which is precisely this file's own
+ * "grows FOREVER, with no symptom of any kind until disk".
+ *
+ * That gap is deliberately NOT closed with a scanner over expiry-shaped columns,
+ * and `user_uploads.expires_at` is why: it is exactly that shape and must NEVER
+ * be registered, because a blind row delete orphans the file's S3 objects and
+ * skips the T−14d warning the retention policy promises. Any such scanner has to
+ * carry an exemption list from its first commit, and an exemption list is the
+ * thing this repo has repeatedly found rots. Adding a table? Ask whether its rows
+ * must stop existing, and answer it here.
  *
  * `findUnsupportedExpiryColumns` (`@oxyhq/db/assert`) reads the real Postgres
  * catalogue against whatever lands here, so an entry added without its

--- a/packages/backend/src/db/schema/user.ts
+++ b/packages/backend/src/db/schema/user.ts
@@ -13,19 +13,21 @@
  * ## The two TTL indexes — and why they are the whole point of this file
  *
  * `db/expiry.ts`'s registry is the Postgres replacement for a Mongo TTL index,
- * and this vertical is where it stops being empty. Two of this repo's four
- * `expireAfterSeconds` declarations live here:
+ * and this vertical is where it stops being empty. Two of the repo's four
+ * `expireAfterSeconds` declarations were ported here:
  *
  *  - `NotificationSuppression.expiresAt`, `expireAfterSeconds: 0` — the column
  *    IS the deadline, so `retentionSeconds: 0`.
  *  - `ListeningEvent.playedAt`, `expireAfterSeconds: 90 days` — a retention
  *    window measured from a birth column.
  *
- * (The other two, `ModerationOutbox` and `ModerationEvent`, are Task 8's. The
- * brief's prose says this task lands three of four; `grep -rn
- * "expireAfterSeconds" packages/backend/src` returns four declarations total
- * and two of them are here, which is also what the brief's own table says.
- * Raised in this task's report.)
+ * (The other two, `ModerationOutbox` and `ModerationEvent`, were Task 8's. The
+ * brief's prose said this task lands three of four; the grep said four
+ * declarations total with two of them here, which is also what the brief's own
+ * table said. Raised in this task's report. That grep no longer reproduces —
+ * the Mongoose models it read are deleted, so `expireAfterSeconds` now survives
+ * only in prose like this; `db/expiry.ts` records what still checks the
+ * registry.)
  *
  * Each entry needs a supporting index or the sweep's `column <= now() - N`
  * predicate becomes a full table scan every time it runs — the exact cost the

--- a/packages/backend/src/utils/withDb.ts
+++ b/packages/backend/src/utils/withDb.ts
@@ -18,17 +18,21 @@ type AsyncHandler<R extends Request = Request> = (
  *
  * This wrapper's only consumer is `routes/playlists.routes.ts`, whose handlers
  * Task 11 moved to Postgres — verified transitively, not by grepping the routes
- * file: walking all 27 files it reaches finds no `models/` import, and
- * `db/__tests__/connectivityGates.test.ts` keeps checking that.
+ * file: walking all 27 files it reaches found no `models/` import.
+ * `db/__tests__/connectivityGates.test.ts` kept checking that until 8cd87a8
+ * retired it along with its subject; the property now holds by construction,
+ * since `mongoose` is not a dependency and `src/models/` does not exist.
  *
  * The gate it used to make was `isDatabaseConnected()`, which is
  * `mongoose.connection.readyState`.
  *
  * So the gate was asking about a database these routes do not use. That cost two
  * things, and the second is the one worth stating: Mongo down with Postgres up
- * answered 503 for playlist routes that would have worked, and once Mongo is
- * removed (Task 19) `readyState` never reaches 1 again — so **every playlist
- * route would 503 for everyone, permanently, with no error anywhere**.
+ * answered 503 for playlist routes that would have worked, and once Mongo was
+ * removed `readyState` could never reach 1 again — so **every playlist route
+ * would have 503'd for everyone, permanently, with no error anywhere**. That is
+ * no longer a live hazard; it is the reason this one-line change was worth a
+ * task of its own.
  *
  * This wrapper is Task 11's and the fix is a one-line change; Task 15 took it
  * because the sweep it was doing for its own two jobs is only meaningful if it


### PR DESCRIPTION
> **Status note, added after merge — `main` is GREEN.** This PR and #93 crossed:
> #93 landed the one-line `EXPECTED_ALLOWLIST` fix first, and this branch (cut
> before it) carried the identical deletion. Git resolved the duplicate cleanly,
> so **this PR's net effect on `deployWorkflow.test.ts` was comment-only** — the
> code hunk was a no-op against #93, which is the intended end state. Quality on
> `main` @ `702ad1a` is green. Section 1 below is kept as the historical account
> of a failure that was live when this was written; read it in the past tense.

Two unrelated things, and the first is why this is `fix` and not `docs`.

## 1. `main` is red, from #92 — this unblocks it

#92 removed `MONGODB_URI` from `deploy-aws.yml` but left it in
`EXPECTED_ALLOWLIST` in `src/db/__tests__/deployWorkflow.test.ts`. Two tests
fail:

```
(fail) ... > binds each allowlisted secret under a SYNC_ prefix, and nothing else
(fail) ... > iterates exactly the secrets it binds
        @@ -6,3 +6,3 @@
            "JWT_SECRET",
        -   "MONGODB_URI",
            "REDIS_URL",
```

`quality` failed on #92's own PR and again on `main` at `8309d569`; `2b6e0fa8`
(#91) was the last green commit. Reproduced locally on an untouched checkout:
**1819 pass / 2 fail**, real `toEqual` diffs — not the `40P01` deadlock flake,
which shows up as a `PostgresError` thrown mid-test rather than a clean
assertion diff.

Included here rather than split out because this branch inherits the failure and
cannot go green without it.

**Why the gate did not stop it**, which is worth recording because the gate is
well built: it cross-checks the workflow's two spellings — the `env:` bindings
and the shell word lists — against *each other* rather than against a literal,
which catches the drift that normally happens (adding one, forgetting the other).
`EXPECTED_ALLOWLIST` is a third, *literal* leg, and removing a secret from both
spellings while leaving the literal is the one shape that cross-check cannot see.
Now noted on the constant itself.

## 2. Six comments promise gates that were deleted

`8cd87a8` retired three gates, each on its own file's written instruction — that
commit was careful and I am not second-guessing it. What it did not do is sweep
the comments *pointing at* those gates from elsewhere:

| site | claim |
|---|---|
| `utils/withDb.ts` + 4 controller suites (one copy-pasted block) | `connectivityGates.test.ts` "is what keeps this true" |
| `db/expiry.ts` | the TTL registry "IS GATED" by a walk over `src/models/*.ts` |
| `db/schema/user.ts` (found while working) | cites a `grep -rn "expireAfterSeconds"` result that no longer reproduces — it now returns 14 hits across 3 files, every one of them prose |

I resolved each by asking what still covers the property, not by deleting the
sentence.

**The five connectivity sites** → the property is now closed **by construction**:
`mongoose` is not a dependency and `src/models/` does not exist, so reintroducing
a model is a package install plus a new directory, not a silent import. Stated in
place with the retirement named, so the next reader is not left wondering whether
a guard was dropped quietly.

**`expiry.ts`** got the fuller treatment, because its answer is *not* "all
covered". What survives is now listed explicitly — the exact **ordered**
`table.column:retentionSeconds` assertion, `findUnsupportedExpiryColumns` against
a real migrated database, the per-target `EXPLAIN` probes in
`user.explain.test.ts`, and the negative `keeps user_uploads.expires_at OUT`
gate. All of those check **Postgres**, which is why none of them went with the
models.

## A property with no guard — flagged, not silently fixed

**Nothing forces a NEW table that ought to be swept into the registry.** The
deleted walk never covered that either — it only caught a *Mongoose model ported
without an entry* — so nothing regressed when it went. But "THAT IS GATED"
overstated what exists, and this file's own subject is a failure with "no symptom
of any kind until disk", so the gap is now written down rather than implied away.

I did **not** close it with a scanner over expiry-shaped columns, and
`user_uploads.expires_at` is precisely why: it is exactly that shape and must
**never** be registered, because a blind row delete orphans the file's S3 objects
and skips the T−14d warning the retention policy promises. Any such scanner needs
an exemption list from its first commit — the shape this repo has repeatedly
found rots. That is a design decision worth a human, so it is flagged rather than
built.

## Gates

| gate | result |
|---|---|
| typecheck, all 5 packages | clean |
| lint (frontend + studio) | 0 errors (60 / 8 warnings, pre-existing) |
| schema/migration drift | no changes |
| deploy script tests | pass |
| backend suite vs real migrated `postgres:17` | **1821 pass, 9 skip, 0 fail** |

Baseline on untouched `8309d56` was **1819 pass / 2 fail**; the +2 here is exactly
the two this restores. No test was added or removed.

