### PR TITLE
ci: gate the AGENTS.md budget so it cannot grow back

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Guard against MongoDB returning
         run: bun run validate:no-mongo
 
+      # AGENTS.md is prepended to EVERY agent session, so its bytes are paid on
+      # every task forever, and it grows by accretion — one reasonable paragraph
+      # at a time, invisible per-commit. Nothing breaks when it grows, which is
+      # why a gate rather than a convention. Reads the tracked file listing only.
+      - name: Guard the AGENTS.md budget
+        run: bun run validate:agents-md
+
       # shared-types and the SDK are consumed as built output (dist/lib) by the
       # apps, so their typechecks — and the apps' — need them built first, same
       # order the deploy workflows use.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Syra
 
+> **Budget: under 12 KB**, enforced by `scripts/check-agents-md-size.mjs`
+> (`bun run validate:agents-md`). It is prepended to EVERY agent session, so its
+> bytes are paid on every task forever, and it grows by accretion — one
+> reasonable paragraph at a time, invisible per-commit. An addition that pushes
+> it over is paid for in the SAME edit: compress something, or move it to
+> `docs/` and leave a pointer.
+
 > Org-wide engineering standards (TypeScript, React, naming, error handling, security, testing, git, bun) live at <https://github.com/OxyHQ/engineering/blob/main/AGENTS.md> and are not repeated here. This file holds ONLY Syra-specific content.
 
 ## Monorepo Structure

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "bun run --filter '*' test",
     "lint": "bun run --filter '*' lint",
     "validate:no-mongo": "bun ./scripts/validate-no-mongo.mjs && bun ./scripts/test-validate-no-mongo.mjs",
+    "validate:agents-md": "bun ./scripts/check-agents-md-size.mjs && bun ./scripts/test-check-agents-md-size.mjs",
     "clean": "bun run --filter '*' clean && rm -rf node_modules",
     "install:all": "bun install",
     "start:frontend": "bun run --filter '@syra/frontend' start",

--- a/scripts/check-agents-md-size.mjs
+++ b/scripts/check-agents-md-size.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+
+/**
+ * `AGENTS.md` is loaded into EVERY agent session in this repository, so a byte
+ * added here is a byte paid for on every task forever. This keeps it bounded.
+ *
+ * ## Why a gate rather than a rule somebody remembers
+ *
+ * Measured: between 2026-06 and 2026-08 the root `AGENTS.md` went from ~10 KB to
+ * 478 KB — 6,866 lines, 64 sections, 44 of them a per-issue design note added by
+ * the feature branch that closed the issue. Thirty-one of those sections already
+ * said "Full reference: `docs/<x>.md`" and then restated the doc anyway.
+ *
+ * Nothing was wrong with any single one of those diffs. Each added ~100 lines of
+ * true, carefully-written prose about work that had just landed, and each was
+ * reviewed as part of a feature PR whose subject was the feature. The growth is
+ * invisible per-commit and only exists in the sum, which is exactly the shape a
+ * gate catches and a convention does not.
+ *
+ * So this is a budget, not a lint. Adding to `AGENTS.md` is allowed; it just has
+ * to be paid for in the same edit, by compressing something or by moving the
+ * material to `docs/` and leaving a pointer.
+ *
+ * ## The two checks
+ *
+ *   1. **Size.** Each tracked `AGENTS.md` against its budget. The root file is
+ *      the loaded-everywhere one and gets the larger allowance; a nested one is
+ *      a DELTA on top of its parents and gets very little, because a child that
+ *      needs 8 KB is usually repeating a parent.
+ *
+ *   2. **Per-issue headings.** A heading naming an issue number (`## Foo (#57)`)
+ *      is per-issue documentation by definition, and per-issue documentation is
+ *      what `docs/` is for. This is the actual mechanism of the 478 KB — it
+ *      names it directly, so the failure message can say where the material
+ *      goes instead of only saying "too big". Issue numbers in BODY text are
+ *      fine and common ("#57 owns the offer"); only headings fire.
+ *
+ * ## Bytes, not lines, and one bound rather than two
+ *
+ * The widely-repeated "keep AGENTS.md under 150 lines" figure is an UNCITED
+ * blog claim; the one published measurement (arXiv 2601.20404, 10 repos /
+ * 124 PRs) reports the opposite direction — having an AGENTS.md at all reduced
+ * output tokens ~17-20% and wall-clock ~29%. So the justification here is not a
+ * study, it is arithmetic: this file is prepended to every session, so its
+ * BYTES are what gets paid for, and bytes are what this measures. A second
+ * line-count bound would be a second representation of one fact that could
+ * disagree with the first, which is the failure this repository's own house
+ * invariants warn about.
+ *
+ * Both checks carry a vacuity floor: a `git ls-files` that returns nothing, or a
+ * repository that has lost its root `AGENTS.md`, reports a clean tree under a
+ * naive implementation. `scripts/test-check-agents-md-size.mjs` mutation-tests
+ * every rule and both floors.
+ */
+
+import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const KIB = 1024;
+
+/** The root file is loaded on every task in the repo. */
+export const ROOT_BUDGET_BYTES = 12 * KIB;
+
+/** A nested file carries only its own delta on top of the root and the parents. */
+export const NESTED_BUDGET_BYTES = 8 * KIB;
+
+/** A heading that names an issue. Body prose naming one is fine. */
+const ISSUE_HEADING = /^#{1,6} .*#\d{2,4}\b/;
+
+/**
+ * At least one `AGENTS.md` must be found and the ROOT one must be among them.
+ * "I measured nothing" and "everything is under budget" are the same output
+ * without this.
+ */
+function assertScanSawSomething(paths) {
+  if (paths.length === 0) {
+    throw new Error(
+      "check-agents-md-size: found NO tracked AGENTS.md. The file listing is broken — this is a failure, not a clean tree.",
+    );
+  }
+  if (!paths.includes("AGENTS.md")) {
+    throw new Error(
+      "check-agents-md-size: the root AGENTS.md is not in the tracked file listing. The file listing is broken, or the repo lost the one file this gate exists for.",
+    );
+  }
+}
+
+export function budgetFor(path) {
+  return path === "AGENTS.md" ? ROOT_BUDGET_BYTES : NESTED_BUDGET_BYTES;
+}
+
+export function issueHeadings(contents) {
+  return contents
+    .split("\n")
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(({ line }) => ISSUE_HEADING.test(line));
+}
+
+export async function checkAgentsMdSize({
+  root,
+  rootBudgetBytes = ROOT_BUDGET_BYTES,
+  nestedBudgetBytes = NESTED_BUDGET_BYTES,
+  enforceIssueHeadings = true,
+} = {}) {
+  const repositoryRoot = root ?? resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+  const listing = execFileSync("git", ["ls-files", "-z", "AGENTS.md", "**/AGENTS.md"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+  const paths = listing.split("\0").filter(Boolean).sort();
+
+  assertScanSawSomething(paths);
+
+  const failures = [];
+
+  for (const path of paths) {
+    const contents = await readFile(resolve(repositoryRoot, path), "utf8");
+    const bytes = Buffer.byteLength(contents, "utf8");
+    const budget = path === "AGENTS.md" ? rootBudgetBytes : nestedBudgetBytes;
+
+    if (bytes > budget) {
+      failures.push(
+        `${path} is ${(bytes / KIB).toFixed(1)} KB, over its ${(budget / KIB).toFixed(0)} KB budget by ${((bytes - budget) / KIB).toFixed(1)} KB.\n` +
+          `    Compress something in the SAME edit, or move the material to docs/ and leave a one-line pointer.`,
+      );
+    }
+
+    if (enforceIssueHeadings) {
+      for (const { line, number } of issueHeadings(contents)) {
+        failures.push(
+          `${path}:${number} is a per-issue heading: ${line.trim()}\n` +
+            `    Per-issue design notes go in docs/ (see docs/index.mdx). AGENTS.md gets the RULE and a pointer.`,
+        );
+      }
+    }
+  }
+
+  return { paths, failures };
+}
+
+if (import.meta.main) {
+  const { paths, failures } = await checkAgentsMdSize();
+
+  if (failures.length > 0) {
+    console.error("AGENTS.md budget check FAILED:\n");
+    for (const failure of failures) console.error(`  - ${failure}\n`);
+    process.exit(1);
+  }
+
+  console.log(`AGENTS.md budget check passed (${paths.length} file(s): ${paths.join(", ")}).`);
+}

--- a/scripts/test-check-agents-md-size.mjs
+++ b/scripts/test-check-agents-md-size.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+
+/**
+ * Mutation-tests `check-agents-md-size.mjs`.
+ *
+ * A budget gate is the easiest kind to leave inert: every part of it is a file
+ * listing or a byte count, and both fail QUIET. A broken `git ls-files` reports
+ * a clean tree. A regex with a typo reports a clean tree. A budget nobody is
+ * near reports a clean tree forever, including after somebody has deleted the
+ * comparison.
+ *
+ * Each case below breaks exactly one thing and requires the gate to fail with
+ * the words that identify the right rule. The cases that must PASS matter as
+ * much: this repository's prose names issue numbers constantly, on purpose, and
+ * a gate that fired on body text would be disabled by whoever hit it first.
+ *
+ * Fixtures are real trees with a real `git init`, so the gate's actual file
+ * listing runs rather than a stand-in for it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkAgentsMdSize,
+  issueHeadings,
+  ROOT_BUDGET_BYTES,
+  NESTED_BUDGET_BYTES,
+} from "./check-agents-md-size.mjs";
+
+const KIB = 1024;
+
+/**
+ * Fixture sizes are DERIVED from the two budgets rather than written down, so
+ * this file stays correct when a repository sets a different root budget. The
+ * middle size is what makes the nested pair a discriminator: it must be over
+ * the nested budget and under the root one, so a scanner using either budget
+ * everywhere fails exactly one of the two cases.
+ */
+const OVER_ROOT = ROOT_BUDGET_BYTES * 2;
+const BETWEEN = Math.floor((NESTED_BUDGET_BYTES + ROOT_BUDGET_BYTES) / 2) + 1;
+const ROOT_KB = (ROOT_BUDGET_BYTES / KIB).toFixed(0);
+const NESTED_KB = (NESTED_BUDGET_BYTES / KIB).toFixed(0);
+
+if (!(NESTED_BUDGET_BYTES < BETWEEN && BETWEEN < ROOT_BUDGET_BYTES)) {
+  console.error(
+    "  FAIL the nested budget must be strictly smaller than the root budget,\n" +
+      "       or the discriminating pair below measures nothing.",
+  );
+  process.exit(1);
+}
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+let failed = 0;
+
+function report(name, ok, detail = "") {
+  if (ok) {
+    console.log(`  ok   ${name}`);
+    return;
+  }
+  failed += 1;
+  console.error(`  FAIL ${name}${detail ? `\n       ${detail}` : ""}`);
+}
+
+/** Build a scratch checkout and run the REAL gate against it. */
+async function runAgainst(files, options = {}) {
+  const root = await mkdtemp(join(tmpdir(), "agents-md-budget-"));
+  try {
+    for (const [path, contents] of Object.entries(files)) {
+      const absolute = join(root, path);
+      await mkdir(dirname(absolute), { recursive: true });
+      await writeFile(absolute, contents, "utf8");
+    }
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    execFileSync("git", ["add", "-A"], { cwd: root });
+    try {
+      return { result: await checkAgentsMdSize({ root, ...options }) };
+    } catch (error) {
+      return { error };
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const withinBudget = "# Mercaria\n\nA rule.\n";
+
+console.log("check-agents-md-size self-test\n");
+
+// --- the vacuity floors -----------------------------------------------------
+
+{
+  const { error } = await runAgainst({ "README.md": "no instructions here\n" });
+  report(
+    "floor: a tree with no AGENTS.md is a FAILURE, not a clean scan",
+    Boolean(error) && /found NO tracked AGENTS\.md/.test(error.message),
+    error ? error.message : "the gate returned success",
+  );
+}
+
+{
+  const { error } = await runAgainst({ "packages/backend/AGENTS.md": withinBudget });
+  report(
+    "floor: a tree whose ROOT AGENTS.md is missing is a FAILURE",
+    Boolean(error) && /root AGENTS\.md is not in the tracked file listing/.test(error.message),
+    error ? error.message : "the gate returned success",
+  );
+}
+
+// --- the size rule ----------------------------------------------------------
+
+{
+  const { result } = await runAgainst({ "AGENTS.md": withinBudget });
+  report(
+    "a small root AGENTS.md passes",
+    result?.failures.length === 0,
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+{
+  const { result } = await runAgainst({ "AGENTS.md": "#".repeat(OVER_ROOT) + "\n" });
+  report(
+    "an over-budget root AGENTS.md fails, naming the budget",
+    result?.failures.length === 1 && new RegExp(`over its ${ROOT_KB} KB budget`).test(result.failures[0]),
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+{
+  // The nested budget is a DIFFERENT number and must actually be applied: a gate
+  // that used the root budget everywhere would pass this.
+  const { result } = await runAgainst({
+    "AGENTS.md": withinBudget,
+    "packages/backend/AGENTS.md": "x".repeat(BETWEEN) + "\n",
+  });
+  report(
+    "a nested AGENTS.md is held to the SMALLER budget",
+    result?.failures.length === 1 &&
+      /packages\/backend\/AGENTS\.md/.test(result.failures[0]) &&
+      new RegExp(`over its ${NESTED_KB} KB budget`).test(result.failures[0]),
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+{
+  // Same bytes, root path: proves the previous case failed on the BUDGET rather
+  // than on the size alone. 10 KB sits strictly between the two budgets, which
+  // is what makes the pair a discriminator at all.
+  const { result } = await runAgainst({ "AGENTS.md": "x".repeat(BETWEEN) + "\n" });
+  report(
+    "control: the same middle size passes at the ROOT path",
+    result?.failures.length === 0,
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+// --- the per-issue-heading rule --------------------------------------------
+
+{
+  const { result } = await runAgainst({
+    "AGENTS.md": "# Mercaria\n\n## The unified offer model (#57, ADR 0002)\n\nprose\n",
+  });
+  report(
+    "a per-issue HEADING fails and says where it goes",
+    result?.failures.length === 1 &&
+      /per-issue heading/.test(result.failures[0]) &&
+      /docs\//.test(result.failures[0]),
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+{
+  const { result } = await runAgainst({
+    "AGENTS.md": "# Mercaria\n\n## Offers\n\n#57 owns the offer row; see docs/commerce-graph.md (#55, #58).\n",
+  });
+  report(
+    "an issue number in BODY prose passes",
+    result?.failures.length === 0,
+    result ? result.failures.join("; ") : "threw",
+  );
+}
+
+{
+  // A one-digit "#1" in a heading is far likelier to be a step number or an
+  // anchor than an issue, so the rule requires two digits. Pin that boundary,
+  // or a later tightening breaks headings nobody meant to forbid.
+  report(
+    "a one-digit '#1' in a heading does not fire; '#57' does",
+    issueHeadings("## Step #1\n").length === 0 && issueHeadings("## Offers (#57)\n").length === 1,
+  );
+}
+
+// --- the real repository ----------------------------------------------------
+
+{
+  const { result, error } = await checkAgentsMdSize({ root: repositoryRoot })
+    .then((result) => ({ result }))
+    .catch((error) => ({ error }));
+  report(
+    "the real repository is within budget",
+    !error && result?.failures.length === 0,
+    error ? error.message : result?.failures.join("\n       "),
+  );
+}
+
+console.log("");
+if (failed > 0) {
+  console.error(`${failed} self-test case(s) FAILED.`);
+  process.exit(1);
+}
+console.log("All self-test cases passed.");


### PR DESCRIPTION
`AGENTS.md` is prepended to **every** agent session, so its bytes are paid on every task forever — and it grows by accretion: a subsystem walkthrough or a per-issue note appended by the change that produced it, none wrong on its own, none visible except in the sum. Measured across Oxy this month it had reached **478 KB** (Mercaria), **152 KB** (OxyHQServices), **83 KB** (Astro), **52 KB** (Homiio). Nothing breaks when it grows, which is exactly why it grows — the shape a gate catches and a convention does not.

**This repository's file is already within budget (10.1 KB).** The gate is here so it stays that way; no content changes.

`scripts/check-agents-md-size.mjs` holds this repository's own root budget plus a smaller one for any nested `AGENTS.md`, and fails on a **per-issue heading** — the mechanism of the growth, named directly so the message can say where the material goes.

Both rules carry a vacuity floor: a `git ls-files` that returns nothing, or a tree that has lost its root `AGENTS.md`, is a **FAILURE** rather than a clean scan.

`scripts/test-check-agents-md-size.mjs` mutation-tests every rule and both floors against real scratch checkouts, and pins the two cases that must PASS (an issue number in body prose; a one-digit `#1` heading). Its fixture sizes are **derived from the two budgets** rather than written down, so the discriminating pair keeps discriminating when a repository picks a different budget — and it refuses to run if the nested budget is not strictly smaller than the root one, since the pair would then measure nothing.

It measures **bytes, not lines**, and adds no second line-count bound: the widely-repeated "under 150 lines" figure is an uncited blog claim, the one published measurement ([arXiv 2601.20404](https://arxiv.org/html/2601.20404v2)) reports the opposite direction, and two bounds on one fact can disagree.

Part of a sweep across the Oxy repos. Merged so far: Mercaria 478 KB → 10 KB, OxyHQServices 152 KB → 10 KB, Astro 83 KB → 8.9 KB, Homiio 52 KB → 9.8 KB, CrowdSource 25 KB → 10 KB, and `~/Oxy/AGENTS.md` 52 KB → 12 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)