### PR TITLE
fix(deploy): apply the post phase at desiredCount=0 instead of skipping it

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -567,22 +567,64 @@ if ! aws ecs update-service \
   exit 1
 fi
 
-# Everything real at zero capacity is now done: the PRE one-shot ran, the
-# revision is registered, and the service points at it. What follows is not real
-# — a rollout at desiredCount 0 reaches "COMPLETED" with zero running tasks,
-# which is exactly the plausible green this stops at; a smoke check measures the
-# hold rather than the image; and the POST one-shot is this repo's `post`
-# migration, which drops and narrows and has no healthy image to confirm it.
+# The ROLLOUT is the only thing here that would be a lie, so it is the only
+# thing skipped: a rollout at desiredCount 0 reaches "COMPLETED" with zero
+# running tasks, which is exactly the plausible-looking green this estate keeps
+# getting caught by. The post-deploy one-shot is neither a lie nor optional.
 #
-# The POST line is NOT boilerplate copied from a sibling: in Syra
-# POST_DEPLOY_TASK_COMMAND_JSON *is* `migrate.js --phase=post`, so an operator
-# who scales up later has a pending schema change and no other way to know.
+# It runs as its OWN ECS task — run_one_shot_command calls `ecs run-task`, not
+# the service — so the service's capacity has nothing to do with it. The
+# pre-rollout run above is the positive control: it launches and succeeds at
+# this same desiredCount=0, by the same mechanism, on the same revision.
+#
+# And zero capacity is the one condition under which `post` is unconditionally
+# SAFE. A `post` statement is defined as one that breaks a write the previous
+# image performs; with zero tasks running there is no previous image, and no
+# such write. The rule that defers it has no subject here.
+#
+# Deferring it anyway DEADLOCKS the service. @oxyhq/db records migration
+# progress as a high-water mark and cannot skip a hole (see planMigrationRun in
+# its migrate/phases), so the NEXT release's `pre` run is BLOCKED behind the
+# unapplied `post` one and that deploy fails at its migration step — before ever
+# reaching the post-deploy task that was supposed to catch up. So "it applies on
+# the first deploy after the service is scaled up" is FALSE: every deploy in
+# between fails, and a human has to clear it with a `--phase=all` one-shot.
+# Measured in alia, which sat parked at zero: four consecutive merges deployed
+# red behind an unapplied 0016 while every one of their PRs was green.
 if [[ "$zero_capacity_deploy" == "true" ]]; then
+  if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
+    # Skipped, and named rather than silently omitted. Every smoke script in
+    # this estate asserts HTTP against the service's own public origin, so with
+    # zero running tasks it can only fail on a target group with no healthy
+    # member, or "pass" against something in front that is not this image.
+    # Neither outcome measures the release, and a rollback over either is
+    # meaningless when nothing is serving.
+    echo "::warning::NO ROLLOUT PERFORMED: post-deploy smoke checks were SKIPPED ($POST_DEPLOY_SMOKE_SCRIPT). With zero running tasks they cannot reach this image, so they could only fail or mislead."
+  fi
+
+  if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+    if ! run_one_shot_command \
+      "Post-deploy reconciliation" \
+      "$POST_DEPLOY_TASK_COMMAND_JSON"; then
+      # No rollback, for the same reason update-service does not roll back here:
+      # nothing is running to roll back FROM, and rollback_service would sit in
+      # wait_for_service_rollout until MAX_WAIT_SECS waiting for a steady state
+      # that cannot arrive.
+      echo "::error::Post-deploy reconciliation failed at desiredCount=0. $APP is left pointed at $new_task_definition with the post phase UNAPPLIED, and no rollback was attempted because nothing is running to roll back from. Resolve it before the next deploy: a later pre-phase migration queued behind an unapplied post one is refused, which fails that deploy at its migration step."
+      exit 1
+    fi
+  fi
+
   echo "::warning::NO ROLLOUT PERFORMED: ECS service $APP is at desiredCount=0 and is running ZERO tasks."
   echo "::warning::NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: $new_task_definition"
   echo "::warning::NO ROLLOUT PERFORMED: image $IMAGE_URI is NOT live and $APP is serving NOTHING. This deploy released nothing to users."
-  if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
-    echo "::warning::NO ROLLOUT PERFORMED: the post-deploy one-shot was NOT run — for this repo that is the 'post' migration phase, which drops and narrows and has no healthy image to confirm first. It applies on the first ordinary deploy after the service is scaled up, not before."
+  # Which phases ran, stated rather than implied. A reader of this log has to be
+  # able to tell a schema that is fully migrated from one that is half migrated,
+  # and "NO ROLLOUT PERFORMED" is silent about both.
+  if [[ -n "$PRE_DEPLOY_TASK_COMMAND_JSON" ]] && [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+    echo "::warning::NO ROLLOUT PERFORMED: MIGRATIONS DID RUN — the pre-deploy one-shot ran before the repoint and the post-deploy one-shot after it. The schema is fully migrated; only the rollout was skipped."
+  elif [[ -n "$PRE_DEPLOY_TASK_COMMAND_JSON" ]]; then
+    echo "::warning::NO ROLLOUT PERFORMED: MIGRATIONS DID RUN — the pre-deploy one-shot ran before the repoint. This release carries no post-deploy one-shot."
   fi
   echo "::warning::NO ROLLOUT PERFORMED: to run this image, raise desired_count in oxy-infra terraform and deploy again."
   exit 0

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -580,10 +580,30 @@ diff -u \
 # The exact log is the whole assertion, and what it does NOT contain matters more
 # than what it does. Compare `migration-success` directly above -- the SAME
 # release at desired=1 -- where `service:` is followed by `smoke` and the POST
-# task. Here the log must STOP at `service:`, because neither is real when
-# nothing is running: a smoke check measures the hold rather than the image, and
-# the POST task is this repo's `post` migration, which drops and narrows with no
-# healthy image to confirm it. `diff -u` fails if either appears.
+# task. Here `smoke` must be ABSENT and the POST task PRESENT.
+#
+# THE ASYMMETRY, because an earlier version of this case got it wrong: it
+# asserted the log STOPS at `service:`, excluding the post one-shot ALONG WITH
+# the smoke check, on the reasoning that "neither is real when nothing is
+# running". That is true of the smoke check and false of the one-shot.
+#
+#   - A smoke script asserts HTTP against the service's own origin. Zero tasks,
+#     so it can only fail on an empty target group or "pass" against something
+#     that is not this image. Not real. Skipped.
+#   - `run_one_shot_command` calls `ecs run-task`: its own task, on the new
+#     revision, independent of the service. The pre-phase line directly above in
+#     this same expected log is the positive control -- it launches and succeeds
+#     at desired=0 by exactly that mechanism. Real. Run.
+#
+# Excluding the one-shot DEADLOCKS a parked service: it is the `post` migration
+# phase, @oxyhq/db's ledger is a high-water mark, and the next release's `pre`
+# run is refused behind an unapplied `post` one -- so the deploy that was
+# supposed to "catch up later" fails at its migration step instead. Measured in
+# alia: four consecutive merges deployed red behind an unapplied 0016.
+#
+# In Syra POST_DEPLOY_TASK_COMMAND_JSON *is* `migrate.js --phase=post`, so the
+# expected log below names it verbatim: this case reads as the post migration
+# running, because that is exactly what it is.
 DEPLOY_TEST_POST_COMMAND="$workflow_post_command"
 export DEPLOY_TEST_POST_COMMAND
 run_release zero-desired-count true "$workflow_pre_command" false 0 false 0
@@ -591,6 +611,7 @@ unset DEPLOY_TEST_POST_COMMAND
 printf '%s\n' \
   "task:$(jq -r 'join(" ")' <<<"$workflow_pre_command")" \
   'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=0' \
+  "task:$(jq -r 'join(" ")' <<<"$workflow_post_command")" \
   >"$test_directory/zero-desired-count/expected.log"
 diff -u \
   "$test_directory/zero-desired-count/expected.log" \
@@ -611,9 +632,19 @@ grep -F \
   "NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: arn:aws:ecs:test:task-definition/deploy-test:2" \
   "$test_directory/zero-desired-count/output.log" \
   >/dev/null
-# Syra-specific, and the reason this case differs from the other four repos'.
+# The smoke script is skipped, and SAID to be skipped. An omitted line and a
+# deliberate skip look identical in a log, which is how the post phase went
+# missing in the first place.
+if grep -qF 'smoke' "$test_directory/zero-desired-count/aws.log"; then
+  echo "A zero-capacity release ran smoke checks against a service with no tasks." >&2
+  exit 1
+fi
 grep -F \
-  "NO ROLLOUT PERFORMED: the post-deploy one-shot was NOT run" \
+  "post-deploy smoke checks were SKIPPED" \
+  "$test_directory/zero-desired-count/output.log" \
+  >/dev/null
+grep -F \
+  "MIGRATIONS DID RUN — the pre-deploy one-shot ran before the repoint and the post-deploy one-shot after it" \
   "$test_directory/zero-desired-count/output.log" \
   >/dev/null
 # The success line of an ordinary release. If it ever appears here, a reader of
@@ -626,14 +657,20 @@ if grep -qF \
   exit 1
 fi
 
-# A release with NO post-deploy task must not claim one was skipped. Without
-# this, the warning could be printed unconditionally and read as true.
+# A release with NO post-deploy task must say so POSITIVELY rather than claim a
+# post phase ran. Asserted as a present string, not an absent one: the previous
+# form asserted the absence of a warning, which would also pass if the whole
+# summary block were deleted.
 DEPLOY_TEST_POST_COMMAND="" \
   run_release zero-desired-count-no-post true "$workflow_pre_command" false 0 false 0
+grep -F \
+  "MIGRATIONS DID RUN — the pre-deploy one-shot ran before the repoint. This release carries no post-deploy one-shot." \
+  "$test_directory/zero-desired-count-no-post/output.log" \
+  >/dev/null
 if grep -qF \
-  "the post-deploy one-shot was NOT run" \
+  "the post-deploy one-shot after it" \
   "$test_directory/zero-desired-count-no-post/output.log"; then
-  echo "A release with no post-deploy task claimed one was skipped." >&2
+  echo "A release with no post-deploy task claimed one ran." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## The defect

The zero-capacity early `exit 0` in `.github/scripts/deploy-ecs-image.sh` sat **above** the post-deploy one-shot. At `desiredCount=0` the deploy therefore ran the pre phase, registered the revision, repointed the service — and **skipped the post phase, exiting 0**. The comment above it claimed the migration had run, which is true of one phase and false of the other.

## Why deferring `post` does not work

`@oxyhq/db` records migration progress as a **high-water mark and cannot skip a hole** (`planMigrationRun`, `migrate/phases`). So the next release's `pre` run is *refused* behind the unapplied `post` one, and **that** deploy fails at its migration step — before ever reaching the post-deploy task that was supposed to catch up.

Measured in `alia`, parked at zero since it was provisioned: `0016` is `post`, with `0017` and `0018` `pre` behind it. Four consecutive merges deployed red while every one of their PRs was green. Clearing it took a manual `--phase=all` one-shot.

So "it applies on the first deploy after the service is scaled up" is **false** — every deploy in between fails.

## Why running it is correct

Zero capacity is the one condition under which `post` is unconditionally **safe**. A `post` statement is defined as one that breaks a write the previous image performs — with zero tasks running there is no previous image and no such write.

It is also **reachable**: `run_one_shot_command` calls `ecs run-task`, its own task on the new revision, independent of the service. The pre run at this same `desiredCount=0` is the positive control.

## The change

The rollout stays skipped — that is the only part that would be a lie. Beyond that:

- the post-deploy one-shot **runs**, after the repoint, preserving the relative order the at-capacity path has;
- a failure there **exits 1 without `rollback_service`**, which would otherwise sit in `wait_for_service_rollout` for `MAX_WAIT_SECS` waiting for a steady state that cannot arrive, and reports that the service is left on the new revision with the post phase unapplied;
- `POST_DEPLOY_SMOKE_SCRIPT` is **skipped and named as skipped**. Every smoke script in this estate asserts HTTP against the service's own origin, so at zero tasks it can only fail on an empty target group or "pass" against something that is not this image;
- the warnings **state which phases ran**, instead of being silent about migrations while shouting about the rollout.

## The test

The existing harness case **encoded the bug as correct behaviour**: it asserted the log stops after the repoint, excluding the post one-shot *along with* the smoke check, on the reasoning that "neither is real when nothing is running". That is true of the smoke check and false of the one-shot — the case now asserts that asymmetry.

**Mutation-tested** (what the gate reports if its subject vanishes): restoring the script to `origin/main` makes the suite go red with the post one-shot missing from the expected log.

`shellcheck` clean.
