### PR TITLE
ci: refuse to let MongoDB back into Syra by accident

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -62,6 +62,15 @@ jobs:
         with:
           bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
+
+      # Before the builds and typechecks, and needing neither: it reads the tracked
+      # file listing. Syra went to Postgres greenfield in #92 and `syra-production`
+      # was dropped on 2026-08-09, so a Mongo reference is now always a mistake —
+      # and it would arrive as a hoisted dependency or a stray env name, neither of
+      # which breaks a build.
+      - name: Guard against MongoDB returning
+        run: bun run validate:no-mongo
+
       # shared-types and the SDK are consumed as built output (dist/lib) by the
       # apps, so their typechecks — and the apps' — need them built first, same
       # order the deploy workflows use.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:backend": "bun run --filter '@syra/backend' build",
     "test": "bun run --filter '*' test",
     "lint": "bun run --filter '*' lint",
+    "validate:no-mongo": "bun ./scripts/validate-no-mongo.mjs && bun ./scripts/test-validate-no-mongo.mjs",
     "clean": "bun run --filter '*' clean && rm -rf node_modules",
     "install:all": "bun install",
     "start:frontend": "bun run --filter '@syra/frontend' start",

--- a/scripts/test-validate-no-mongo.mjs
+++ b/scripts/test-validate-no-mongo.mjs
@@ -1,0 +1,608 @@
+#!/usr/bin/env bun
+
+/**
+ * Mutation-tests `validate-no-mongo.mjs`.
+ *
+ * A guard that has only ever been seen to pass is indistinguishable from one
+ * that cannot fail — and this one is especially easy to break silently, because
+ * every part of it is a regex or a file listing and both fail QUIET. A broken
+ * `git ls-files` reports a clean tree. A regex with a typo reports a clean tree.
+ * Each case below breaks exactly one thing and requires the guard to fail, and
+ * to fail with the words that identify the right rule.
+ *
+ * The cases that must PASS matter as much: this repository's comments discuss
+ * Mongo constantly, on purpose, and both loggers carry a Mongo-URI redaction
+ * pattern that is wanted. A version of this guard that fired on either would be
+ * disabled by whoever hit it first.
+ *
+ * Fixtures are real trees with a real `git init`, so the guard's actual file
+ * listing runs rather than a stand-in for it.
+ */
+
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const validator = resolve(repositoryRoot, "scripts/validate-no-mongo.mjs");
+
+/**
+ * Run the REAL validator against a scratch checkout.
+ *
+ * `realFloors` runs it with production vacuity floors, which is the only way to
+ * see them fire; every other case relaxes them, since a fixture tree of six
+ * files would otherwise fail for a reason that has nothing to do with Mongo.
+ */
+async function runAgainst(files, { realFloors = false, removeAfterAdd = [] } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "no-mongo-validator-"));
+  try {
+    for (const [path, contents] of Object.entries(files)) {
+      const full = join(root, path);
+      await mkdir(dirname(full), { recursive: true });
+      await writeFile(full, contents);
+    }
+
+    // `-f` because a developer's global excludes file can legitimately ignore
+    // `*.lock`, which would drop the lockfile fixture and make its case pass for
+    // the wrong reason.
+    Bun.spawnSync({ cmd: ["git", "-c", "init.defaultBranch=main", "init", "-q"], cwd: root });
+    Bun.spawnSync({ cmd: ["git", "add", "-A", "-f"], cwd: root });
+
+    // Deleted AFTER `git add`, so the path stays in the index while the working
+    // tree loses it. That divergence is real — a half-applied checkout or an
+    // interrupted rebase produces it — and it is the only way to reach the
+    // unreadable-file branch, which cannot be staged into existence.
+    for (const path of removeAfterAdd) await rm(join(root, path), { force: true });
+
+    const environment = { ...process.env, NO_MONGO_VALIDATOR_ROOT: root };
+    if (!realFloors) environment.NO_MONGO_VALIDATOR_FIXTURE_FLOORS = "1";
+
+    const proc = Bun.spawnSync({
+      cmd: ["bun", validator],
+      cwd: repositoryRoot,
+      env: environment,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      exitCode: proc.exitCode,
+      output: `${proc.stdout.toString()}${proc.stderr.toString()}`,
+    };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A clean tree.
+ *
+ * It carries one file per live `KNOWN_EXCEPTIONS` entry, holding the text that
+ * entry excuses — so every case below also exercises the exception path, and the
+ * guard's "the list must only shrink" check has something to be satisfied by.
+ * The stale-exception case is the one tree that deliberately omits it.
+ *
+ * THIS IS COUPLED TO THE LIVE LIST ON PURPOSE, and the coupling is the point:
+ * the self-test then proves the real exceptions match real text, rather than
+ * proving a synthetic list matches synthetic text. Adding an entry to the guard
+ * means adding its file here; forgetting turns every case below red with a
+ * message naming the entry. The cost shrinks as the list does.
+ */
+function filler(extra = {}) {
+  return {
+    "package.json": `${JSON.stringify(
+      {
+        name: "fixture",
+        workspaces: { packages: ["packages/*"], catalog: { typescript: "~5.9.3" } },
+        dependencies: { postgres: "3.4.9" },
+        overrides: { ioredis: "5.11.1" },
+      },
+      null,
+      2,
+    )}\n`,
+    "bun.lock": [
+      "{",
+      '  "lockfileVersion": 1,',
+      '  "packages": {',
+      '    "postgres": ["postgres@3.4.9", "", {}, "sha512-fixture=="],',
+      '    "drizzle-orm": ["drizzle-orm@0.45.2", "", {}, "sha512-fixture=="],',
+      "  },",
+      "}",
+      "",
+    ].join("\n"),
+    "packages/backend/src/db/postgres.ts": "export const dialect = 'postgres';\n",
+    "packages/backend/src/config/env.ts":
+      "// zod accepts mongodb+srv:// quite happily (verified), and a leftover Mongo connection\n"
+      + "// string in this slot is the one wrong value the cutover could produce.\n",
+    "packages/backend/src/config/env.productionBoot.test.ts":
+      "// accepts mongodb+srv:// — and a leftover Mongo connection string in this slot is refused.\n"
+      + "// mongodb+srv:// is first deliberately: it passes z.string().url(), so it is the\n"
+      + "// fixture that actually discriminates.\n"
+      + "const fixtures = ['mongodb+srv://user:pass@cluster.mongodb.net/syra',\n"
+      + "  'mongodb://127.0.0.1:27017/syra'];\n"
+      + "const withPassword = 'mongodb+srv://syra:hunter2-do-not-log@cluster.mongodb.net/syra';\n",
+    "packages/backend/src/db/__tests__/deployWorkflow.test.ts":
+      "// `MONGODB_URI` left in #92, with the Mongo it named. `DATABASE_URL` took its place.\n",
+    ".github/workflows/quality.yml":
+      "      # carries DATABASE_URL and no MONGODB_URI, /health reports engine=postgres\n",
+    ...extra,
+  };
+}
+
+const cases = [
+  {
+    name: "a clean PostgreSQL-only tree passes",
+    files: filler(),
+    expectFailure: false,
+  },
+
+  // ------------------------------------------------------------ manifests ---
+  {
+    name: "a dependency on mongoose is rejected",
+    files: filler({
+      "packages/backend/package.json": `${JSON.stringify(
+        { name: "@syra/backend", dependencies: { mongoose: "^8.24.0" } },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "dependencies declares mongoose",
+  },
+  {
+    name: "a devDependency on mongodb-memory-server is rejected",
+    files: filler({
+      "packages/backend/package.json": `${JSON.stringify(
+        { name: "@syra/backend", devDependencies: { "mongodb-memory-server": "^10.0.0" } },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "devDependencies declares mongodb-memory-server",
+  },
+  {
+    name: "a catalog entry is rejected",
+    files: filler({
+      "package.json": `${JSON.stringify(
+        { name: "fixture", workspaces: { packages: ["packages/*"], catalog: { mongodb: "^6.10.0" } } },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "workspaces.catalog declares mongodb",
+  },
+  {
+    name: "an override is rejected",
+    files: filler({
+      "package.json": `${JSON.stringify({ name: "fixture", overrides: { mongoose: "8.24.0" } }, null, 2)}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "overrides declares mongoose",
+  },
+  {
+    // The regression this check exists for. `@syra/backend` described itself
+    // as an "Express 5 / Mongoose / Socket.io backend" while every dependency
+    // check above passed, because a description declares nothing. The most
+    // visible line in the manifest was the one the guard could not read.
+    name: "a description claiming Mongoose is rejected",
+    files: filler({
+      "packages/backend/package.json": `${JSON.stringify(
+        { name: "@syra/backend", description: "Express 5 / Mongoose / Socket.io backend for Mercaria" },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "description claims Mongoose",
+  },
+  {
+    name: "a keyword claiming MongoDB is rejected",
+    files: filler({
+      "packages/backend/package.json": `${JSON.stringify(
+        { name: "@syra/backend", keywords: ["api", "MongoDB"] },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: true,
+    expectOutput: "keywords claims MongoDB",
+  },
+  {
+    // The distinguishing shape for the word anchor. A substring match would
+    // reject both of these, and a maintainer who hit that would delete the
+    // check rather than argue with it — a gate that cries wolf gets disabled by
+    // whoever trips over it next. Without this fixture, `/mongo/i` and
+    // `/\bmongo(?:db|ose)?\b/i` are indistinguishable.
+    name: "a description containing mongo inside another word passes",
+    files: filler({
+      "packages/backend/package.json": `${JSON.stringify(
+        { name: "@syra/backend", description: "Ranked among the fastest, deployed in Mongolia" },
+        null,
+        2,
+      )}\n`,
+    }),
+    expectFailure: false,
+  },
+
+  // ------------------------------------------------------------- lockfile ---
+  {
+    name: "a lockfile resolution is rejected even with clean manifests",
+    files: filler({
+      "bun.lock": [
+        "{",
+        '  "lockfileVersion": 1,',
+        '  "packages": {',
+        '    "postgres": ["postgres@3.4.9", "", {}, "sha512-fixture=="],',
+        '    "mongoose": ["mongoose@8.24.0", "", { "dependencies": { "mongodb": "6.10.0" } }, "sha512-fixture=="],',
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+    }),
+    expectFailure: true,
+    expectOutput: "resolves mongoose",
+  },
+  {
+    name: "a NESTED lockfile resolution is rejected too",
+    files: filler({
+      "bun.lock": [
+        "{",
+        '  "lockfileVersion": 1,',
+        '  "packages": {',
+        '    "postgres": ["postgres@3.4.9", "", {}, "sha512-fixture=="],',
+        '    "@some/pkg/mongodb": ["mongodb@6.10.0", "", {}, "sha512-fixture=="],',
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+    }),
+    expectFailure: true,
+    expectOutput: "resolves mongodb",
+  },
+  {
+    name: "a package whose NAME merely contains a banned one is not rejected",
+    files: filler({
+      "bun.lock": [
+        "{",
+        '  "lockfileVersion": 1,',
+        '  "packages": {',
+        '    "mongoose-helper": ["mongoose-helper@1.0.0", "", {}, "sha512-fixture=="],',
+        '    "not-mongodb": ["not-mongodb@2.0.0", "", {}, "sha512-fixture=="],',
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+    }),
+    expectFailure: false,
+  },
+
+  // -------------------------------------------------------- source imports ---
+  {
+    name: "an import statement is rejected",
+    files: filler({
+      "packages/backend/src/db/legacy.ts":
+        "import mongoose from 'mongoose';\nexport const connect = () => mongoose.connect('');\n",
+    }),
+    expectFailure: true,
+    expectOutput: "imports a Mongo driver",
+  },
+  {
+    name: "a require call is rejected",
+    files: filler({
+      "packages/backend/src/db/legacy.cjs": "const { MongoClient } = require('mongodb');\nmodule.exports = MongoClient;\n",
+    }),
+    expectFailure: true,
+    expectOutput: "imports a Mongo driver",
+  },
+  {
+    name: "a dynamic import is rejected",
+    files: filler({
+      "packages/backend/src/db/legacy.ts":
+        'export const boot = async () => (await import("mongodb-memory-server")).MongoMemoryServer;\n',
+    }),
+    expectFailure: true,
+    expectOutput: "imports a Mongo driver",
+  },
+  {
+    name: "a subpath import is rejected",
+    files: filler({
+      "packages/backend/src/db/legacy.ts": "import { Schema } from 'mongoose/lib/schema';\nexport { Schema };\n",
+    }),
+    expectFailure: true,
+    expectOutput: "imports a Mongo driver",
+  },
+
+  // ------------------------------------------------------- config and env ---
+  {
+    name: "MONGODB_URI in a workflow is rejected",
+    files: filler({
+      ".github/workflows/deploy.yml": "jobs:\n  deploy:\n    env:\n      MONGODB_URI: ${{ secrets.MONGODB_URI }}\n",
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    name: "MONGODB_URI in an env template is rejected",
+    files: filler({ "packages/backend/.env.example": "DATABASE_URL=\nMONGODB_URI=\n" }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    name: "MONGODB_URI in a .github shell script is rejected",
+    files: filler({ ".github/scripts/deploy.sh": "#!/usr/bin/env bash\naws ssm get-parameter --name MONGODB_URI\n" }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    // The distinguishing shape for the case-insensitive read. Without a fixture
+    // in a casing other than the canonical one, a case-SENSITIVE regex passes
+    // every other case in this file too, so the difference would go untested.
+    name: "a lowercased mongodb_uri config key is rejected",
+    files: filler({
+      "packages/backend/src/config/legacy.ts": "export const keys = { mongodb_uri: process.env.DATABASE_URL };\n",
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    name: "a suffixed MONGODB_URI_LEGACY is rejected",
+    files: filler({ ".github/workflows/deploy.yml": "env:\n  MONGODB_URI_LEGACY: ${{ secrets.OLD }}\n" }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    name: "a mongodb:// connection string in a source file is rejected",
+    files: filler({
+      "packages/backend/src/db/legacy.ts": "export const uri = 'mongodb://localhost:27017/mercaria';\n",
+    }),
+    expectFailure: true,
+    expectOutput: "carries a mongodb:// connection string",
+  },
+  {
+    name: "a mongodb+srv:// connection string in a compose file is rejected",
+    files: filler({
+      "docker-compose.yml": "services:\n  api:\n    environment:\n      - URI=mongodb+srv://user:pw@cluster/mercaria\n",
+    }),
+    expectFailure: true,
+    expectOutput: "carries a mongodb:// connection string",
+  },
+
+  // ------------------------------------------ prose and redaction are safe ---
+  {
+    name: "backticked prose about Mongo does NOT fire",
+    files: filler({
+      "packages/backend/src/db/postgres.ts":
+        "/**\n"
+        + " * Replaces the old `import mongoose from mongoose` boot path. Every model that\n"
+        + " * used Mongoose now goes through drizzle; nothing requires mongodb any more,\n"
+        + " * and the Mongo connection string this once read is gone.\n"
+        + " */\n"
+        + "export const dialect = 'postgres';\n",
+    }),
+    expectFailure: false,
+  },
+  {
+    // The distinguishing shape for the `from|require|import` prefix. Backticked
+    // prose is caught by the QUOTE anchor alone, so without a quoted module name
+    // outside import position, deleting the prefix entirely leaves every case
+    // green — measured. This is the input that tells the two apart.
+    name: "a QUOTED module name that is not an import does NOT fire",
+    files: filler({
+      "packages/backend/src/db/postgres.ts":
+        "// Nothing in this package loads 'mongoose' any more; the driver key was\n"
+        + '// "mongodb" and both are gone. Kept as a note for anyone grepping.\n'
+        + "export const driver = 'postgres';\n",
+    }),
+    expectFailure: false,
+  },
+  {
+    // The guard names every banned package and both URI shapes by necessity, and
+    // this file carries a fixture for each. Scanned, the pair reports itself on
+    // every run — which is exactly what happened the moment they were first
+    // committed and became visible to `git ls-files`.
+    name: "the guard's own source and self-test are not their own subject",
+    files: filler({
+      "scripts/validate-no-mongo.mjs":
+        "const BANNED = ['mongoose', 'mongodb', 'connect-mongo'];\n"
+        + "const URI = /\\bmongodb(?:\\+srv)?:\\/\\//i;\n"
+        + "const ENV = /\\bMONGODB_URI/i;\n",
+      "scripts/test-validate-no-mongo.mjs":
+        "const fixture = \"const { MongoClient } = require('mongodb');\";\n"
+        + "const uri = 'mongodb://localhost:27017/mercaria';\n"
+        + "const env = 'MONGODB_URI=';\n",
+    }),
+    expectFailure: false,
+  },
+  {
+    name: "the loggers' Mongo-URI REDACTION pattern does NOT fire",
+    files: filler({
+      "packages/backend/src/utils/logger.ts":
+        "const REDACT = /\\b(?:https?|wss?|redis|rediss|mongodb(?:\\+srv)?):\\/\\/[^\\s\"'<>]+/gi;\n"
+        + "const SENSITIVE_KEYS = ['mongouri', 'dbname'];\n"
+        + "export const sanitise = (line: string) => line.replace(REDACT, '[REDACTED]');\n",
+    }),
+    expectFailure: false,
+  },
+  {
+    // Markdown's exemption comes from the scan sets — no glob in the guard can
+    // match a `.md` path — rather than from an exclusion filter. An explicit
+    // filter was written and then deleted, because mutation-testing showed no
+    // input could tell the two versions apart. So this case cannot be broken by
+    // touching an exclusion; it fires if someone widens the SOURCE_FILE pattern,
+    // which is the change that would actually put docs back in scope.
+    name: "a markdown file describing the migration does NOT fire",
+    files: filler({
+      "docs/MONGO-TO-POSTGRES.md":
+        "The copier read `MONGODB_URI` (a mongodb://host/db string) and wrote Postgres.\n"
+        + "```ts\nimport mongoose from 'mongoose';\n```\n",
+      "packages/backend/README.md": "Set MONGODB_URI to nothing — it is gone. Old value: mongodb://localhost:27017.\n",
+    }),
+    expectFailure: false,
+  },
+
+  // --------------------------- the retired standing removal ----------------
+  //
+  // `TASK_SECRET_REMOVALS: MONGODB_URI` was briefly excused. It named the secret
+  // in order to strip it from every rendered task definition, which was load-
+  // bearing while a Terraform apply could still reintroduce it — the definition
+  // is derived from the LIVE one, so a secret nobody names is carried forward.
+  //
+  // That threat model closed upstream: oxy-infra `099db84` records DATABASE_URL
+  // and no MONGODB_URI for this service, and `/oxy/mercaria/MONGODB_URI` is
+  // deleted from SSM, so a name that comes back now fails task provisioning
+  // loudly instead of resurrecting a secret. The directive and its exception are
+  // both gone, and the absence assertion lives here instead, in CI.
+  //
+  // These two cases are what makes that a decision rather than a drift: the
+  // retired directive is now an ordinary finding, and so is every other shape a
+  // reintroduction would take in that file.
+  {
+    name: "the retired removal directive is now an ordinary finding",
+    files: filler({
+      ".github/workflows/deploy-aws.yml": "        env:\n          TASK_SECRET_REMOVALS: MONGODB_URI\n",
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+  {
+    // `TASK_SECRET_OVERRIDES_JSON` supplies secrets by SSM path in this file, so
+    // an ARN is the other shape a reintroduction would take — and the one a
+    // scanner looking only for a bare variable name would miss.
+    name: "the deploy workflow FAILS on an SSM ARN for the parameter",
+    files: filler({
+      ".github/workflows/deploy-aws.yml":
+        "        env:\n"
+        + '          TASK_SECRET_OVERRIDES_JSON: {"MONGODB_URI":'
+        + '"arn:aws:ssm:us-west-2:237343248947:parameter/oxy/mercaria/MONGODB_URI"}\n',
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGODB_URI",
+  },
+
+  {
+    // A tracked path the working tree does not have. Before this was handled the
+    // guard threw an ENOENT stack trace out of the middle of the scan: no
+    // verdict, and a failure that reads like a bug in the guard rather than a
+    // fact about the tree. Met in the wild on a stale worktree, not imagined.
+    //
+    // It must FAIL rather than skip quietly, because the scan really was
+    // incomplete — the unread file is exactly where a reintroduction could sit.
+    name: "a tracked file missing from the working tree fails loudly, not with a stack trace",
+    files: filler({
+      "packages/backend/src/db/legacy.ts": "export const uri = 'postgres://localhost/x';\n",
+    }),
+    removeAfterAdd: ["packages/backend/src/db/legacy.ts"],
+    expectFailure: true,
+    expectOutput: "tracked by git but could not be read",
+  },
+
+  {
+    // THE NARROWNESS PROOF, and the reason the entries are per-line rather than
+    // per-file. `env.productionBoot.test.ts` is excused for six specific lines
+    // because it is the test that proves a Mongo URL is REFUSED. A real live
+    // connection string added to that SAME file must still fail, or the
+    // exception is a hole rather than an allowlist.
+    name: "an excused file still fails on a line the exceptions do not cover",
+    files: filler({
+      "packages/backend/src/config/env.productionBoot.test.ts":
+        "// accepts mongodb+srv:// — and a leftover Mongo connection string in this slot is refused.\n"
+        + "// mongodb+srv:// is first deliberately: it passes z.string().url(), so it is the\n"
+        + "// fixture that actually discriminates.\n"
+        + "const fixtures = ['mongodb+srv://user:pass@cluster.mongodb.net/syra',\n"
+        + "  'mongodb://127.0.0.1:27017/syra'];\n"
+        + "const withPassword = 'mongodb+srv://syra:hunter2-do-not-log@cluster.mongodb.net/syra';\n"
+        + "const live = 'mongodb://prod-cluster.internal:27017/syra_live';\n",
+    }),
+    expectFailure: true,
+    expectOutput: "carries a mongodb:// connection string",
+  },
+
+  // ------------------------------------------------------- self-protection ---
+  {
+    name: "a broken file listing cannot pass silently (vacuity floors)",
+    files: {
+      "packages/backend/src/db/postgres.ts": "export const dialect = 'postgres';\n",
+    },
+    realFloors: true,
+    expectFailure: true,
+    expectOutput: "below the 400 floor",
+  },
+  {
+    name: "a KNOWN_EXCEPTIONS entry that matches nothing FAILS the run",
+    // Both live entries excuse lines in the deploy workflow that come out with
+    // the oxy-infra change. This tree omits that file, so they go stale and the
+    // shrink discipline must fire — which is what forces their deletion once
+    // that change lands, rather than leaving them to rot.
+    files: {
+      "package.json": `${JSON.stringify({ name: "fixture" }, null, 2)}\n`,
+      "packages/backend/src/db/postgres.ts": "export const dialect = 'postgres';\n",
+    },
+    expectFailure: true,
+    expectOutput: "no longer matches anything",
+  },
+  {
+    // THE DISTINGUISHING SHAPE for this repo, and the reason the env pattern
+    // matches `MONGO_URI` as well as `MONGODB_URI`.
+    //
+    // This service's task definition, its SSM parameter and its deploy workflow
+    // all spell it WITHOUT the DB. A guard written for `MONGODB_URI` alone
+    // reports this repository clean while a live secret names a dropped
+    // database — which is not hypothetical: that exact substitution produced a
+    // wrong "clean" verdict during the Mongo retirement.
+    name: "the no-DB spelling MONGO_URI is caught too, and reported as itself",
+    files: filler({
+      "server/config.ts": "export const uri = process.env.MONGO_URI;\n",
+    }),
+    expectFailure: true,
+    expectOutput: "names MONGO_URI",
+  },
+];
+
+const guardSource = await readFile(validator, "utf8");
+
+let failed = 0;
+for (const testCase of cases) {
+  // A source-level assertion, for a property of the GUARD rather than of a tree
+  // it scans. Runs no fixture: there is nothing to put in one.
+  if (testCase.assertGuardSource) {
+    if (testCase.assertGuardSource(guardSource)) {
+      console.log(`ok   ${testCase.name}`);
+    } else {
+      console.error(`FAIL ${testCase.name}: the guard source no longer satisfies this assertion`);
+      failed += 1;
+    }
+    continue;
+  }
+
+  const { exitCode, output } = await runAgainst(testCase.files, {
+    realFloors: testCase.realFloors === true,
+    removeAfterAdd: testCase.removeAfterAdd ?? [],
+  });
+  const didFail = exitCode !== 0;
+
+  if (didFail !== testCase.expectFailure) {
+    console.error(
+      `FAIL ${testCase.name}: expected ${testCase.expectFailure ? "a failure" : "a pass"}, `
+      + `got exit ${exitCode}\n${output}`,
+    );
+    failed += 1;
+    continue;
+  }
+  if (testCase.expectOutput && !output.includes(testCase.expectOutput)) {
+    console.error(
+      `FAIL ${testCase.name}: failed as expected, but the message never said `
+      + `"${testCase.expectOutput}"\n${output}`,
+    );
+    failed += 1;
+    continue;
+  }
+  console.log(`ok   ${testCase.name}`);
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} of ${cases.length} guard cases failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${cases.length} guard cases passed.`);

--- a/scripts/validate-no-mongo.mjs
+++ b/scripts/validate-no-mongo.mjs
@@ -1,0 +1,519 @@
+#!/usr/bin/env bun
+
+/**
+ * Syra is PostgreSQL-only. This refuses to let MongoDB back in by accident.
+ *
+ * ## What it guards, and why a guard rather than a memory
+ *
+ * Mongoose was removed wholesale after the Postgres cutover (PR #136): the models,
+ * every Mongoose model, the driver dependencies, the connection config. What
+ * makes that removal fragile is not the code — it is that Mongo comes back in
+ * SMALL pieces, each individually reasonable and none of them alarming in a
+ * diff. A `mongodb` dependency arrives as a transitive of something else and
+ * gets hoisted into a manifest to pin it. A `MONGODB_URI` reappears in a
+ * workflow because a one-shot needed it. Someone reaches for
+ * `mongodb-memory-server` because it is the fixture library they know.
+ *
+ * None of those fail a build. The first one that DOES fail something is the
+ * fourth or fifth, by which point the honest description of the repository is
+ * "two databases", and nobody decided that.
+ *
+ * So this is a decision gate, not a lint: reintroducing Mongo is allowed, it
+ * just has to be a decision somebody makes on purpose and writes down, either by
+ * deleting this file or by adding a reasoned `KNOWN_EXCEPTIONS` entry.
+ *
+ * ## The four surfaces
+ *
+ *   1. **Manifests** — a banned package named in any dependency field, in the
+ *      root `overrides`, or in `workspaces.catalog`.
+ *   2. **The lockfile** — a recorded resolution for a Mongo driver, which is
+ *      what actually lands the code in `node_modules` whatever the manifests
+ *      say. Matched on the resolution's own package NAME, never as a substring,
+ *      so `mongodb-memory-server` and `mongodb` stay distinguishable and an
+ *      unrelated package whose name contains one of them cannot trip it.
+ *   3. **Source imports** — real import syntax only, anchored on a
+ *      quote-delimited specifier. A docblock writing `import mongoose` in
+ *      backticks is prose about history and must not fire; this repository's
+ *      comments are FULL of such prose, deliberately, and a gate that fired on
+ *      it would be turned off within a day.
+ *   4. **Config and env** — `MONGODB_URI` or a live `mongodb://` /
+ *      `mongodb+srv://` connection string in an env template, a compose file, a
+ *      workflow, a `.github` shell script, or any source file.
+ *
+ * Markdown is exempt everywhere. Docs are where the history of a migration is
+ * supposed to live, and a guard that forbade describing Mongo in prose would be
+ * asking the repository to forget why it moved. That exemption is a property of
+ * the four scan sets rather than a filter: none of the patterns below can match
+ * a `.md` path. An explicit markdown exclusion WAS written here and removed —
+ * mutation-testing showed it could be deleted with every self-test still green,
+ * because no input exists that the two versions answer differently. Widening
+ * `SOURCE_FILE` is what would change that, and a self-test case stands over it.
+ *
+ * ## Two near-misses that are wanted, and must keep passing
+ *
+ * Both loggers redact Mongo URIs out of log lines — `packages/mcp/lib/logger.ts`
+ * and `packages/backend/src/utils/logger.ts` each carry a pattern whose source
+ * text reads `mongodb(?:\+srv)?):\/\/`. That is a REDACTION and it stays: logs
+ * can still carry a legacy URI from somewhere upstream. The connection-string
+ * check looks for the literal `mongodb://`, which that escaped regex source does
+ * not contain, so neither file matches — verified rather than assumed, and
+ * pinned by a self-test case.
+ *
+ * The same files carry `mongouri` and `mongoUri` as redaction KEY names, and
+ * those pass for a duller reason than they look: the env-variable check wants
+ * the character sequence `mongodb_uri`, and a key spelled `mongouri` simply is
+ * not it. A case-sensitive check was written here first, justified by those
+ * keys; the justification was wrong, since no casing of `MONGODB_URI` matches
+ * them either. It reads case-INSENSITIVELY now, which is strictly the broader
+ * check and costs nothing — measured, no case variant exists in the tree.
+ *
+ * Usage:  bun scripts/validate-no-mongo.mjs
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The tree to scan. Overridable so the self-test can point the REAL validator at
+ * a scratch checkout instead of asserting against a copy of its own logic.
+ */
+const repositoryRoot = process.env.NO_MONGO_VALIDATOR_ROOT
+  ? resolve(process.env.NO_MONGO_VALIDATOR_ROOT)
+  : resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Fixture trees are a handful of files, so the real vacuity floors would fail
+ * every self-test case for the wrong reason. This lowers them to 1 — it never
+ * removes them, so a fixture run still catches a traversal that finds nothing,
+ * and the floor that matters stays hard in every normal run.
+ */
+const fixtureFloors = process.env.NO_MONGO_VALIDATOR_FIXTURE_FLOORS === "1";
+
+/** Packages that mean "Mongo is back", in a manifest. */
+const BANNED_PACKAGES = [
+  "mongoose",
+  "mongodb",
+  "mongodb-memory-server",
+  "bson",
+  "connect-mongo",
+  "@typegoose/typegoose",
+  "mongodb-client-encryption",
+];
+
+/**
+ * Packages that mean "Mongo is back", in the lockfile. Narrower than the
+ * manifest set on purpose: these four are only ever Mongo, while `bson` and the
+ * encryption addon can legitimately arrive as somebody else's transitive without
+ * a line of Mongo code being reachable. The lockfile records the whole tree, so
+ * it is the one surface where that distinction is worth drawing.
+ */
+const BANNED_LOCK_PACKAGES = ["mongoose", "mongodb", "mongodb-memory-server", "connect-mongo"];
+
+/**
+ * Mongo named in PROSE, for the manifest's `description` and `keywords`.
+ *
+ * Word-anchored so `mongo`, `mongodb` and `mongoose` all match in any case,
+ * while a word that merely contains them does not: `mongolia` and `among` stay
+ * clean. This is a claim check, not a dependency check — the package names in
+ * `BANNED_PACKAGES` are the wrong vocabulary for a sentence a human wrote.
+ */
+const MONGO_PROSE = /\bmongo(?:db|ose)?\b/i;
+
+/**
+ * Deliberate, reasoned survivals. Each entry excuses findings in ONE file whose
+ * matched text contains `pattern`.
+ *
+ * The list must only SHRINK: an entry that stops matching anything FAILS the
+ * run, so a workaround cannot outlive the thing it worked around. Same
+ * discipline as `ACCEPTED_OVERRIDE_RANGE_VIOLATIONS` in `validate-lockfile.mjs`,
+ * for the same reason — a stale exception is indistinguishable from a real one
+ * until somebody audits the list, and nobody audits the list.
+ */
+const KNOWN_EXCEPTIONS = [
+  // ---------------------------------------------------------------------------
+  // The boot-time DATABASE_URL scheme check, and the test that proves it works.
+  //
+  // `env.ts` refuses any DATABASE_URL that is not `postgres(ql)://`, and it
+  // checks the SCHEME rather than trusting `z.string().url()` because zod
+  // accepts `mongodb+srv://...` quite happily. A leftover Mongo connection
+  // string in that slot is the one wrong value this cutover could actually
+  // produce — a copy-paste from the old task definition.
+  //
+  // So this is a guard that FORBIDS Mongo, inside a repository whose guard
+  // forbids naming Mongo. The test cannot prove a value is rejected without
+  // containing that value, and the comments cannot explain the scheme check
+  // without naming what defeats a plain shape check. Deleting any of them to
+  // satisfy this scanner would delete the protection or its reasoning.
+  //
+  // Listed ONE LINE AT A TIME rather than as a single pattern for the file: a
+  // file-level excuse is a hole, and each entry must keep matching its own line
+  // or the shrink rule fails the run.
+  // ---------------------------------------------------------------------------
+  {
+    file: "packages/backend/src/config/env.ts",
+    pattern: "quite happily (verified), and a leftover Mongo connection",
+    reason:
+      "The comment stating WHY the scheme is checked rather than the URL shape. Remove it and "
+      + "the regex has no justification, so the next person relaxes it to z.string().url().",
+  },
+  {
+    file: "packages/backend/src/config/env.productionBoot.test.ts",
+    pattern: "and a leftover Mongo connection string in this",
+    reason: "The same reasoning restated where the test asserts it. See the env.ts entry above.",
+  },
+  {
+    file: "packages/backend/src/config/env.productionBoot.test.ts",
+    pattern: "is first deliberately: it passes",
+    reason:
+      "Explains the ORDER of the rejection fixtures: the Mongo URL is first because it is the "
+      + "only one that passes a naive URL check, so it is the case that actually discriminates.",
+  },
+  {
+    file: "packages/backend/src/config/env.productionBoot.test.ts",
+    pattern: "user:pass@cluster.mongodb.net/syra",
+    reason:
+      "The fixture the test proves production REFUSES — the exact shape a copy-paste from the "
+      + "pre-cutover task definition produces. Deleting it deletes the assertion.",
+  },
+  {
+    file: "packages/backend/src/config/env.productionBoot.test.ts",
+    pattern: "127.0.0.1:27017/syra",
+    reason: "The second rejection fixture, plain scheme rather than +srv. Same reason as above.",
+  },
+  {
+    file: "packages/backend/src/config/env.productionBoot.test.ts",
+    pattern: "hunter2-do-not-log",
+    reason:
+      "A DIFFERENT test: that a refusal quotes the offending value WITHOUT its password, because "
+      + "a production boot failure is logged and log lines outlive the incident. Proving the "
+      + "credential is stripped needs a credential-bearing URL, and the realistic one is a Mongo "
+      + "URL. The pattern is the password rather than the scheme for exactly that reason.",
+  },
+  // ---------------------------------------------------------------------------
+  {
+    file: "packages/backend/src/db/__tests__/deployWorkflow.test.ts",
+    pattern: "left in #92, with the Mongo it named",
+    reason:
+      "Records that DATABASE_URL replaced MONGODB_URI on the task definition, beside the test "
+      + "asserting the deploy workflow's secret list. That history is what stops someone "
+      + "re-adding the name after meeting an old task definition.",
+  },
+  {
+    file: ".github/workflows/quality.yml",
+    pattern: "carries DATABASE_URL and no MONGODB_URI",
+    reason:
+      "States the evidence that Syra opens no Mongo — live task definition, /health engine, and "
+      + "that the mongoose in node_modules is an UNSATISFIED optional peer of "
+      + "@oxyhq/crowdsource-app rather than a dependency (verified: bun.lock carries no mongoose "
+      + "resolution entry). That paragraph answers 'why is mongoose in node_modules', which is "
+      + "otherwise alarming and would be re-investigated from scratch.",
+  },
+];
+
+const MINIMUM_MANIFESTS = fixtureFloors ? 1 : 3;
+const MINIMUM_SOURCE_FILES = fixtureFloors ? 1 : 400;
+const MINIMUM_LOCK_RESOLUTIONS = fixtureFloors ? 1 : 900;
+
+const SOURCE_FILE = /\.(?:tsx?|jsx?|mjs|cjs)$/;
+const MANIFEST_FILE = /(?:^|\/)package\.json$/;
+const ENV_TEMPLATE_FILE = /(?:^|\/)\.env[^/]*\.example$/;
+const COMPOSE_FILE = /(?:^|\/)docker-compose[^/]*\.ya?ml$/;
+const WORKFLOW_FILE = /^\.github\/workflows\/[^/]+\.ya?ml$/;
+const SHELL_SCRIPT_FILE = /^\.github\/scripts\/[^/]+\.sh$/;
+
+/**
+ * The guard cannot be its own subject. This file names every banned package and
+ * both URI shapes because that is what it is FOR, and the self-test carries a
+ * fixture for each of them; scanned, the pair reports itself on every run.
+ *
+ * Excluded by path rather than through `KNOWN_EXCEPTIONS`, which is for content
+ * that legitimately survives in the tree at large — a content-matched entry here
+ * would go stale every time the guard's own wording changed, and the shrink
+ * discipline would then fight ordinary edits to the guard. A rename cannot make
+ * this fail quietly: the renamed file falls back into the scan and reports
+ * itself loudly, which is the signal to update this list.
+ */
+const GUARD_OWN_FILES = new Set(["scripts/validate-no-mongo.mjs", "scripts/test-validate-no-mongo.mjs"]);
+
+const escapeForRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Real import syntax for a banned module, including subpaths. Longest name
+ * first so `mongodb-memory-server` is never reported as `mongodb`.
+ *
+ * The specifier MUST be quote-delimited, which is the whole reason a docblock
+ * saying `import mongoose` in backticks does not match. A quoted specifier
+ * inside a COMMENT does match, and that is intended: a commented-out import is
+ * one keystroke from being a live one.
+ */
+const BANNED_IMPORT = new RegExp(
+  "(?:\\bfrom\\s*|\\brequire\\s*\\(\\s*|\\bimport\\s*\\(\\s*|\\bimport\\s+)"
+  + `(['"])(?:${[...BANNED_PACKAGES].sort((a, b) => b.length - a.length).map(escapeForRegExp).join("|")})`
+  + "(?:/[^'\"]*)?\\1",
+);
+
+/**
+ * The env variable, in any casing and under any suffix — `MONGODB_URI_LEGACY`
+ * and a lowercased `mongodb_uri` config key are both the same reference. No
+ * trailing word boundary, deliberately: a suffixed spelling is the likeliest way
+ * one comes back, and nothing benign is spelled this way.
+ *
+ * `MONGO_URI` — no DB — is matched too, and in this repo that is the SPELLING
+ * THAT MATTERS: the task definition, the SSM parameter and the deploy workflow
+ * all use it, and `MONGODB_URI` appears nowhere. A guard written for the other
+ * spelling would have reported this repository clean while a live secret named
+ * a dropped database. That exact substitution already produced a wrong "clean"
+ * verdict once during the Mongo retirement, from a grep for one spelling.
+ */
+const MONGO_ENV_VARIABLE = /\bMONGO(?:DB)?_URI/i;
+
+/** A live connection string. Escaped regex SOURCE containing `:\/\/` cannot match. */
+const MONGO_CONNECTION_STRING = /\bmongodb(?:\+srv)?:\/\//i;
+
+/** One line of bun.lock's `packages` map: `"key": ["name@version", …],`. */
+const LOCK_RESOLUTION = /^\s*"[^"]+":\s*\[\s*"([^"]+)"/;
+
+/** `@scope/name@1.2.3` → `@scope/name`; `name@1.2.3` → `name`. */
+function packageNameOf(resolution) {
+  const separator = resolution.indexOf("@", resolution.startsWith("@") ? 1 : 0);
+  return separator === -1 ? resolution : resolution.slice(0, separator);
+}
+
+/** Every file git tracks, repo-relative — so ignored and generated files cannot count. */
+function trackedFiles() {
+  const listed = spawnSync("git", ["ls-files", "-z"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (listed.status !== 0) {
+    throw new Error(`git ls-files failed in ${repositoryRoot}: ${listed.stderr ?? listed.error}`);
+  }
+  return listed.stdout.split("\0").filter(Boolean);
+}
+
+/** The 1-based line holding `needle`, or 1 when the text has moved on. */
+function lineHolding(lines, needle) {
+  const index = lines.findIndex((line) => line.includes(needle));
+  return index === -1 ? 1 : index + 1;
+}
+
+/**
+ * Read a tracked file, or record WHY it could not be read and skip it.
+ *
+ * `git ls-files` reports the INDEX, which can name a file the working tree does
+ * not have — a half-applied checkout, an interrupted rebase, a stale worktree.
+ * Left unhandled that threw an ENOENT stack trace out of the middle of the
+ * scan, which is the worst of both worlds: the run ends with no verdict, and
+ * the reason looks like a bug in the guard rather than a fact about the tree.
+ * Reading it as a FAILURE keeps the run loud and finishes the other surfaces.
+ */
+async function readTrackedFile(path) {
+  try {
+    return await readFile(resolve(repositoryRoot, path), "utf8");
+  } catch (error) {
+    failures.push(
+      `${path} is tracked by git but could not be read (${error.code ?? error.message}) — `
+      + "the working tree disagrees with the index, so this scan was incomplete",
+    );
+    return null;
+  }
+}
+
+const findings = [];
+const failures = [];
+
+const record = (file, line, match, rule) => findings.push({ file, line, match, rule });
+
+const tracked = trackedFiles();
+const manifests = tracked.filter((path) => MANIFEST_FILE.test(path));
+const sources = tracked.filter((path) => SOURCE_FILE.test(path) && !GUARD_OWN_FILES.has(path));
+const configs = tracked.filter(
+  (path) =>
+    ENV_TEMPLATE_FILE.test(path)
+    || COMPOSE_FILE.test(path)
+    || WORKFLOW_FILE.test(path)
+    || SHELL_SCRIPT_FILE.test(path),
+);
+
+// ------------------------------------------------------------- 1. manifests ---
+
+/** Every key in `overrides`, however deeply an npm-style nested override nests it. */
+function overrideKeys(value, collected = []) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return collected;
+  for (const [key, nested] of Object.entries(value)) {
+    collected.push(key);
+    overrideKeys(nested, collected);
+  }
+  return collected;
+}
+
+for (const path of manifests) {
+  const text = await readTrackedFile(path);
+  if (text === null) continue;
+  const lines = text.split("\n");
+  let manifest;
+  try {
+    manifest = JSON.parse(text);
+  } catch (error) {
+    failures.push(`${path}: not parseable as JSON, so its dependencies could not be checked — ${error.message}`);
+    continue;
+  }
+
+  const declared = [];
+  for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
+    const block = manifest[field];
+    if (!block || typeof block !== "object") continue;
+    for (const name of Object.keys(block)) declared.push([field, name]);
+  }
+  for (const name of overrideKeys(manifest.overrides)) declared.push(["overrides", name]);
+  for (const name of Object.keys(manifest.workspaces?.catalog ?? {})) declared.push(["workspaces.catalog", name]);
+
+  for (const [field, name] of declared) {
+    if (!BANNED_PACKAGES.includes(name)) continue;
+    const quoted = `"${name}"`;
+    record(
+      path,
+      lineHolding(lines, quoted),
+      (lines.find((line) => line.includes(quoted)) ?? `${field}.${name}`).trim(),
+      `${field} declares ${name}`,
+    );
+  }
+
+  // `description` is PROSE, and it is the most visible claim a manifest makes —
+  // npm, the GitHub sidebar and every package viewer render it. It is also the
+  // one this kind of validator misses: `@mention/backend` described itself as an
+  // "Express 5 / Mongoose / Socket.io backend" for the whole life of the guard,
+  // because a description declares no dependency and every check above reads
+  // dependency NAMES. A gate blind to the single most-read line in the file it
+  // guards is worse than no gate, since its silence is taken for a verdict.
+  //
+  // Matched on the word rather than the package names: prose says "Mongoose",
+  // "MongoDB" and "Mongo", none of which is a package identifier, and the point
+  // is the CLAIM, not the spelling.
+  for (const field of ["description", "keywords"]) {
+    const value = manifest[field];
+    if (value === undefined) continue;
+    const text = Array.isArray(value) ? value.join(" ") : value;
+    if (typeof text !== "string") continue;
+    const found = MONGO_PROSE.exec(text);
+    if (!found) continue;
+    record(
+      path,
+      lineHolding(lines, `"${field}"`),
+      (lines.find((line) => line.includes(`"${field}"`)) ?? `${field}: ${text}`).trim().slice(0, 160),
+      `${field} claims ${found[0]}`,
+    );
+  }
+}
+
+// ------------------------------------------------------------- 2. lockfile ---
+
+let lockResolutions = 0;
+if (tracked.includes("bun.lock")) {
+  const lines = (await readFile(resolve(repositoryRoot, "bun.lock"), "utf8")).split("\n");
+  for (const [index, line] of lines.entries()) {
+    const matched = LOCK_RESOLUTION.exec(line);
+    if (!matched) continue;
+    lockResolutions += 1;
+    const name = packageNameOf(matched[1]);
+    if (!BANNED_LOCK_PACKAGES.includes(name)) continue;
+    record("bun.lock", index + 1, line.trim().slice(0, 160), `resolves ${name}`);
+  }
+} else if (!fixtureFloors) {
+  failures.push(
+    "bun.lock is not tracked, so the resolution scan had nothing to read — the guard's second surface is blind",
+  );
+}
+
+// ---------------------------------------------- 3 & 4. sources and config ---
+
+for (const path of [...sources, ...configs]) {
+  const isSource = SOURCE_FILE.test(path);
+  const text = await readTrackedFile(path);
+  if (text === null) continue;
+  const lines = text.split("\n");
+
+  for (const [index, line] of lines.entries()) {
+    if (isSource && BANNED_IMPORT.test(line)) {
+      record(path, index + 1, line.trim(), "imports a Mongo driver");
+    }
+    const envMatch = MONGO_ENV_VARIABLE.exec(line);
+    if (envMatch) {
+      // Reports the spelling it actually matched, not a canonical one: the two
+      // are different facts about the tree, and an operator reading `names
+      // MONGODB_URI` under a line that says MONGO_URI would reasonably doubt
+      // the finding.
+      record(path, index + 1, line.trim(), `names ${envMatch[0].toUpperCase()}`);
+    }
+    if (MONGO_CONNECTION_STRING.test(line)) {
+      record(path, index + 1, line.trim(), "carries a mongodb:// connection string");
+    }
+  }
+}
+
+// ---------------------------------------------------------- 5. exceptions ---
+
+const honoured = new Set();
+const unexcused = findings.filter((finding) => {
+  const entry = KNOWN_EXCEPTIONS.find(
+    (exception) => exception.file === finding.file && finding.match.includes(exception.pattern),
+  );
+  if (!entry) return true;
+  honoured.add(entry);
+  return false;
+});
+
+for (const entry of KNOWN_EXCEPTIONS) {
+  if (honoured.has(entry)) continue;
+  failures.push(
+    `KNOWN_EXCEPTIONS still excuses "${entry.pattern}" in ${entry.file}, which no longer matches anything. `
+    + "The reference is gone or the file moved — delete the entry so the list keeps describing the tree.",
+  );
+}
+
+// -------------------------------------------------------- 6. vacuity floors ---
+
+if (manifests.length < MINIMUM_MANIFESTS) {
+  failures.push(
+    `${manifests.length} manifests scanned is below the ${MINIMUM_MANIFESTS} floor — `
+    + "the file listing is probably broken, and a broken listing reports a clean tree",
+  );
+}
+if (sources.length < MINIMUM_SOURCE_FILES) {
+  failures.push(
+    `${sources.length} source files scanned is below the ${MINIMUM_SOURCE_FILES} floor — `
+    + "the file listing is probably broken, and a broken listing reports a clean tree",
+  );
+}
+if (lockResolutions < MINIMUM_LOCK_RESOLUTIONS && (tracked.includes("bun.lock") || !fixtureFloors)) {
+  failures.push(
+    `${lockResolutions} lockfile resolutions parsed is below the ${MINIMUM_LOCK_RESOLUTIONS} floor — `
+    + "bun.lock's format has probably moved and the resolution matcher no longer reads it",
+  );
+}
+
+// ------------------------------------------------------------------ verdict ---
+
+if (unexcused.length > 0 || failures.length > 0) {
+  console.error("MongoDB reintroduction guard failed:\n");
+  for (const finding of unexcused) {
+    console.error(`  ${finding.file}:${finding.line}: ${finding.rule}`);
+    console.error(`    ${finding.match}\n`);
+  }
+  for (const failure of failures) console.error(`  ${failure}\n`);
+  console.error(
+    "  Syra is PostgreSQL-only (#92 cut it over greenfield and `syra-production` was dropped\n"
+    + "  on 2026-08-09); reintroducing Mongo needs an explicit architectural decision —\n"
+    + "  remove the reference or add a reasoned KNOWN_EXCEPTIONS entry.\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `MongoDB reintroduction guard passed — ${manifests.length} manifests, ${sources.length} source files, `
+  + `${configs.length} config files and ${lockResolutions} lockfile resolutions scanned; `
+  + `${honoured.size} of ${KNOWN_EXCEPTIONS.length} known exceptions honoured.`,
+);


### PR DESCRIPTION
#92 cut Syra over to Postgres greenfield and `syra-production` was dropped on 2026-08-09, so a Mongo reference is now always a mistake. Nothing enforced it — and it would not arrive as a broken build: a hoisted transitive, a stray env name, a fixture library somebody knows.

Ported from Mention's `validate-no-mongo.mjs`. **The exception list is the interesting part**, because Syra contains the sharpest version of the tension these guards create.

### A guard that forbids Mongo, inside a repo whose guard forbids naming Mongo

`env.ts` **refuses** any `DATABASE_URL` that is not `postgres(ql)://`, and it checks the *scheme* rather than trusting `z.string().url()` precisely because zod accepts `mongodb+srv://`. A leftover Mongo connection string is the one wrong value this cutover could produce — straight out of a copy-paste from the old task definition. `env.productionBoot.test.ts` proves that refusal, and a second test proves the refusal does not print the *password* of the value it rejects.

The test cannot prove a value is rejected without **containing** that value. The comments cannot justify a scheme check without naming what defeats a shape check. Deleting any of them to satisfy this scanner would delete the protection or the reasoning behind it.

### Eight entries, one line at a time — not one pattern per file

A file-level excuse is a hole: `env.productionBoot.test.ts` would then accept a real connection string sitting beside its fixtures. There is a test for exactly that (*"an excused file still fails on a line the exceptions do not cover"*), and the same property is verified against the real tree below.

The `quality.yml` entry keeps the paragraph explaining why `mongoose` is in `node_modules` at all — an **unsatisfied optional peer** of `@oxyhq/crowdsource-app`, not a dependency. Re-verified here: `bun.lock` carries no `mongoose` resolution entry. Without that paragraph the next person re-investigates it from scratch.

### Verification

| | result |
|---|---|
| clean tree | exit 0, **8 of 8** exceptions honoured |
| live `mongodb://` added to `env.ts` — an **excused** file | **exit 1**, `packages/backend/src/config/env.ts:234: carries a mongodb:// connection string` |
| restored | exit 0 |

That middle row is the point: the exceptions are **per-line, not per-file**.

Self-test **34 of 34**. Floors measured: 6 manifests, 763 source files, 2199 lockfile resolutions; floors 3 / 400 / 900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)