### PR TITLE
fix(deploy): desiredCount 0 is a state, so release the image and skip only what is not real

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -120,10 +120,37 @@ if [[ -z "$current_task_definition" ]]; then
 fi
 
 service_desired_count="$(jq -r '.services[0].desiredCount // empty' <<<"$service_json")"
-if ! [[ "$service_desired_count" =~ ^[0-9]+$ ]] ||
-   (( service_desired_count < 1 )); then
-  echo "::error::ECS service $APP must have a positive desiredCount before deployment (current: ${service_desired_count:-missing}). Scale the service up explicitly before retrying."
+# Split from the zero check below on purpose, and the split is the safety
+# property. A non-numeric or ABSENT desiredCount is ECS declining to tell us the
+# answer — throttled, malformed, changed — and treating that as a deliberate hold
+# turns an API failure into a silent no-op deploy that exits 0. Absence is not
+# zero. Note the order matters as much as the test: `(( "" < 1 ))` is TRUE in
+# bash, so an unreadable value reaching the zero branch would take the
+# held-down-carry-on path.
+if ! [[ "$service_desired_count" =~ ^[0-9]+$ ]]; then
+  echo "::error::ECS service $APP reported a non-numeric desiredCount (${service_desired_count:-missing}); refusing to deploy."
   exit 1
+fi
+
+# desiredCount 0 is a STATE, not an error. A service is parked at zero for the
+# whole of a store cutover on purpose, and refusing the deploy there is
+# self-sealing: the image that would make the service bootable again is the image
+# the refusal blocks, so the parked state can never be left.
+#
+# What this must NOT become is a green deploy that reports a release nobody got.
+# So the release still does everything that is real at zero capacity — it runs
+# the PRE one-shot, registers the revision, and POINTS THE SERVICE AT IT — and
+# then stops at the steps that are not real, saying so loudly.
+#
+# Pointing the service is the half that is easy to leave out and expensive to
+# skip. `register-task-definition` alone does not repoint anything: ECS launches
+# whatever revision the SERVICE is configured with, so a later `desiredCount`
+# bump would start the OLD image, and this script derives its next render from
+# `services[0].taskDefinition` (see `current_task_definition` above), so every
+# subsequent deploy would keep building on the stale revision too.
+zero_capacity_deploy=false
+if (( service_desired_count < 1 )); then
+  zero_capacity_deploy=true
 fi
 
 task_definition_file="$(mktemp)"
@@ -526,10 +553,39 @@ if ! aws ecs update-service \
   }' \
   >/dev/null; then
   echo "::error::ECS rejected the service update; restoring the previous task definition defensively."
+  # At zero capacity there is nothing to restore TO: no task is running, so the
+  # "previous image" is not serving either, and rollback_service would sit in
+  # wait_for_service_rollout until MAX_WAIT_SECS waiting for a steady state that
+  # cannot arrive. Say that instead of spending twenty minutes proving it.
+  if [[ "$zero_capacity_deploy" == "true" ]]; then
+    echo "::error::$APP is at desiredCount=0, so no rollback was attempted: nothing is running to roll back from, and the service is still pointed at $current_task_definition."
+    exit 1
+  fi
   if ! rollback_service; then
     echo "::error::The defensive rollback also failed; manual intervention is required."
   fi
   exit 1
+fi
+
+# Everything real at zero capacity is now done: the PRE one-shot ran, the
+# revision is registered, and the service points at it. What follows is not real
+# — a rollout at desiredCount 0 reaches "COMPLETED" with zero running tasks,
+# which is exactly the plausible green this stops at; a smoke check measures the
+# hold rather than the image; and the POST one-shot is this repo's `post`
+# migration, which drops and narrows and has no healthy image to confirm it.
+#
+# The POST line is NOT boilerplate copied from a sibling: in Syra
+# POST_DEPLOY_TASK_COMMAND_JSON *is* `migrate.js --phase=post`, so an operator
+# who scales up later has a pending schema change and no other way to know.
+if [[ "$zero_capacity_deploy" == "true" ]]; then
+  echo "::warning::NO ROLLOUT PERFORMED: ECS service $APP is at desiredCount=0 and is running ZERO tasks."
+  echo "::warning::NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: $new_task_definition"
+  echo "::warning::NO ROLLOUT PERFORMED: image $IMAGE_URI is NOT live and $APP is serving NOTHING. This deploy released nothing to users."
+  if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+    echo "::warning::NO ROLLOUT PERFORMED: the post-deploy one-shot was NOT run — for this repo that is the 'post' migration phase, which drops and narrows and has no healthy image to confirm first. It applies on the first ordinary deploy after the service is scaled up, not before."
+  fi
+  echo "::warning::NO ROLLOUT PERFORMED: to run this image, raise desired_count in oxy-infra terraform and deploy again."
+  exit 0
 fi
 
 echo "Deploying immutable image $IMAGE_URI with task definition $new_task_definition"

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -64,6 +64,12 @@ aws() {
     --argjson desired "$DEPLOY_TEST_SERVICE_DESIRED_COUNT" \
     '.services[0].desiredCount = $desired' \
     <<<"$service_json")"
+  # `absent-desired-count` DELETES the key rather than passing a sentinel. A
+  # sentinel is a value the script can compare; the case under test is a field
+  # ECS did not report at all, so a sentinel would pass for the wrong reason.
+  if [[ "${DEPLOY_TEST_DELETE_DESIRED_COUNT:-false}" == "true" ]]; then
+    service_json="$(jq 'del(.services[0].desiredCount)' <<<"$service_json")"
+  fi
 
   case "$1 $2" in
     "ecs describe-services")
@@ -276,7 +282,19 @@ aws() {
 }
 export -f aws
 
+# Vacuity floor. On success this suite prints ONE line, so a traversal that
+# silently stopped after two cases is indistinguishable from a full green run --
+# and every guarantee below would read as verified while never having executed.
+# A `set -e` abort mid-file exits non-zero, but an early `return` from a helper,
+# a case list truncated by a bad merge, or a rewrite that drops cases does not.
+#
+# Raise this with the case count; lower it ONLY alongside a deletion you can
+# name. A floor quietly adjusted to match whatever ran is not a floor.
+cases_run=0
+MINIMUM_CASES=14
+
 run_release() {
+  cases_run=$((cases_run + 1))
   local case_name="$1"
   local expect_success="$2"
   # The pre-deploy one-shot command, as a JSON string array. Empty means the
@@ -330,7 +348,10 @@ run_release() {
     # `["reconcile"]` is a generic fixture: most cases care only that the post
     # slot runs in the right place in the sequence, not what it runs. A case
     # that IS about the command sets DEPLOY_TEST_POST_COMMAND.
-    POST_DEPLOY_TASK_COMMAND_JSON="${DEPLOY_TEST_POST_COMMAND:-[\"reconcile\"]}"
+    # `-` rather than `:-` on purpose: `:-` substitutes the default for an EMPTY
+    # value as well as an unset one, so no case could express "this release has
+    # no post-deploy task at all", which is a state the script branches on.
+    POST_DEPLOY_TASK_COMMAND_JSON="${DEPLOY_TEST_POST_COMMAND-[\"reconcile\"]}"
   )
   if [[ "$inject_internal_metrics" == "true" ]]; then
     release_environment+=(
@@ -552,13 +573,86 @@ diff -u \
   "$test_directory/migration-success/expected.log" \
   "$test_directory/migration-success/aws.log"
 
-run_release zero-desired-count false '' false 0 false 0
+# syra is not parked today, but the guard this replaces is the one that blocked
+# every other repo's cutover: a service held at desiredCount 0 could not land the
+# image that would make it bootable again.
+#
+# The exact log is the whole assertion, and what it does NOT contain matters more
+# than what it does. Compare `migration-success` directly above -- the SAME
+# release at desired=1 -- where `service:` is followed by `smoke` and the POST
+# task. Here the log must STOP at `service:`, because neither is real when
+# nothing is running: a smoke check measures the hold rather than the image, and
+# the POST task is this repo's `post` migration, which drops and narrows with no
+# healthy image to confirm it. `diff -u` fails if either appears.
+DEPLOY_TEST_POST_COMMAND="$workflow_post_command"
+export DEPLOY_TEST_POST_COMMAND
+run_release zero-desired-count true "$workflow_pre_command" false 0 false 0
+unset DEPLOY_TEST_POST_COMMAND
+printf '%s\n' \
+  "task:$(jq -r 'join(" ")' <<<"$workflow_pre_command")" \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=0' \
+  >"$test_directory/zero-desired-count/expected.log"
+diff -u \
+  "$test_directory/zero-desired-count/expected.log" \
+  "$test_directory/zero-desired-count/aws.log"
+# `service:...deploy-test:2:...` is the REPOINT, and it is the half that is easy
+# to drop: registering a revision does not point the service at it, so without
+# this line a later scale-up would launch the OLD image and every subsequent
+# deploy would render from the stale revision.
 grep -F \
-  "must have a positive desiredCount before deployment (current: 0)" \
+  "service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=0" \
+  "$test_directory/zero-desired-count/aws.log" \
+  >/dev/null
+grep -F \
+  "NO ROLLOUT PERFORMED: ECS service deploy-test is at desiredCount=0" \
   "$test_directory/zero-desired-count/output.log" \
   >/dev/null
-if [[ -s "$test_directory/zero-desired-count/aws.log" ]]; then
-  echo "Zero-capacity service reached a mutating AWS call." >&2
+grep -F \
+  "NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: arn:aws:ecs:test:task-definition/deploy-test:2" \
+  "$test_directory/zero-desired-count/output.log" \
+  >/dev/null
+# Syra-specific, and the reason this case differs from the other four repos'.
+grep -F \
+  "NO ROLLOUT PERFORMED: the post-deploy one-shot was NOT run" \
+  "$test_directory/zero-desired-count/output.log" \
+  >/dev/null
+# The success line of an ordinary release. If it ever appears here, a reader of
+# the workflow log six weeks from now cannot tell this run apart from one that
+# actually shipped, which is the failure this whole case exists to prevent.
+if grep -qF \
+  "ECS rollout reached a healthy steady state" \
+  "$test_directory/zero-desired-count/output.log"; then
+  echo "A zero-capacity release claimed a healthy rollout it never performed." >&2
+  exit 1
+fi
+
+# A release with NO post-deploy task must not claim one was skipped. Without
+# this, the warning could be printed unconditionally and read as true.
+DEPLOY_TEST_POST_COMMAND="" \
+  run_release zero-desired-count-no-post true "$workflow_pre_command" false 0 false 0
+if grep -qF \
+  "the post-deploy one-shot was NOT run" \
+  "$test_directory/zero-desired-count-no-post/output.log"; then
+  echo "A release with no post-deploy task claimed one was skipped." >&2
+  exit 1
+fi
+
+# ABSENCE IS NOT ZERO, and the ORDER of the two checks is what enforces it:
+# `(( "" < 1 ))` is TRUE in bash, so an unreadable count reaching the zero branch
+# would take the held-down-carry-on path and exit 0 on an API failure. Today the
+# property holds only because the numeric test runs first -- which is exactly why
+# it needs a test that holds it deliberately.
+#
+# The key is DELETED rather than set to a sentinel: a sentinel is a value the
+# script can compare, and the case under test is a field that is not there.
+DEPLOY_TEST_DELETE_DESIRED_COUNT=true \
+  run_release absent-desired-count false '' false 0 false 0
+grep -F \
+  "reported a non-numeric desiredCount" \
+  "$test_directory/absent-desired-count/output.log" \
+  >/dev/null
+if [[ -s "$test_directory/absent-desired-count/aws.log" ]]; then
+  echo "A service with an unreadable desiredCount reached a mutating AWS call." >&2
   exit 1
 fi
 
@@ -646,4 +740,10 @@ grep -F \
   "$test_directory/smoke-no-rollback-failure/output.log" \
   >/dev/null
 
-echo "Deployment script transaction tests passed."
+if (( cases_run < MINIMUM_CASES )); then
+  echo "ASSERTION FAILED: only $cases_run release cases ran, expected at least $MINIMUM_CASES." >&2
+  echo "The suite exited green without executing everything it claims to check." >&2
+  exit 1
+fi
+
+echo "Deployment script transaction tests passed ($cases_run release cases)."


### PR DESCRIPTION
> **Preventive, not unblocking.** `syra` is at `desired=2 running=2`. This is the same guard that blocked `alia` and `crowdsource` all day; both are fixed and both deployed successfully once it was gone. Syra is the last repo carrying it.

## The defect

`deploy-ecs-image.sh` refused any deploy against a service at `desiredCount 0` — **L122**, before `register-task-definition` (L467) and before the PRE one-shot. Self-sealing: the image that would make a parked service bootable again is the image the refusal blocks.

## The change

At zero the release runs the PRE one-shot, registers the revision, and **points the service at it** with `--desired-count 0`, then stops:

```
::warning::NO ROLLOUT PERFORMED: ECS service syra is at desiredCount=0 and is running ZERO tasks.
::warning::NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: <arn>
::warning::NO ROLLOUT PERFORMED: image <uri> is NOT live and syra is serving NOTHING. This deploy released nothing to users.
::warning::NO ROLLOUT PERFORMED: the post-deploy one-shot was NOT run — for this repo that is the 'post' migration phase, ...
::warning::NO ROLLOUT PERFORMED: to run this image, raise desired_count in oxy-infra terraform and deploy again.
```

**Pointing the service is the load-bearing half.** `register-task-definition` repoints nothing — ECS launches whatever revision the *service* carries. Skipping `update-service` registers a revision nothing will ever launch, pins every future deploy to the stale base (this script renders its next release from `services[0].taskDefinition`), and starts the **old image** on scale-up: the fix reintroducing the failure it exists to fix.

What is skipped is what is not real at zero — the rollout (which reaches `COMPLETED` with zero running tasks, the plausible green), the smoke check (which would measure the hold rather than the image), and the POST one-shot.

## The `post` line is Syra-specific and is not copied from a sibling

In this repo `POST_DEPLOY_TASK_COMMAND_JSON` **is** `migrate.js --phase=post --target-database=syra` on the ordinary-release path. So an operator who scales up later has a pending schema change and no other way to learn it.

The other four repos needed no such line, and I checked rather than assumed: CrowdSource's `post` phase is separate machinery (already covered there), and **Alia, Allo and Homiio set a post-deploy task but have no `post` phase at all**. This is the one repo where that question reopens on its merits.

## Absence is not zero — and the ORDER is the safety property

A missing or non-numeric `desiredCount` stays a hard error. The order matters as much as the test: **`(( "" < 1 ))` is TRUE in bash**, so an unreadable count reaching the zero branch would take the held-down-carry-on path and exit 0 on a throttled or malformed `describe-services`. The `order-swapped` mutation below is what holds that.

`absent-desired-count` models absence by **deleting the key**, never a sentinel — a sentinel is a value the script can compare, and the case under test is a field that is not there.

## Five repos, five migration architectures

Under a commit message asserting one shared script:

| repo | mechanism | `post` phase |
|---|---|---|
| Alia | `MIGRATION_PHASE` env, one call | no |
| Allo | `MIGRATION_TASK_COMMAND_JSON`, **no phase flag at all** | no |
| Homiio | `MIGRATION_TASK_COMMANDS_JSON`, array of `{label,command}`, `pre` only | no |
| CrowdSource | two-phase, on its **own** task definition + container | yes |
| **Syra** | `PRE_`/`POST_DEPLOY_TASK_COMMAND_JSON` bracketing the rollout, **no `RUN_MIGRATIONS`** | **yes** |

Even the harness signatures differ — Syra's `run_release` third positional is a JSON command string rather than a boolean. A diff ported from any one of these would have been wrong in the other four.

## Verification

Baseline green on `f679573` before editing. Mutation-tested, each confirmed **applied and semantically live**:

| mutation | result |
|---|---|
| rollout, smoke and POST run at zero | **RED** |
| skip without repointing the service | **RED** |
| weaken the `NO ROLLOUT PERFORMED` message | **RED** |
| unreadable `desiredCount` treated as zero | **RED** |
| drop the post-migration sentence | **RED** |
| claim POST was skipped when there was none | **RED** |
| numeric and zero checks swapped in order | **RED** |
| the vacuity floor's counter never increments | **RED** |

Restored to ship-intended bytes after each (`md5 855bbbb26ee8`), suite green on the restored file, `shellcheck` clean on both.

## Also: the vacuity floor this harness lacked

On success the suite printed one line, so a traversal that stopped early was indistinguishable from a full green run. `MINIMUM_CASES=14` now guards it — **and it caught my own wrong guess immediately**, refusing a green when I set it to 16 against a real count of 14. The floor is itself mutation-tested (counter never increments → red), because a floor that cannot fail is not a floor.

One supporting change: `${DEPLOY_TEST_POST_COMMAND:-…}` → `${DEPLOY_TEST_POST_COMMAND-…}`. `:-` substitutes the default for an *empty* value as well as an unset one, so no case could express "this release has no post-deploy task" — a state the script branches on, and the one the `post-warning-unconditional` mutation needs in order to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)