### PR TITLE
docs(db): the post-genesis ordering gate is live now, not waiting on 0025

### DIFF
--- a/packages/backend/src/db/__tests__/gates.test.ts
+++ b/packages/backend/src/db/__tests__/gates.test.ts
@@ -4078,13 +4078,15 @@ describe('deploy-phase ordering (post-genesis)', () => {
     // construction (see migrate.ts); this only holds every migration that
     // lands AFTER it to the invariant a real staged rollout needs.
     //
-    // That post-genesis window is EMPTY right now, and legitimately so: the
-    // boundary froze at the newest migration the cutover applied, so this
-    // becomes load-bearing with `0025` and every migration after it. Which is
-    // exactly why the boundary must never be advanced again — an advanced
-    // boundary would keep this window empty permanently and this test would go
-    // on passing. The three synthetic tests above keep the CHECKER honest in the
-    // meantime; the frozen-boundary pin below keeps the INPUT honest.
+    // That post-genesis window WAS empty at cutover, because the boundary froze
+    // at the newest migration the cutover applied. It is not empty any more:
+    // `0025_powerful_famine` and `0026_supreme_hardball` landed on 2026-08-09,
+    // so this test now holds real migrations to the invariant rather than
+    // passing vacuously. Do not read the emptiness as a reason to delete it —
+    // that reading is what an advanced boundary would manufacture permanently,
+    // which is exactly why the boundary must never be advanced again. The three
+    // synthetic tests above keep the CHECKER honest; the frozen-boundary pin
+    // below keeps the INPUT honest.
     const folder = findMigrationsFolder();
     const journal = readJournal(folder);
     const { phases, problems } = readMigrationPhases(


### PR DESCRIPTION
## This gate was flagged for deletion. It should not be deleted.

The theory was that the genesis series closing left
`findPostGenesisPhaseOrderingViolations` inspecting an **empty queue** — green
forever, the "cannot distinguish success from failure" shape. It is the opposite,
and the reason that reading is available is **a comment that went stale**.

## What is actually true

`LAST_GENESIS_MIGRATION_TAG` is `0024_ambitious_xorn` and is **frozen**, with a
pin that hard-codes the value a second time so it cannot compare itself to
itself. The journal now holds 27 entries — **`0025_powerful_famine` and
`0026_supreme_hardball` landed 2026-08-09**, after the 2026-08-08 cutover. So the
gate inspects a real two-entry tail today.

The comment still said:

> That post-genesis window is EMPTY right now … this becomes load-bearing with
> `0025` and every migration after it.

Both halves are now false, and anyone reading it concludes the test is vacuous —
which is exactly the conclusion that reached me. Corrected to state what is true,
and to say plainly that emptiness is **not** a reason to delete it, because an
advanced boundary is what would manufacture that emptiness permanently.

## Mutation-tested rather than argued

Flipping `0025` to `post` (leaving `0026` `pre`) turns the gate **red**, and it
names the offending pair:

```
0026_supreme_hardball is "pre" but is ordered behind "0025_powerful_famine" ("post").
```

**87 pass / 1 fail** under the mutation; **88 pass / 0 fail** restored. The
migration was restored from a pristine copy taken before the edit — not
`git checkout`, which would have reverted my own uncommitted work in the same
file — and the marker for this comment change was re-asserted afterwards.

Full backend suite: **1853 pass / 0 fail** (a single `fpcalc … Empty fingerprint`
failure appeared on one run and cleared on re-run; it is an audio-fingerprint
binary flake, unrelated).

## Scope

Comment only — no code, no test logic. The deletion this prevents would have
removed a live gate protecting deploy-phase ordering for every migration from
`0025` onward.

Follows #97, which is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)